### PR TITLE
Fix as type with sliced tensors, add tests

### DIFF
--- a/src/arraymancer/ufunc.nim
+++ b/src/arraymancer/ufunc.nim
@@ -14,8 +14,7 @@
 
 proc astype*[T, U](t: Tensor[T], typ: typedesc[U]): Tensor[U] {.noSideEffect.}=
   ## Apply type conversion on the whole tensor
-  tensorCpu(t.shape, result)
-  result.data = t.data.map(x => x.U)
+  result = t.map(x => x.U)
 
 template makeUniversal*(func_name: untyped) =
   # Lift an unary function into an exported universal function.

--- a/tests/test_ufunc.nim
+++ b/tests/test_ufunc.nim
@@ -16,6 +16,11 @@ import ../src/arraymancer
 import math, unittest
 
 suite "Universal functions":
+  test "As type with slicing":
+    let a = [1, 2, 3, 4].toTensor()
+    let b = a[1..2].astype(float)
+    check b == [2.0'f64,3.0'f64].toTensor()
+
   test "Common math functions are exported":
     let a = @[@[1.0,2,3],@[4.0,5,6]]
     let b = @[@[7.0, 8],@[9.0, 10],@[11.0, 12]]


### PR DESCRIPTION
`astype` was failing with sliced tensors because it was using `map` directly on tensor data, fixed and added tests