### PR TITLE
Tensor element-wise division

### DIFF
--- a/src/arraymancer/operators_extra.nim
+++ b/src/arraymancer/operators_extra.nim
@@ -25,3 +25,11 @@ proc `|*|`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] {.noSideEffect.} =
   ## TODO use mitems instead of result.data[i] cf profiling
   for i, ai, bi in enumerate_zip(a.values, b.values):
     result.data[i] = ai * bi
+
+proc `|/|`*[T: SomeInteger](a, b: Tensor[T]): Tensor[T] {.noSideEffect.} =
+  ## Tensor element-wise division for integer numbers
+  return fmap2(a, b, proc(x, y: T): T = x div y)
+
+proc `|/|`*[T: SomeReal](a, b: Tensor[T]): Tensor[T] {.noSideEffect.} =
+  ## Tensor element-wise division for real numbers
+  return fmap2(a, b, proc(x, y: T): T = x / y)

--- a/tests/test_operators_blas.nim
+++ b/tests/test_operators_blas.nim
@@ -172,6 +172,23 @@ suite "BLAS (Basic Linear Algebra Subprograms)":
     check: u_int + v_int == expected_add
     check: u_int - v_int == expected_sub
 
+  test "Tensor element-wise multiplication/division":
+    let u_int = @[-4, 0, 9].toTensor()
+    let v_int = @[2, 10, 3].toTensor()
+    let expected_mul_int = @[-8, 0, 27].toTensor()
+    let expected_div_int = @[-2, 0, 3].toTensor()
+
+    check: u_int |*| v_int == expected_mul_int
+    check: u_int |/| v_int == expected_div_int
+
+    let u_float = @[1.0, 8.0, -3.0].toTensor()
+    let v_float = @[4.0, 2.0, 10.0].toTensor()
+    let expected_mul_float = @[4.0, 16.0, -30.0].toTensor()
+    let expected_div_float = @[0.25, 4.0, -0.3].toTensor()
+
+    check: u_float |*| v_float == expected_mul_float
+    check: u_float |/| v_float == expected_div_float
+
   test "Addition-Substraction - slices":
     let a = @[@[1.0,2,3],@[4.0,5,6], @[7.0,8,9]].toTensor()
     let a_t = a.transpose()


### PR DESCRIPTION
To be consistent with the element-wise multiplication syntax (`|*|`)  the syntax `|/|` is used.

The implementation has been split into integer and real procs, because nim's division of `a / b` always returns a float, even if both `a` and `b` are integers. So the operation `div` should be used for the integer case.

Tests are included.

Other syntax choice is open for discussion.