### PR TITLE
Add unsafeToTensor and unsafeToTensorReshape

### DIFF
--- a/src/arraymancer/init_cpu.nim
+++ b/src/arraymancer/init_cpu.nim
@@ -70,6 +70,16 @@ proc toTensor*(s:openarray, dummy_bugfix: static[int] = 0 ): auto {.noSideEffect
   # TODO: remove 'dummy_bugfix'
   toTensorCpu(s)
 
+proc unsafeToTensor*[T: SomeNumber](data: seq[T]): Tensor[T] {.noSideEffect.} =
+  ## Convert a seq to a Tensor, sharing the seq data
+  ## Input:
+  ##      - A seq with the tensor data
+  ## Result:
+  ##      - A rank 1 tensor with the same size of the input
+  ## WARNING: result share storage with input
+  tensorCpu([data.len], result)
+  shallowCopy(result.data, data)
+
 proc toTensor*(s:string): auto {.noSideEffect.} =
   ## Convert an openarray to a Tensor
   ##

--- a/tests/test_shapeshifting.nim
+++ b/tests/test_shapeshifting.nim
@@ -106,3 +106,14 @@ suite "Shapeshifting":
       let b = a[0, 0..1, 0, 3..0|-1].squeeze(0)
 
       check b == [4, 3, 2, 1, 8, 7, 6, 5].toTensor.reshape(2,1,4)
+
+  test "To tensor reshape":
+    block:
+      let a = [1,2,3,4].toTensorReshape([2,2])
+      check a == [[1,2],[3,4]].toTensor()
+    block:
+      var s = @[1,2,3,4]
+      var a = s.unsafeToTensorReshape([2,2])
+      check a == [[1,2],[3,4]].toTensor()
+      s[0] = 0
+      check a == [[0,2],[3,4]].toTensor()


### PR DESCRIPTION
Both functions are useful for loading data from disk without doing an extra copy when passing to a tensor, tests added

Also tests for toTensorReshape were added, and its function exported