### PR TITLE
Use non initialized seqs where appropriate

### DIFF
--- a/src/arraymancer/higher_order.nim
+++ b/src/arraymancer/higher_order.nim
@@ -29,7 +29,7 @@ proc map*[T, U](t: Tensor[T], f: T -> U): Tensor[U] {.noSideEffect.}=
   # But may avoid a lot of unnecessary computations on slices
   tensorCpu(t.shape, result)
 
-  result.data = newSeq[U](result.size)
+  result.data = newSeqUninitialized[U](result.size)
   var i = 0 # TODO: use pairs/enumerate instead - pending https://forum.nim-lang.org/t/2972
   for val in t:
     result.data[i] = f(val)
@@ -58,7 +58,7 @@ proc map2*[T, U, V](t1: Tensor[T], f: (T,U) -> V, t2: Tensor[U]): Tensor[V] {.no
 
   tensorCpu(t1.shape, result)
 
-  result.data = newSeq[U](result.size)
+  result.data = newSeqUninitialized[U](result.size)
 
   # TODO use mitems instead of result.data[i] cf profiling
   # TODO: inline iterators - pending https://github.com/nim-lang/Nim/issues/4516

--- a/src/arraymancer/init_cuda.nim
+++ b/src/arraymancer/init_cuda.nim
@@ -118,7 +118,7 @@ proc cpu*[T:SomeReal](t: CudaTensor[T]): Tensor[T] {.noSideEffect.}=
   result.shape = t.shape
   result.strides = t.strides
   result.offset = t.offset
-  result.data = newSeq[T](t.data.len) # We copy over all the memory allocated
+  result.data = newSeqUninitialized[T](t.data.len) # We copy over all the memory allocated
 
   let size = t.data.len * sizeof(T)
 

--- a/src/arraymancer/operators_blas_l2l3.nim
+++ b/src/arraymancer/operators_blas_l2l3.nim
@@ -48,7 +48,7 @@ template matvec_blis[T: SomeReal](a, x, result: Tensor[T]): auto =
 
   when compileOption("boundChecks"): check_matvec(a,b)
 
-  result.data = newSeq[T](rowA)
+  result.data = newSeqUninitialized[T](rowA)
   result.shape = @[rowA]
   result.strides = @[1]
   result.offset = 0
@@ -83,7 +83,7 @@ template matvec_blas[T: SomeReal](a, x, result: Tensor[T]): auto =
 
   when compileOption("boundChecks"): check_matvec(a,b)
 
-  result.data = newSeq[T](rowA)
+  result.data = newSeqUninitialized[T](rowA)
   result.shape = @[rowA]
   result.strides = @[1]
   result.offset = 0
@@ -108,7 +108,7 @@ template matvec_fallback[T: SomeInteger](a, x, result: Tensor[T]): auto =
 
   when compileOption("boundChecks"): check_matvec(a,b)
 
-  result.data = newSeq[T](rowA)
+  result.data = newSeqUninitialized[T](rowA)
   result.shape = @[rowA]
   result.strides = @[1]
   result.offset = 0
@@ -134,7 +134,7 @@ template matmat_blis[T: SomeReal](a, b, result: Tensor[T]): auto =
 
   when compileOption("boundChecks"): check_matmat(a,b)
 
-  result.data = newSeq[T](rowA * colB)
+  result.data = newSeqUninitialized[T](rowA * colB)
   result.shape = @[rowA, colB]
   result.strides = @[rowA, 1]  # We force row-major after computation
   result.offset = 0
@@ -166,7 +166,7 @@ template matmat_blas[T: SomeReal](a, b, result: Tensor[T]): auto =
 
   when compileOption("boundChecks"): check_matmat(a,b)
 
-  result.data = newSeq[T](M * N)
+  result.data = newSeqUninitialized[T](M * N)
   result.shape = @[M, N]
   result.strides = @[N, 1]
   result.offset = 0
@@ -205,7 +205,7 @@ template matmat_fallback[T: SomeInteger](a, b, result: Tensor[T]): auto =
   result.shape = @[M, N]
   result.strides = @[N, 1]
   result.offset = 0
-  result.data = newSeq[T](M*N)
+  result.data = newSeqUninitialized[T](M*N)
 
   gemm_nn_fallback(M, N, K,
            1.T,

--- a/src/arraymancer/shapeshifting.nim
+++ b/src/arraymancer/shapeshifting.nim
@@ -62,7 +62,7 @@ proc unsafeTranspose*(t: Tensor): Tensor {.noSideEffect, inline.}=
 
 template contiguousT*[T](result, t: Tensor[T], layout: OrderType): untyped=
   tensorCpu(t.shape, result, layout)
-  result.data = newSeq[T](result.size)
+  result.data = newSeqUninitialized[T](result.size)
 
   var i = 0 ## TODO: use pairs/enumerate instead - pending https://forum.nim-lang.org/t/2972
 
@@ -108,7 +108,7 @@ proc unsafeContiguous*[T](t: Tensor[T], layout: OrderType = rowMajor, force: boo
 proc reshape_with_copy[T](t: Tensor[T], new_shape: seq[int]): Tensor[T] {.noSideEffect.}=
   # Can't call "tensorCpu" template here for some reason
   tensorCpu(new_shape, result)
-  result.data = newSeq[T](result.size)
+  result.data = newSeqUninitialized[T](result.size)
 
   var i = 0 ## TODO: use pairs/enumerate instead - pending https://forum.nim-lang.org/t/2972
   for val in t:
@@ -311,7 +311,7 @@ proc concat*[T](t_list: varargs[Tensor[T]], axis: int): Tensor[T]  {.noSideEffec
 
   ## Setup the Tensor
   tensorCpu(concat_shape, result)
-  result.data = newSeq[T](result.size)
+  result.data = newSeqUninitialized[T](result.size)
 
   # Fill in the copy with the matching values
   var slices = concat_shape.mapIt((0..<it)|1)

--- a/tests/test_init.nim
+++ b/tests/test_init.nim
@@ -79,4 +79,35 @@ suite "Creating a new Tensor":
 
     check: u.shape == t.shape
 
-  # TODO add tests for zeros, ones and randomTensor
+  test "Zeros":
+    block:
+      let t = zeros([4,4,4], float)
+      for v in t.items:
+        check v == 0.0f
+    block:
+      let t = zeros([4,4,4], int)
+      for v in t.items:
+        check v == 0
+
+  test "Ones":
+    block:
+      let t = ones([4,4,4], float)
+      for v in t.items:
+        check v == 1.0f
+    block:
+      let t = ones([4,4,4], int)
+      for v in t.items:
+        check v == 1
+
+  test "Filled new tensor":
+    block:
+      let t = newTensor([4,4,4], 2.0f)
+      for v in t.items:
+        check v == 2.0f
+    block:
+      let t = newTensor([4,4,4], 2)
+      for v in t.items:
+        check v == 2
+
+  # TODO add tests for randomTensor
+


### PR DESCRIPTION
This will optimize for who is using nim's head, however it is compatible with older nim instances, `newSeqUninitialized` skip memory initialization, in my tests this increases the allocation time in a factor greater than ~200x for tensor in the order of 100000 elements.

Also introduces `newTensor` with default filled value for its elements, with tests

Performance difference will be only noticeably using nim's head, this is the code that I used to confirm greater performance:

```Nim
import times

proc newSeqUninitialized[T](len: Natural): seq[T] {.noSideEffect,inline.}=
  result = newSeqOfCap[int](len)
  result.setLen(len)

var start: float
start = cpuTime()
for i in 0..<100000:
  var s = newSeqUninitialized[int](100000)
echo "noinit ", cpuTime() - start

start = cpuTime()
for i in 0..<100000:
  var s = newSeq[int](100000)
echo "init ", cpuTime() - start

```


Outputs:
```
noinit 0.014142
init 2.266459
```
