### PR TITLE
Fix shallow/unsafe reshape on slices

### DIFF
--- a/src/arraymancer/shapeshifting.nim
+++ b/src/arraymancer/shapeshifting.nim
@@ -112,7 +112,7 @@ template reshape_no_copy(t: Tensor|var Tensor, new_shape: varargs[int]): untyped
   # Strides extended for unmatched dimension
   let ext_strides = result.shape[matched_dims..result.shape.high].shape_to_strides
   result.strides = t.strides[0..<matched_dims] & ext_strides
-  result.offset = 0
+  result.offset = t.offset
 
   shallowCopy(result.data, t.data)
 

--- a/tests/test_shapeshifting.nim
+++ b/tests/test_shapeshifting.nim
@@ -51,6 +51,25 @@ suite "Shapeshifting":
     check: a == [[1,2],
                  [3,4]].toTensor()
 
+  test "Shallow/Unsafe reshape":
+    block:
+      var a = toSeq(1..4).toTensor()
+      var a_view = a.shallowReshape(2,2)
+      check: a_view == [[1,2],[3,4]].toTensor()
+      a_view[_, _] = 0
+      check: a == [0,0,0,0].toTensor()
+
+    # on slices
+    block:
+      # not that 'a' here a let variable, however
+      # unsafeView and unsafeReshape allow us to
+      # modify its elements value
+      let a = toSeq(1..4).toTensor()
+      var a_view = a.unsafeView(1..2).unsafeReshape(1,2)
+      check: a_view == [[2,3]].toTensor()
+      a_view[_, _] = 0
+      check: a == [1,0,0,4].toTensor()
+
   test "Concatenation":
     let a = toSeq(1..4).toTensor().reshape(2,2)
 


### PR DESCRIPTION
Shallow reshape function was missing to set the offset, making it fail with slices
Also added tests for this bug and for shallow/unsafe reshape in general