### PR TITLE
Implement broadcasting for numbers

### DIFF
--- a/src/arraymancer/shapeshifting.nim
+++ b/src/arraymancer/shapeshifting.nim
@@ -130,7 +130,22 @@ proc broadcast*[T](t: Tensor[T], shape: openarray[int]): Tensor[T] {.noSideEffec
     elif result.shape[i] != shape[i]:
       raise newException(ValueError, "The broadcasted size of the tensor must match existing size for non-singleton dimension")
 
-template bc*(t: Tensor, shape: openarray[int]): untyped =
+proc broadcast*[T: SomeNumber](v: T, shape: openarray[int]): Tensor[T] {.noSideEffect.} =
+  ## Broadcast a number
+  ## Input:
+  ##   - a number to be broadcasted
+  ##   - a tensor shape that will be broadcasted to
+  ## Returns:
+  ##   - a tensor with the broadcasted shape where all elements has the broadcasted value
+  ##
+  ## The broadcasting is made using tensor data of size 1 and 0 strides, i.e.
+  ## the operation is memory efficient
+  result.shape = @shape
+  result.strides = newSeqWith(result.shape.len, 0)
+  result.offset = 0
+  result.data = newSeqWith(1, v)
+
+template bc*(t: (Tensor|SomeNumber), shape: openarray[int]): untyped =
   ## Alias for ``broadcast``
   t.broadcast(shape)
 

--- a/tests/test_shapeshifting.nim
+++ b/tests/test_shapeshifting.nim
@@ -62,3 +62,22 @@ suite "Shapeshifting":
                                      [7,8]].toTensor()
     check: concat(a,b, axis = 1) == [[1,2,5,6],
                                      [3,4,7,8]].toTensor()
+
+  test "Broadcasting":
+    block:
+      let a = 2.bc([3,2])
+      check a == [[2,2],
+                  [2,2],
+                  [2,2]].toTensor()
+
+    block:
+      let a = toSeq(1..2).toTensor().reshape(1,2)
+      let b = a.bc([2,2])
+      check b == [[1,2],
+                  [1,2]].toTensor()
+
+    block:
+      let a = toSeq(1..2).toTensor().reshape(2,1)
+      let b = a.bc([2,2])
+      check b == [[1,1],
+                  [2,2]].toTensor()


### PR DESCRIPTION
This PR extend broadcasting for numbers too, the broadcasting is made using a tensor of data size 1 and strides 0, so it should be memory and performance efficient

Some tests from broadcasting where also added which was missing