### PR TITLE
[WIP] Conv2D and nnpack bindings

### DIFF
--- a/src/nn_primitives/backend/nnpack.nim
+++ b/src/nn_primitives/backend/nnpack.nim
@@ -1,0 +1,486 @@
+# Copyright 2017 the Arraymancer contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## *
+##  @brief Status code for any NNPACK function call.
+##
+
+{.passl: "-lnnpack -lpthreadpool -lpthread".}
+
+type
+  nnp_status* {.size: sizeof(cint).} = enum ## * The call succeeded, and all output arguments now contain valid data.
+    nnp_status_success = 0,     ## * NNPACK function was called with batch_size == 0.
+    nnp_status_invalid_batch_size = 2, ## * NNPACK function was called with channels == 0.
+    nnp_status_invalid_channels = 3, ## * NNPACK function was called with input_channels == 0.
+    nnp_status_invalid_input_channels = 4, ## * NNPACK function was called with output_channels == 0.
+    nnp_status_invalid_output_channels = 5, ## * NNPACK function was called with input_size.height == 0 or input_size.width == 0
+    nnp_status_invalid_input_size = 10, ## * NNPACK function was called with input_stride.height == 0 or input_stride.width == 0
+    nnp_status_invalid_input_stride = 11, ## * NNPACK function was called with input_padding not less than respective kernel (or pooling) size, i.e.:
+                                       ##
+                                       ##   - input_padding.left   >= kernel_size.width  (>= pooling_size.width)
+                                       ##   - input_padding.right  >= kernel_size.width  (>= pooling_size.width)
+                                       ##   - input_padding.top    >= kernel_size.height (>= pooling_size.height)
+                                       ##   - input_padding.bottom >= kernel_size.height (>= pooling_size.height)
+                                       ##
+    nnp_status_invalid_input_padding = 12, ## * NNPACK function was called with kernel_size.height == 0 or kernel_size.width == 0
+    nnp_status_invalid_kernel_size = 13, ## * NNPACK function was called with pooling_size.height == 0 or pooling_size.width == 0
+    nnp_status_invalid_pooling_size = 14, ## * NNPACK function was called with pooling_stride.height == 0 or pooling_stride.width == 0
+    nnp_status_invalid_pooling_stride = 15, ## * NNPACK function was called with convolution algorithm not in nnp_convolution_algorithm enumeration
+    nnp_status_invalid_algorithm = 16, ## * NNPACK function was called with convolution transform strategy not in nnp_convolution_transform_strategy enum
+    nnp_status_invalid_transform_strategy = 17, ## * NNPACK function was called with output_subsampling.height == 0 or output_subsampling.width == 0
+    nnp_status_unsupported_input_size = 20, ## * NNPACK does not support the particular input stride for the function
+    nnp_status_unsupported_input_stride = 21, ## * NNPACK does not support the particular input padding for the function
+    nnp_status_unsupported_input_padding = 22, ## * NNPACK does not support the particular kernel size for the function
+    nnp_status_unsupported_kernel_size = 23, ## * NNPACK does not support the particular pooling size for the function
+    nnp_status_unsupported_pooling_size = 24, ## * NNPACK does not support the particular pooling stride for the function
+    nnp_status_unsupported_pooling_stride = 25, ## * NNPACK does not support the particular convolution algorithm for the function
+    nnp_status_unsupported_algorithm = 26, ## * NNPACK does not support the particular convolution transform strategy for the algorithm
+    nnp_status_unsupported_transform_strategy = 27, ## * NNPACK does not support the particular activation function for the function
+    nnp_status_unsupported_activation = 28, ## * NNPACK does not support the particular activation function parameters for the function
+    nnp_status_unsupported_activation_parameters = 29, ## * NNPACK function was called before the library was initialized
+    nnp_status_uninitialized = 50, ## * NNPACK does not implement this function for the host CPU
+    nnp_status_unsupported_hardware = 51, ## * NNPACK failed to allocate memory for temporary buffers
+    nnp_status_out_of_memory = 52, ## * Scratch space buffer is too small
+    nnp_status_insufficient_buffer = 53, ## * Scratch space buffer is not properly aligned
+    nnp_status_misaligned_buffer = 54
+
+  pthreadpool_t* = pointer
+
+const
+  nnp_status_invalid_output_subsampling* = nnp_status_invalid_kernel_size
+  nnp_status_invalid_activation* = nnp_status_invalid_pooling_size
+  nnp_status_invalid_activation_parameters* = nnp_status_invalid_pooling_stride
+
+## *
+##  @brief Activation applied applied after a convolutional or fully-connected layer.
+##
+
+type
+  nnp_activation* {.size: sizeof(cint).} = enum ## * Identity activation f(x) := x, i.e. no transformation
+    nnp_activation_identity = 0, ## * ReLU activation f(x) := max(0, x)
+    nnp_activation_relu = 1
+
+
+## *
+##  @brief Algorithm for computing convolutional layers.
+##
+
+type
+  nnp_convolution_algorithm* {.size: sizeof(cint).} = enum ## * Let NNPACK choose the algorithm depending on layer parameters
+    nnp_convolution_algorithm_auto = 0, ## * Tiled convolution based on 2D Fourier transform with 8x8 blocks. Supports kernels up to 8x8.
+    nnp_convolution_algorithm_ft8x8 = 1, ## * Tiled convolution based on 2D Fourier transform with 16x16 blocks. Supports kernels up to 16x16.
+    nnp_convolution_algorithm_ft16x16 = 2, ## * Tiled convolution based on 2D Winograd transform F(3x3, 6x6) with 8x8 blocks. Supports only 3x3 kernels.
+    nnp_convolution_algorithm_wt8x8 = 3, ## * Direct convolution via implicit GEMM.
+    nnp_convolution_algorithm_implicit_gemm = 4, ## * Direct convolution implementation.
+    nnp_convolution_algorithm_direct = 5, ## *
+                                       ##  Tiled convolution based on 2D Winograd transform F(3x3, 6x6) with 8x8 blocks in FP16.
+                                       ##  Supports only 3x3 kernels. Implemented only for new ARM processors (with NEON-HP),
+                                       ##  on non-supported processors falls back to nnp_convolution_algorithm_wt8x8.
+                                       ##
+    nnp_convolution_algorithm_wt8x8_fp16 = 6
+
+
+type
+  nnp_convolution_transform_strategy* {.size: sizeof(cint).} = enum
+    nnp_convolution_transform_strategy_compute = 1,
+    nnp_convolution_transform_strategy_precompute = 2,
+    nnp_convolution_transform_strategy_reuse = 3
+
+
+##  For backward compatibility
+
+const
+  nnp_convolution_transform_strategy_block_based* = nnp_convolution_transform_strategy_compute
+  nnp_convolution_transform_strategy_tuple_based* = nnp_convolution_transform_strategy_compute
+
+## *
+##  @brief Size of images, kernels, and pooling filters in NNPACK.
+##
+
+type
+  nnp_size* {.bycopy.} = object
+    width*: csize              ## * Width (horizontal size) of an image, kernel, or pooling filter.
+    ## * Height (vertical size) of an image, kernel, or pooling filter.
+    height*: csize
+
+## *
+##  @brief Padding of images in NNPACK.
+##
+
+type
+  nnp_padding* {.bycopy.} = object
+    top*: csize                ## * Padding above the image data
+    ## * Padding on the right of image data
+    right*: csize              ## * Padding below the image data
+    bottom*: csize             ## * Padding on the left of image data
+    left*: csize
+
+## *
+##  @brief Profiling information about time spent in different phases of a function call.
+##
+
+type
+  nnp_profile* {.bycopy.} = object
+    total*: cdouble            ## * Time spent inside the function call, in seconds.
+    ## * Time spend on transformation of the input or input gradient tensor, in seconds.
+    input_transform*: cdouble  ## * Time spend on transformation of the kernel or kernel gradient tensor, in seconds.
+    kernel_transform*: cdouble ## * Time spend on transformation of the output or output gradient tensor, in seconds.
+    output_transform*: cdouble ## * Time spend on multiplication-accumulation of transformed coefficients, in seconds.
+    block_multiplication*: cdouble
+
+
+proc nnp_initialize*(): nnp_status {.cdecl, importc: "nnp_initialize".}
+proc nnp_deinitialize*(): nnp_status {.cdecl, importc: "nnp_deinitialize".}
+## *
+##  @brief Computes output of a 2D convolutional layer from input and kernel tensors.
+##  @details This function targets training of convolutional neural networks and performs forward propagation.
+##           It is optimized for moderate minibatch sizes (64-128) and can be inefficient on a small minibatch.
+##           For minibatch size 1, use nnp_convolution_inference for optimal performance.
+##  @param algorithm The type of algorithm to use for convolution. Possible values are:
+##
+##     - nnp_convolution_algorithm_auto    -- let the function choose the algorithm.
+##     - nnp_convolution_algorithm_ft8x8   -- tiled convolution based on 2D Fourier transform with 8x8 blocks.
+##                                            Supports kernels up to 8x8.
+##     - nnp_convolution_algorithm_ft16x16 -- tiled convolution based on 2D Fourier transform with 16x16 blocks.
+##                                            Supports kernels up to 16x16.
+##     - nnp_convolution_algorithm_wt8x8   -- tiled convolution based on 2D Winograd transform F(3x3, 6x6).
+##                                            Supports only 3x3 kernels.
+##
+##  @param batch_size The number of images on the input and output of the convolutional layer.
+##  @param input_channels The number of channels (AKA features, dimensions) in the input images.
+##  @param output_channels The number of channels (AKA features, dimensions) in the output images.
+##  @param input_size Size of input images, excluding implicit zero-padding.
+##  @param input_padding Implicit zero-padding of input images.
+##  @param kernel_size Kernel size.
+##  @param[in]  input  A 4D tensor input[batch_size][input_channels][input_size.height][input_size.width].
+##  @param[in]  kernel A 4D tensor kernel[output_channels][input_channels][kernel_size.height][kernel_size.width].
+##  @param[in]  bias   A 1D array bias[output_channels].
+##  @param[out] output A 4D tensor output[batch_size][output_channels][output_size.height][output_size.width] where
+##                         output_size.height = (input_padding.top + input_size.height + input_padding.bottom) -
+##                                              (kernel_size.height - 1)
+##                         output_size.width  = (input_padding.left + input_size.width + input_padding.right) -
+##                                              (kernel_size.width - 1)
+##  @param threadpool A thread pool for parallelization of the computation.
+##                    If threadpool is NULL, the computation would run on the caller thread without parallelization.
+##  @param[out] profile An optional pointer to profiling structure.
+##                      If provided, the structure would record time spent in different phases of the computation.
+##
+
+proc nnp_convolution_output*(algorithm: nnp_convolution_algorithm;
+                            batch_size: csize; input_channels: csize;
+                            output_channels: csize; input_size: nnp_size;
+                            input_padding: nnp_padding; kernel_size: nnp_size;
+                            input: ptr cfloat; kernel: ptr cfloat; bias: ptr cfloat;
+                            output: ptr cfloat; workspace_buffer: pointer=nil;
+                            workspace_size: ptr csize=nil; activation: nnp_activation=nnp_activation_identity;
+                            activation_parameters: pointer=nil;
+                            threadpool: pthreadpool_t=nil; profile: ptr nnp_profile=nil): nnp_status {.
+    cdecl, importc: "nnp_convolution_output".}
+## *
+##  @brief Computes gradient of input of a 2D convolutional layer from gradient of output and kernel tensors.
+##  @details This function targets training of convolutional neural networks and performs backward propagation.
+##           It is optimized for moderate minibatch sizes (64-128) and can be inefficient on a small minibatch.
+##  @param algorithm The type of algorithm to use for convolution. Possible values are:
+##
+##     - nnp_convolution_algorithm_auto    -- let the function choose the algorithm.
+##     - nnp_convolution_algorithm_ft8x8   -- tiled convolution based on 2D Fourier transform with 8x8 blocks.
+##                                            Supports kernels up to 8x8.
+##     - nnp_convolution_algorithm_ft16x16 -- tiled convolution based on 2D Fourier transform with 16x16 blocks.
+##                                            Supports kernels up to 16x16.
+##     - nnp_convolution_algorithm_wt8x8   -- tiled convolution based on 2D Winograd transform F(3x3, 6x6).
+##                                            Supports only 3x3 kernels.
+##
+##  @param batch_size The number of images (and their gradients) on the input and output of the convolutional layer.
+##  @param input_channels The number of channels (AKA features, dimensions) in the input images (and gradients).
+##  @param output_channels The number of channels (AKA features, dimensions) in the output images (and gradients).
+##  @param input_size Size of input images and their gradients, excluding implicit zero-padding.
+##  @param input_padding Implicit zero-padding of input images.
+##  @param kernel_size Kernel size.
+##  @param[in]  grad_output A 4D tensor grad_output[batch_size][output_channels][output_size.height][output_size.width]
+##                          where
+##                            output_size.height = (input_padding.top + input_size.height + input_padding.bottom) -
+##                                                 (kernel_size.height - 1)
+##                            output_size.width  = (input_padding.left + input_size.width + input_padding.right) -
+##                                                 (kernel_size.width - 1)
+##  @param[in]  kernel      A 4D tensor kernel[output_channels][input_channels][kernel_size.height][kernel_size.width].
+##  @param[out] grad_input  A 4D tensor grad_input[batch_size][input_channels][input_size.height][input_size.width].
+##  @param threadpool A thread pool for parallelization of the computation.
+##                    If threadpool is NULL, the computation would run on the caller thread without parallelization.
+##  @param[out] profile An optional pointer to profiling structure.
+##                      If provided, the structure would record time spent in different phases of the computation.
+##
+
+proc nnp_convolution_input_gradient*(algorithm: nnp_convolution_algorithm;
+                                    batch_size: csize; input_channels: csize;
+                                    output_channels: csize; input_size: nnp_size;
+                                    input_padding: nnp_padding;
+                                    kernel_size: nnp_size;
+                                    grad_output: ptr cfloat; kernel: ptr cfloat;
+                                    grad_input: ptr cfloat;
+                                    workspace_buffer: pointer = nil;
+                                    workspace_size: ptr csize = nil;
+                                    activation: nnp_activation = nnp_activation_identity;
+                                    activation_parameters: pointer = nil;
+                                    threadpool: pthreadpool_t = nil;
+                                    profile: ptr nnp_profile = nil): nnp_status {.cdecl,
+    importc: "nnp_convolution_input_gradient".}
+## *
+##  @brief Computes gradient of kernel of a 2D convolutional layer from gradient of output and input tensors.
+##  @details This function targets training of convolutional neural networks and performs backward propagation.
+##           It is optimized for moderate minibatch sizes (64-128) and can be inefficient on a small minibatch.
+##  @param algorithm The type of algorithm to use for convolution. Possible values are:
+##
+##     - nnp_convolution_algorithm_auto    -- let the function choose the algorithm.
+##     - nnp_convolution_algorithm_ft8x8   -- tiled convolution based on 2D Fourier transform with 8x8 blocks.
+##                                            Supports kernels up to 8x8.
+##     - nnp_convolution_algorithm_ft16x16 -- tiled convolution based on 2D Fourier transform with 16x16 blocks.
+##                                            Supports kernels up to 16x16.
+##
+##  @param batch_size The number of images (and their gradients) on the input and output of the convolutional layer.
+##  @param input_channels The number of channels (AKA features, dimensions) in the input images.
+##  @param output_channels The number of channels (AKA features, dimensions) in the output images (and gradients).
+##  @param input_size Size of input images and their gradients, excluding implicit zero-padding.
+##  @param input_padding Implicit zero-padding of input images.
+##  @param kernel_size Kernel size.
+##  @param[in]  input       A 4D tensor input[batch_size][input_channels][input_size.height][input_size.width].
+##  @param[in]  grad_output A 4D tensor grad_output[batch_size][output_channels][output_size.height][output_size.width]
+##                          where
+##                            output_size.height = (input_padding.top + input_size.height + input_padding.bottom) -
+##                                                 (kernel_size.height - 1)
+##                            output_size.width  = (input_padding.left + input_size.width + input_padding.right) -
+##                                                 (kernel_size.width - 1)
+##  @param[out] grad_kernel A 4D tensor
+##                          grad_kernel[output_channels][input_channels][kernel_size.height][kernel_size.width].
+##  @param threadpool A thread pool for parallelization of the computation.
+##                    If threadpool is NULL, the computation would run on the caller thread without parallelization.
+##  @param[out] profile An optional pointer to profiling structure.
+##                      If provided, the structure would record time spent in different phases of the computation.
+##
+
+proc nnp_convolution_kernel_gradient*(algorithm: nnp_convolution_algorithm;
+                                     batch_size: csize; input_channels: csize;
+                                     output_channels: csize; input_size: nnp_size;
+                                     input_padding: nnp_padding;
+                                     kernel_size: nnp_size; input: ptr cfloat;
+                                     grad_output: ptr cfloat;
+                                     grad_kernel: ptr cfloat;
+                                     workspace_buffer: pointer = nil;
+                                     workspace_size: ptr csize = nil;
+                                     activation: nnp_activation = nnp_activation_identity;
+                                     activation_parameters: pointer = nil;
+                                     threadpool: pthreadpool_t = nil;
+                                     profile: ptr nnp_profile = nil): nnp_status {.cdecl,
+    importc: "nnp_convolution_kernel_gradient".}
+## *
+##  @brief Computes output of a 2D convolutional layer for a single input image and a kernel tensor.
+##  @details This function targets prediction with convolutional neural networks and performs forward propagation.
+##  @param algorithm The type of algorithm to use for convolution. Possible values are:
+##
+##     - nnp_convolution_algorithm_auto    -- let the function choose the algorithm.
+##     - nnp_convolution_algorithm_ft8x8   -- tiled convolution based on 2D Fourier transform with 8x8 blocks.
+##                                            Supports kernels up to 8x8.
+##     - nnp_convolution_algorithm_ft16x16 -- tiled convolution based on 2D Fourier transform with 16x16 blocks.
+##                                            Supports kernels up to 16x16.
+##     - nnp_convolution_algorithm_wt8x8   -- tiled convolution based on 2D Winograd transform F(3x3, 6x6).
+##                                            Supports only 3x3 kernels.
+##
+##  @param transform_strategy A strategy that guides computation of kernel transforms coefficients.
+##                            Possible values are:
+##
+##     - nnp_convolution_transform_strategy_block_based -- do multiplication-accumulations on blocks of transformed
+##                                                         coefficients.
+##     - nnp_convolution_transform_strategy_tuple_based -- do multiplication-accumulations on tuples of transformed
+##                                                         coefficients.
+##
+##  @param input_channels The number of channels (AKA features, dimensions) in the input image.
+##  @param output_channels The number of channels (AKA features, dimensions) in the output image.
+##  @param input_size Size of input image, excluding implicit zero-padding.
+##  @param input_padding Implicit zero-padding of input image.
+##  @param kernel_size Kernel size.
+##  @param output_subsampling Subsample region for output, also known as convolution stride.
+##  @param[in]  input  A 3D tensor input[input_channels][input_size.height][input_size.width].
+##  @param[in]  kernel A 4D tensor kernel[output_channels][input_channels][kernel_size.height][kernel_size.width].
+##  @param[in]  bias   A 1D array bias[output_channels].
+##  @param[out] output A 3D tensor output[output_channels][output_size.height][output_size.width] where
+##                         output_size.height = (input_padding.top + input_size.height + input_padding.bottom) -
+##                                              (kernel_size.height - 1)
+##                         output_size.width  = (input_padding.left + input_size.width + input_padding.right) -
+##                                              (kernel_size.width - 1)
+##  @param[in] workspace_buffer Buffer for scratch memory used during computation. Buffer must be aligned on 64 bytes.
+##                              If workspace_buffer is NULL and workspace_size is non-NULL, NNPACK would store the size
+##                              of required workspace memory at the workspace_size location, and exit without
+##                              computations.
+##                              If workspace_buffer is NULL and workspace_size is NULL, NNPACK would allocate memory
+##                              before and deallocate after this computation, potentially at significant runtime cost.
+##  @param[in,out] workspace_size Pointer to the size of workspace buffer.
+##                                If workspace_buffer is NULL, NNPACK will write the size of required scratch memory to
+##                                the location specified by this pointer.
+##                                If workspace_buffer is non-NULL, NNPACK expects workspace_size to specify the size of
+##                                the buffer, in bytes.
+##                                If workspace_size is NULL, workspace_buffer must be NULL as well. In this case NNPACK
+##                                would allocate memory before and deallocate after this computation, potentially at
+##                                significant runtime cost.
+##  @param threadpool A thread pool for parallelization of the computation.
+##                    If threadpool is NULL, the computation would run on the caller thread without parallelization.
+##  @param[out] profile An optional pointer to profiling structure.
+##                      If provided, the structure would record time spent in different phases of the computation.
+##
+
+proc nnp_convolution_inference*(algorithm: nnp_convolution_algorithm;
+    transform_strategy: nnp_convolution_transform_strategy; input_channels: csize;
+                               output_channels: csize; input_size: nnp_size;
+                               input_padding: nnp_padding; kernel_size: nnp_size;
+                               output_subsampling: nnp_size; input: ptr cfloat;
+                               kernel: ptr cfloat; bias: ptr cfloat;
+                               output: ptr cfloat; workspace_buffer: pointer;
+                               workspace_size: ptr csize;
+                               activation: nnp_activation;
+                               activation_parameters: pointer;
+                               threadpool: pthreadpool_t; profile: ptr nnp_profile): nnp_status {.
+    cdecl, importc: "nnp_convolution_inference".}
+## *
+##  @brief Computes output of a fully connected layer from input and kernel matrices.
+##  @details This function targets training of convolutional neural networks and performs forward propagation.
+##           It is optimized for moderate minibatch sizes (64-128) and can be inefficient on a small minibatch.
+##           For minibatch size 1, use nnp_fully_connected_inference for optimal performance.
+##  @param batch_size The number of vectors on the input and output of the fully connected layer.
+##  @param input_channels The number of channels (AKA features, dimensions) in the input matrix.
+##  @param output_channels The number of channels (AKA features, dimensions) in the output matrix.
+##  @param[in]  input  A 2D matrix input[batch_size][input_channels].
+##  @param[in]  kernel A 2D matrix kernel[output_channels][input_channels].
+##  @param[out] output A 2D matrix output[batch_size][output_channels].
+##  @param threadpool A thread pool for parallelization of the computation.
+##                    If threadpool is NULL, the computation would run on the caller thread without parallelization.
+##
+
+proc nnp_fully_connected_output*(batch_size: csize; input_channels: csize;
+                                output_channels: csize; input: ptr cfloat;
+                                kernel: ptr cfloat; output: ptr cfloat;
+                                threadpool: pthreadpool_t;
+                                profile: ptr nnp_profile): nnp_status {.cdecl,
+    importc: "nnp_fully_connected_output".}
+## *
+##  @brief Computes output of a fully connected layer for a single input vector and a kernel matrix.
+##  @details This function targets prediction with convolutional neural networks and performs forward propagation.
+##  @param input_channels The number of channels (AKA features, dimensions) in the input vector.
+##  @param output_channels The number of channels (AKA features, dimensions) in the output vector.
+##  @param[in]  input  A 1D array input[input_channels] of FP32 elements.
+##  @param[in]  kernel A 2D matrix kernel[output_channels][input_channels] of FP32 elements.
+##  @param[out] output A 1D array output[output_channels] of FP32 elements.
+##  @param threadpool A thread pool for parallelization of the computation.
+##                    If threadpool is NULL, the computation would run on the caller thread without parallelization.
+##
+
+proc nnp_fully_connected_inference*(input_channels: csize; output_channels: csize;
+                                   input: ptr cfloat; kernel: ptr cfloat;
+                                   output: ptr cfloat; threadpool: pthreadpool_t): nnp_status {.
+    cdecl, importc: "nnp_fully_connected_inference".}
+## *
+##  @brief Computes output of a fully connected layer for a single input vector and a kernel matrix.
+##  @details This function targets prediction with convolutional neural networks and performs forward propagation.
+##  @param input_channels The number of channels (AKA features, dimensions) in the input vector.
+##  @param output_channels The number of channels (AKA features, dimensions) in the output vector.
+##  @param[in]  input  A 1D array input[input_channels] of FP32 elements.
+##  @param[in]  kernel A 2D matrix kernel[output_channels][input_channels] of FP16 (ARM alternative format) elements.
+##  @param[out] output A 1D array output[output_channels] of FP32 elements.
+##  @param threadpool A thread pool for parallelization of the computation.
+##                    If threadpool is NULL, the computation would run on the caller thread without parallelization.
+##
+
+proc nnp_fully_connected_inference_f16f32*(input_channels: csize;
+    output_channels: csize; input: ptr cfloat; kernel: pointer; output: ptr cfloat;
+    threadpool: pthreadpool_t): nnp_status {.cdecl,
+    importc: "nnp_fully_connected_inference_f16f32".}
+## *
+##  @brief Computes output of a max-pooling layer for an input tensor.
+##  @details This function targets both prediction and training of convolutional neural networks and performs forward
+##           propagation. Is is optimized for both large and small minibatch sizes.
+##  @param batch_size The number of images on the input and output of the max-pooling layer.
+##  @param channels   The number of channels (AKA features, dimensions) in both input and output images.
+##  @param input_size Size of input images, excluding implicit zero-padding.
+##  @param input_padding Implicit padding of input images. The padding pixels are ignored by the pooling filter, but
+##                       affect the output size.
+##  @param pooling_size   Size of the pooling filter. Only 2x2 filter are currently supported.
+##  @param pooling_stride Stride of the pooling filter. Only 2x2 strides are currently supported.
+##  @param[in]  input  A 4D tensor input[batch_size][channels][input_size.height][input_size.width].
+##  @param[out] output A 4D tensor output[batch_size][channels][output_size.height][output_size.width] where
+##                     output_size.height = ceil(
+##                       (input_padding.top + input_size.height + input_padding.bottom - pooling_size.height) /
+##                         pooling_stride.height) + 1
+##                     output_size.width = ceil(
+##                       (input_padding.left + input_size.width + input_padding.right - pooling_size.width) /
+##                         pooling_stride.width) + 1
+##  @param threadpool A thread pool for parallelization of the computation.
+##                    If threadpool is NULL, the computation would run on the caller thread without parallelization.
+##
+
+proc nnp_max_pooling_output*(batch_size: csize; channels: csize;
+                            input_size: nnp_size; input_padding: nnp_padding;
+                            pooling_size: nnp_size; pooling_stride: nnp_size;
+                            input: ptr cfloat; output: ptr cfloat;
+                            threadpool: pthreadpool_t): nnp_status {.cdecl,
+    importc: "nnp_max_pooling_output".}
+## *
+##  @brief Computes output of a softmax layer for an input matrix.
+##  @details This function targets both prediction and training of convolutional neural networks and performs forward
+##           propagation. Is is optimized for both large and small minibatch sizes.
+##  @param batch_size The number of vectors on the input and output of the softmax layer.
+##  @param channels   The number of channels (AKA features, dimensions) in both input and output vectors.
+##  @param[in]  input  A 2D matrix input[batch_size][channels].
+##  @param[out] output A 2D matrix output[batch_size][channels].
+##  @param threadpool A thread pool for parallelization of the computation.
+##                    If threadpool is NULL, the computation would run on the caller thread without parallelization.
+##
+
+proc nnp_softmax_output*(batch_size: csize; channels: csize; input: ptr cfloat;
+                        output: ptr cfloat; threadpool: pthreadpool_t): nnp_status {.
+    cdecl, importc: "nnp_softmax_output".}
+## *
+##  @brief Computes output of a rectified linear unit (ReLU) layer for an input matrix.
+##  @details This function targets both prediction and training of convolutional neural networks and performs forward
+##           propagation. Is is optimized for both large and small minibatch sizes.
+##  @param batch_size The number of vectors on the input and output of the ReLU layer.
+##  @param channels   The number of channels (AKA features, dimensions) in both input and output matrices.
+##  @param[in]  input  A 2D matrix input[batch_size][channels].
+##  @param[out] output A 2D matrix output[batch_size][channels].
+##  @param threadpool A thread pool for parallelization of the computation.
+##                    If threadpool is NULL, the computation would run on the caller thread without parallelization.
+##
+
+proc nnp_relu_output*(batch_size: csize; channels: csize; input: ptr cfloat;
+                     output: ptr cfloat; negative_slope: cfloat;
+                     threadpool: pthreadpool_t): nnp_status {.cdecl,
+    importc: "nnp_relu_output".}
+## *
+##  @brief Computes gradient of input of a rectified linear unit (ReLU) layer from gradient of output and input matrices.
+##  @details This function targets training of convolutional neural networks and performs backward propagation.
+##           Is is optimized for both large and small minibatch sizes.
+##  @param batch_size The number of vectors on the input and output of the ReLU layer.
+##  @param channels   The number of channels (AKA features, dimensions) in both input and output matrices.
+##  @param[in]  input  A 2D matrix input[batch_size][channels].
+##  @param[out] output A 2D matrix output[batch_size][channels].
+##  @param threadpool A thread pool for parallelization of the computation.
+##                    If threadpool is NULL, the computation would run on the caller thread without parallelization.
+##
+
+proc nnp_relu_input_gradient*(batch_size: csize; channels: csize;
+                             grad_output: ptr cfloat; input: ptr cfloat;
+                             grad_input: ptr cfloat; negative_slope: cfloat;
+                             threadpool: pthreadpool_t): nnp_status {.cdecl,
+    importc: "nnp_relu_input_gradient".}
+
+# Initialize nnpack automatically
+let nn_init_status = nnp_initialize()
+if nn_init_status != nnp_status_success:
+  raise newException(LibraryError, "Failed to initialize NNPack")

--- a/src/nn_primitives/backend/nnpack_interface.nim
+++ b/src/nn_primitives/backend/nnpack_interface.nim
@@ -1,0 +1,108 @@
+# Copyright 2017 the Arraymancer contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ../../tensor/tensor, ../types
+import ./nnpack
+
+proc nnpack_conv2d*(input, weight, bias: Tensor[float32], padding, stride: Size2D): Tensor[float32] =
+  # Only accepts stride 1
+  assert stride.width == 1 and stride.height == 1
+
+  let
+    batch_size = input.shape[0]
+    output_channels = weight.shape[^4]
+    output_height = (2*padding.height + input.nchw_height) - (weight.nchw_height - 1)
+    output_width = (2*padding.width + input.nchw_width) - (weight.nchw_width - 1)
+
+  # Make sure the data is contiguous before passing to nnpack
+  let input = input.unsafeContiguous()
+  let weight = weight.unsafeContiguous()
+  var bias: Tensor[float32]
+
+  # Bias with 0 rank means no bias at all
+  if bias.rank == 0:
+    # Temporary bias filled with zeros just to pass to nnpack
+    bias = zeros[float32](output_channels)
+  else:
+    bias = bias.unsafeContiguous()
+
+  # Prepare tensor that the result will be stored on
+  result = newTensorUninit[float32](input.shape[0], output_channels, output_height, output_width)
+
+  let status = nnp_convolution_output(
+    algorithm=nnp_convolution_algorithm_auto,
+    batch_size=batch_size,
+    input_channels=input.nchw_channels,
+    output_channels=output_channels,
+    input_size=nnp_size(height: input.nchw_height, width: input.nchw_width),
+    input_padding=nnp_padding(top: padding.height, bottom: padding.height,
+                              left: padding.width, right: padding.width),
+    kernel_size=nnp_size(height:weight.nchw_height, width: weight.nchw_width),
+    input=cast[ptr cfloat](input.get_data_ptr),
+    kernel=cast[ptr cfloat](weight.get_data_ptr),
+    bias=cast[ptr cfloat](bias.get_data_ptr),
+    output=cast[ptr cfloat](result.get_data_ptr))
+  assert status == nnp_status_success
+
+
+proc nnpack_conv2d_gradient*[T](input, weight: Tensor[float32], padding, stride: Size2D,
+                                grad_output: Tensor[T], grad_input, grad_weight: var Tensor[T]) =
+  # Only accepts stride 1
+  assert stride.width == 1 and stride.height == 1
+
+  let
+    batch_size = input.shape[0]
+    input_channels = input.nchw_channels
+    output_channels = weight.shape[^4]
+    output_height = (2*padding.height + input.nchw_height) - (weight.nchw_height - 1)
+    output_width = (2*padding.width + input.nchw_width) - (weight.nchw_width - 1)
+    nninput_size = nnp_size(height: input.nchw_height, width: input.nchw_width)
+    nnpadding = nnp_padding(top: padding.height, bottom: padding.height,
+                              left: padding.width, right: padding.width)
+    nnkernel_size = nnp_size(height:weight.nchw_height, width: weight.nchw_width)
+
+  # Check if grad output shape looks correct
+  assert grad_output.nchw_width == output_width and grad_output.nchw_height == output_height
+  assert grad_output.nchw_channels == output_channels
+  assert grad_output.shape[0] == input.shape[0]
+
+  # Input gradient
+  grad_input = zeros[T](input.shape)
+  var status = nnp_convolution_input_gradient(
+    algorithm=nnp_convolution_algorithm_auto,
+    batch_size=batch_size,
+    input_channels=input_channels,
+    output_channels=output_channels,
+    input_size=nninput_size,
+    input_padding=nnpadding,
+    kernel_size=nnkernel_size,
+    grad_output=cast[ptr cfloat](grad_output.get_data_ptr),
+    kernel=cast[ptr cfloat](weight.get_data_ptr),
+    grad_input=cast[ptr cfloat](grad_input.get_data_ptr))
+  assert status == nnp_status_success
+
+  # Weight gradient
+  grad_weight = zeros[T](weight.shape)
+  status = nnp_convolution_kernel_gradient(
+    algorithm=nnp_convolution_algorithm_auto,
+    batch_size=batch_size,
+    input_channels=input_channels,
+    output_channels=output_channels,
+    input_size=nninput_size,
+    input_padding=nnpadding,
+    kernel_size=nnkernel_size,
+    input=cast[ptr cfloat](input.get_data_ptr),
+    grad_output=cast[ptr cfloat](grad_output.get_data_ptr),
+    grad_kernel=cast[ptr cfloat](grad_weight.get_data_ptr))
+  assert status == nnp_status_success

--- a/src/nn_primitives/convolution_primitives.nim
+++ b/src/nn_primitives/convolution_primitives.nim
@@ -1,0 +1,103 @@
+# Copyright 2017 the Arraymancer contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ../tensor/tensor, ./types
+import ./fallback/conv
+
+when defined(nnpack):
+  import backend/nnpack_interface
+
+type
+  ## Algorithms to be used in Conv2D
+  Conv2DAlgorithm* = enum
+    Im2ColGEMM,
+    NNPackAuto
+
+proc conv2d*[T](input, weight, bias: Tensor[T],
+                padding: Size2D = (0,0),
+                stride: Size2D = (1,1),
+                algorithm = Conv2DAlgorithm.Im2ColGEMM): Tensor[T] {.inline.} =
+  ## Computes a 2D convolution over input images. Intended to be used
+  ## in 2d convolution forward pass. This applies a 2D cross-correlation,
+  ## not to be confused with the mathematical convolution.
+  ##
+  ## Input:
+  ##     - ``input`` 4D Tensor batch of images of the size [N,C_in,H_in,W_in]
+  ##     - ``weight`` 4D Tensor convolving kernel weights of the size [C_out,C_in,kH,kW]
+  ##     - ``bias`` 3D Tensor bias of the size [C_out,1,1] or an empty tensor for no bias
+  ##     - ``padding`` Size2D tuple with height and width of the padding
+  ##     - ``stride`` Size2D tuple with height and width of the stride
+  ##     - ``algorithm`` algorithm to be used in the convolution
+  ## Returns:
+  ##     - A 4D Tensor of sized [N,C_out,H_out,W_out], where
+  ##        H_out = (H_in + (2*padding.height) - kH) / stride.height + 1
+  ##        W_out = (W_in + (2*padding.width) - kW) / stride.width + 1
+  ## Valid algorithms:
+  ##    - ``Im2ColGEMM`` im2col + GEMM algorithm, this is the default
+  ##    - ``NNPackAuto`` Use NNPack and let it auto detect the best algorithm
+  assert input.rank == 4 and weight.rank == 4
+  assert bias.rank == 3 or bias.rank == 0
+
+  case algorithm:
+    of NNPackAuto:
+      when defined(nnpack) and T is float32:
+        result = nnpack_conv2d(input, weight, bias, padding, stride)
+      else:
+        raise newException(LibraryError, "NNPack not enabled, enable with -d:nnpack")
+    of Im2ColGEMM:
+      result = im2colgemm_conv2d(input, weight, bias, padding, stride)
+
+proc conv2d_backward*[T](input, weight, bias: Tensor[T],
+                         padding: Size2D,
+                         stride: Size2D,
+                         grad_output: Tensor[T],
+                         grad_input, grad_weight, grad_bias: var Tensor[T],
+                         algorithm = Conv2DAlgorithm.Im2ColGEMM) =
+  ## Computes gradients of a 2D convolution. Intended to be used after
+  ## ``conv2d`` to calculate gradients in backward pass.
+  ##
+  ## Input:
+  ##     - ``input`` 4D Tensor batch of images of the size [N,C_in,H_in,W_in]
+  ##     - ``weight`` 4D Tensor convolving kernel weights of the size [C_out,C_in,kH,kW]
+  ##     - ``bias`` 3D Tensor bias of the size [C_out,1,1] or an empty tensor for no bias
+  ##     - ``padding`` Size2D tuple with height and width of the padding
+  ##     - ``stride`` Size2D tuple with height and width of the stride
+  ##     - ``grad_output`` 4D tensor gradient of the next layer of the size [N,C_out,H_out,W_out]
+  ##     - ``grad_input`` tensor where the gradient w.r.t input will be written
+  ##     - ``grad_weight`` tensor where the gradient w.r.t weight will be written
+  ##     - ``grad_bias`` tensor where the gradient w.r.t bias will be written
+  ##     - ``algorithm`` algorithm to be used in the convolution
+  ## Valid algorithms:
+  ##    - ``Im2ColGEMM`` im2col + GEMM algorithm, this is the default
+  ##    - ``NNPackAuto`` Use NNPack and let it auto detect the best algorithm
+  assert input.rank == 4 and weight.rank == 4
+  assert bias.rank == 3 or bias.rank == 0
+
+  # Bias gradient
+  if bias.rank > 0:
+    # TODO: sum over many axes
+    grad_bias = grad_output.sum(3).sum(2).sum(0).unsafeReshape(bias.shape)
+
+  case algorithm:
+    of NNPackAuto:
+      when defined(nnpack) and T is float32:
+        nnpack_conv2d_gradient(input, weight,
+                               padding, stride,
+                               grad_output, grad_input, grad_weight)
+      else:
+        raise newException(LibraryError, "NNPack not enabled, enable with -d:nnpack")
+    of Im2ColGEMM:
+      im2colgemm_conv2d_gradient(input, weight,
+                                 padding, stride,
+                                 grad_output, grad_input, grad_weight)

--- a/src/nn_primitives/fallback/conv.nim
+++ b/src/nn_primitives/fallback/conv.nim
@@ -1,0 +1,122 @@
+# Copyright 2017 the Arraymancer contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import  ../../tensor/tensor, ../types
+
+proc im2col[T](input: Tensor[T], kernel_size: Size2D,
+               padding: Size2D = (0,0), stride: Size2D = (1,1)): Tensor[T] =
+  ## Convert blocks of an image into columns, useful for preprocessing
+  ## an image before convolutions
+  let
+    channels = input.nchw_channels
+    height = input.nchw_height
+    width = input.nchw_width
+    channels_col = channels * kernel_size.height * kernel_size.width
+    height_col = (height + (2 * padding.height) - kernel_size.height) div stride.height + 1
+    width_col = (width + (2 * padding.width) - kernel_size.width) div stride.width + 1
+  result = newTensorUninit[T](channels_col, height_col * width_col)
+  for c in 0..<channels_col:
+    let
+      w_offset = (c mod kernel_size.width) - padding.width
+      h_offset = ((c div kernel_size.width) mod kernel_size.height) - padding.height
+      c_offset = (c div kernel_size.width) div kernel_size.height
+    for h in 0..<height_col:
+      let
+        row = h_offset + (h * stride.height)
+        offset_col = h * width_col
+      for w in 0..<width_col:
+        let col = w_offset + (w * stride.width)
+        if row < 0 or col < 0 or row >= height or col >= width:
+          result[c, offset_col + w] = 0
+        else:
+          result[c, offset_col + w] = input[c_offset, row, col]
+
+proc col2im*[T](input: Tensor[T], channels, height, width: int,
+                kernel_size: Size2D,
+                padding: Size2D = (0,0), stride: Size2D = (1,1)): Tensor[T] =
+  ## Convert blocks of an image from columns back to an image, collapsed
+  ## pixels are summed
+  let
+    channels_col = channels * kernel_size.height * kernel_size.width
+    height_col = (height + (2 * padding.height) - kernel_size.height) div stride.height + 1
+    width_col = (width + (2 * padding.width) - kernel_size.width) div stride.width + 1
+  result = zeros[T](channels, height, width)
+  for c in 0..<channels_col:
+    let
+      w_offset = (c mod kernel_size.width) - padding.width
+      h_offset = ((c div kernel_size.width) mod kernel_size.height) - padding.height
+      c_offset = (c div kernel_size.width) div kernel_size.height
+    for h in 0..<height_col:
+      let
+        row = h_offset + (h * stride.height)
+        offset_col = h * width_col
+      for w in 0..<width_col:
+        let col = w_offset + (w * stride.width)
+        if row < 0 or col < 0 or row >= height or col >= width:
+          continue
+        result[c_offset, row, col] += input[c, offset_col + w]
+
+proc im2colgemm_conv2d*[T](input, kernel, bias: Tensor[T],
+                padding: Size2D = (0,0),
+                stride: Size2D = (1,1)): Tensor[T] =
+  ## Compute cross-correlate for image with the given kernel weights
+  # Implementation with ideas from http://cs231n.github.io/convolutional-networks/#conv
+  let
+    batch_size = input.shape[^4]
+    output_channels = kernel.shape[^4]
+    kernel_size = (height: kernel.nchw_height, width: kernel.nchw_width)
+    output_height = (input.nchw_height + (2*padding.height) - kernel.nchw_height) div stride.height + 1
+    output_width = (input.nchw_width + (2*padding.width) - kernel.nchw_width) div stride.width + 1
+    kernel_col = kernel.unsafeReshape(output_channels, input.nchw_channels*kernel.nchw_height*kernel.nchw_width)
+
+  result = newTensorUninit[T](batch_size, output_channels, output_height, output_width)
+
+  for i in 0..<batch_size:
+    let input_col = im2col(input.unsafeAtAxisIndex(0, i).unsafeSqueeze(0), kernel_size, padding, stride)
+    var output = result.unsafeAtAxisIndex(0, i).unsafeReshape(kernel_col.shape[0], input_col.shape[1])
+    gemm(kernel_col, input_col, output)
+
+  if bias.rank > 0:
+    result .+= bias.unsafeUnsqueeze(0)
+
+proc im2colgemm_conv2d_gradient*[T](input, kernel: Tensor[T],
+                         padding: Size2D = (0,0),
+                         stride: Size2D = (1,1),
+                         grad_output: Tensor[T],
+                         grad_input, grad_weight: var Tensor[T]) =
+  ## Computes gradients w.r.t input and weights for a 2D convolution
+  let
+    batch_size = input.shape[^4]
+    output_channels = kernel.shape[^4]
+    kernel_size = (height: kernel.nchw_height, width: kernel.nchw_width)
+    output_height = (input.nchw_height + (2*padding.height) - kernel.nchw_height) div stride.height + 1
+    output_width = (input.nchw_width + (2*padding.width) - kernel.nchw_width) div stride.width + 1
+    output_flatten_size = output_height*output_width
+    kernel_col = kernel.unsafeReshape(output_channels, input.nchw_channels*kernel.nchw_height*kernel.nchw_width)
+
+  # Check if grad output shape looks correct
+  assert grad_output.nchw_width == output_width and grad_output.nchw_height == output_height
+  assert grad_output.nchw_channels == output_channels
+  assert grad_output.shape[0] == input.shape[0]
+
+  grad_input = zeros[T](batch_size, input.nchw_channels, input.nchw_height, input.nchw_width)
+  grad_weight = zeros[T](output_channels, kernel.nchw_channels, kernel.nchw_height, kernel.nchw_width)
+
+  for i in 0..<batch_size:
+    let
+      input_col = im2col(input.unsafeAtAxisIndex(0, i).unsafeSqueeze(0), kernel_size, padding, stride)
+      grad_output_col = grad_output.unsafeAtAxisIndex(0, i).unsafeReshape(output_channels, output_flatten_size)
+      grad_input_col = kernel_col.unsafeTranspose() * grad_output_col
+    grad_input[i, _, _, _] = col2im(grad_input_col, input.nchw_channels, input.nchw_height, input.nchw_width, kernel_size, padding, stride).unsafeUnsqueeze(0)
+    grad_weight += (grad_output_col * input_col.unsafeTranspose()).unsafeReshape(grad_weight.shape)

--- a/src/nn_primitives/nn_primitives.nim
+++ b/src/nn_primitives/nn_primitives.nim
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 import  ./activation_primitives,
+        ./convolution_primitives,
         ./linear_primitives,
         ./sigmoid_cross_entropy_primitives
 
-export activation_primitives, linear_primitives, sigmoid_cross_entropy_primitives
+export activation_primitives,
+       convolution_primitives,
+       linear_primitives,
+       sigmoid_cross_entropy_primitives

--- a/src/nn_primitives/types.nim
+++ b/src/nn_primitives/types.nim
@@ -1,0 +1,18 @@
+import ../tensor/tensor
+
+type
+  Size2D* = tuple
+    height: int
+    width: int
+
+proc nchw_channels*[T](input: Tensor[T]): int {.inline.}  =
+  ## Return number of channels of a Tensor in NCWH layout
+  input.shape[^3]
+
+proc nchw_height*[T](input: Tensor[T]): int {.inline.} =
+  ## Return height of a Tensor in NCWH layout
+  input.shape[^2]
+
+proc nchw_width*[T](input: Tensor[T]): int {.inline.} =
+  ## Return width of a Tensor in NCWH layout
+  input.shape[^1]

--- a/src/tensor/data_structure.nim
+++ b/src/tensor/data_structure.nim
@@ -138,9 +138,9 @@ template get_data_ptr*[T](t: AnyTensor[T]): ptr T =
   ## Returns:
   ##     - A pointer to the start of its data
   when t is Tensor:
-    unsafeAddr(t.data[0])
+    unsafeAddr(t.data[t.offset])
   elif t is CudaTensor:
-    unsafeAddr(t.data.data[0])
+    unsafeAddr(t.data.data[t.offset])
 
 proc dataArray*[T](t: Tensor[T]): ptr UncheckedArray[T] {.inline.} =
   cast[ptr UncheckedArray[T]](t.data[t.offset].unsafeAddr)

--- a/src/tensor/operators_blas_l2l3.nim
+++ b/src/tensor/operators_blas_l2l3.nim
@@ -60,7 +60,7 @@ proc gemm*[T: SomeReal](
   beta: T, C: var Tensor[T]) {.inline.}=
   # Matrix: C = alpha A matmul B + beta C
   when compileOption("boundChecks"):
-    check_matvec(A,B)
+    check_matmat(A,B)
     # TODO: check c + tests
 
   when declared(blis):
@@ -79,6 +79,11 @@ proc gemm*[T: SomeInteger](
     # TODO: check c + tests
 
   fallbackMM_C_eq_aAB_p_bC(alpha, A, B, beta, C)
+
+proc gemm*[T: SomeNumber](
+  A, B: Tensor[T],
+  C: var Tensor[T]) {.inline.}=
+  gemm(1.T, A, B, 0.T, C)
 
 proc `*`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Matrix multiplication (Matrix-Matrix and Matrix-Vector)

--- a/src/tensor/private/p_shapeshifting.nim
+++ b/src/tensor/private/p_shapeshifting.nim
@@ -32,7 +32,7 @@ proc reshape_with_copy*[T](t: Tensor[T], new_shape: varargs[int]|MetadataArray):
 template reshape_no_copy*(t: AnyTensor, new_shape: varargs[int]|MetadataArray): untyped =
   when compileOption("boundChecks"):
     check_nocopyReshape t
-    check_reshape(t, new_shape.toMetadataArray)
+    check_reshape(t, new_shape)
   result.shape.copyFrom(new_shape)
   shape_to_strides(result.shape, rowMajor, result.strides)
   result.offset = t.offset

--- a/tests/nn_primitives/test_convolution_primitives.nim
+++ b/tests/nn_primitives/test_convolution_primitives.nim
@@ -1,0 +1,159 @@
+import ../../src/arraymancer
+import unittest, math, future
+
+suite "Convolution 2D":
+  block:
+    let input = [
+      [1, 2, 0, 0],
+      [5, 3, 0, 4],
+      [0, 0, 0, 7],
+      [9, 3, 0, 0]].toTensor().reshape([1,1,4,4])
+    let kernel = [
+      [1, 1, 1],
+      [1, 1, 0],
+      [1, 0, 0]].toTensor().reshape([1,1,3,3])
+    let target = [
+      [1,  8,  5,  0],
+      [8, 11,  5,  4],
+      [8, 17, 10, 11],
+      [9, 12, 10,  7]].toTensor().reshape([1,1,4,4])
+    let bias = [0].toTensor().reshape(1,1,1)
+    check: input.conv2d(kernel, bias, padding=(1,1)) == target
+
+    let
+      finput = input.astype(float32)
+      fkernel = kernel.astype(float32)
+      fbias = bias.astype(float32)
+      ftarget = target.astype(float32)
+
+    test "Simple Conv2D [Im2ColGEMM]":
+      check: mean_absolute_error(finput.conv2d(fkernel, fbias, padding=(1,1)), ftarget) <= 1e-4'f32
+
+    when defined(nnpack):
+      test "Simple Conv2D [NNPack]":
+        check: mean_absolute_error(finput.conv2d(fkernel, fbias, padding=(1,1), algorithm=Conv2DAlgorithm.NNPackAuto), ftarget) <= 1e-4'f32
+
+  test "Strided Conv2D [Im2ColGEMM]":
+    let input = [
+      [
+        [
+          [2, 2, 0, 2, 1],
+          [0, 1, 1, 0, 2],
+          [1, 2, 1, 2, 1],
+          [2, 2, 0, 0, 2],
+          [2, 1, 1, 1, 2]
+        ], [
+          [2, 0, 1, 1, 1],
+          [2, 2, 0, 0, 2],
+          [2, 2, 1, 0, 0],
+          [1, 1, 2, 2, 0],
+          [2, 1, 1, 1, 0]
+        ], [
+          [0, 1, 2, 2, 0],
+          [1, 1, 1, 1, 0],
+          [2, 1, 2, 2, 0],
+          [0, 2, 2, 2, 1],
+          [0, 0, 2, 2, 1]
+        ]
+      ]].toTensor()
+
+    let kernel =
+      [
+        [
+          [
+            [-1, -1, -1],
+            [ 1,  0,  1],
+            [ 0, -1,  0]
+          ], [
+            [ 1,  0, -1],
+            [ 1, -1,  1],
+            [ 0,  1,  0]
+          ], [
+            [ 0,  0,  1],
+            [-1, -1, -1],
+            [-1,  0,  0]
+          ]
+        ], [
+          [
+            [ 0,  1,  0],
+            [ 1, -1, -1],
+            [ 1,  1, -1]
+          ], [
+            [-1,  0,  1],
+            [-1, -1,  1],
+            [ 1,  1,  0]
+          ], [
+            [ 0,  1,  1],
+            [-1,  1, -1],
+            [-1, -1,  0]
+          ]
+        ]
+      ].toTensor()
+
+    let target =
+      [
+        [
+          [ 2, -2,  0],
+          [-3,  2, -5],
+          [-2, -1,  0]
+        ],[
+          [-7,  1,  0],
+          [ 3, -3,  2],
+          [ 1,  3, -2]
+        ]
+      ].toTensor().reshape([1,2,3,3])
+
+    let bias = [1,0].toTensor().reshape(2,1,1)
+
+    check: input.conv2d(kernel, bias, padding=(1,1), stride=(2,2)) == target
+
+    let
+      finput = input.astype(float32)
+      fkernel = kernel.astype(float32)
+      fbias = bias.astype(float32)
+      ftarget = target.astype(float32)
+
+    check: finput.conv2d(fkernel, fbias, padding=(1,1), stride=(2,2)) == ftarget
+
+  # Convolution 2d Forward + Backward
+  block:
+    let
+      input = randomTensor([2,3,4,5], 1.0f)
+      kernel = randomTensor([2,3,3,3], 1.0f)
+      bias = randomTensor([2,1,1], 1.0f)
+      padding = (1,1)
+      stride = (1,1)
+
+    let output = conv2d(input, kernel, bias, padding, stride)
+
+    let
+      dinput = input.astype(float)
+      dkernel = kernel.astype(float)
+      dbias = bias.astype(float)
+
+    let
+      target_grad_input = dinput.numerical_gradient(
+        x => conv2d(x, dkernel, dbias, padding, stride).sum())
+      target_grad_weight = dkernel.numerical_gradient(
+        w => dinput.conv2d(w, dbias, padding, stride).sum())
+      target_grad_bias = dbias.numerical_gradient(
+        b => dinput.conv2d(dkernel, b, padding, stride).sum())
+
+    var grad_input, grad_weight, grad_bias : Tensor[float32]
+    let grad_output = ones[float32](output.shape)
+
+    test "Conv2D Forward + Backward [Im2ColGEMM]":
+      conv2d_backward(input, kernel, bias, padding, stride,
+                      grad_output, grad_input, grad_weight, grad_bias)
+      check: mean_relative_error(target_grad_bias, grad_bias.astype(float)) < 1e-6
+      check: mean_relative_error(target_grad_weight, grad_weight.astype(float)) < 1e-6
+      check: mean_relative_error(target_grad_input, grad_input.astype(float)) < 1e-6
+
+    when defined(nnpack):
+      test "Conv2D Forward + Backward [NNPack]":
+        conv2d_backward(input, kernel, bias, padding, stride,
+                        grad_output, grad_input, grad_weight, grad_bias,
+                        algorithm=Conv2DAlgorithm.NNPackAuto)
+        check: mean_relative_error(target_grad_bias, grad_bias.astype(float)) < 1e-6
+        check: mean_relative_error(target_grad_weight, grad_weight.astype(float)) < 1e-6
+        check: mean_relative_error(target_grad_input, grad_input.astype(float)) < 1e-6

--- a/tests/tensor/test_math_functions.nim
+++ b/tests/tensor/test_math_functions.nim
@@ -15,7 +15,7 @@
 import ../../src/arraymancer
 import unittest, future, math
 
-suite "CUDA CuBLAS backend (Basic Linear Algebra Subprograms)":
+suite "Math functions":
   test "Reciprocal (element-wise 1/x)":
     var a = [1.0, 10, 20, 30].toTensor.reshape(4,1)
 
@@ -55,3 +55,33 @@ suite "CUDA CuBLAS backend (Basic Linear Algebra Subprograms)":
     check: a.clamp(-2,2) == target
     a.mclamp(-2,2)
     check: a == target
+
+  test "Numerical gradient":
+    proc f(x: float): float = x*x + x + 1.0
+    check: relative_error(numerical_gradient(2.0, f), 5.0) < 1e-8
+
+    proc g(t: Tensor[float]): float =
+      let x = t[0]
+      let y = t[1]
+      x*x + y*y + x*y + x + y + 1.0
+    let input = [2.0, 3.0].toTensor()
+    let grad = [8.0, 9.0].toTensor()
+    check: mean_relative_error(numerical_gradient(input, g), grad) < 1e-8
+
+  test "Mean absolute error":
+    var y_true = [0.9, 0.2, 0.1, 0.4, 0.9].toTensor()
+    var y =      [1.0, 0.0, 0.0, 1.0, 1.0].toTensor()
+    check: absolute_error(y_true, y).sum() == 1.1
+    check: mean_absolute_error(y_true, y) == (1.1 / 5.0)
+
+  test "Mean squared error":
+    var y_true = [0.9, 0.2, 0.1, 0.4, 0.9].toTensor()
+    var y =      [1.0, 0.0, 0.0, 1.0, 1.0].toTensor()
+    check: squared_error(y_true, y).sum() == 0.43
+    check: mean_squared_error(y_true, y) == (0.43 / 5.0)
+
+  test "Relative error":
+    var y_true = [0.0,  0.0, -1.0, 1e-8, 1e-8].toTensor()
+    var y =      [0.0, -1.0,  0.0, 0.0,  1e-7].toTensor()
+    check: relative_error(y_true, y) == [0.0, 1.0, 1.0, 1.0, 0.9].toTensor()
+    check: mean_relative_error(y_true, y) == 0.78

--- a/tests/tests_cpu.nim
+++ b/tests/tests_cpu.nim
@@ -28,6 +28,7 @@ import ../src/arraymancer,
         ./tensor/test_filling_data,
         ./tensor/test_optimization,
         ./tensor/test_bugtracker,
+        ./nn_primitives/test_convolution_primitives,
         ./autograd/test_gate_blas
 
 import ./load_tests/test_load_openmp


### PR DESCRIPTION
Here I'm implementing 2d forward and backward low level functions, with nnpack and fallback implementation.

The PR includes NNPack bindings generated with c2nim with various hand fixes and an additional interface for using it.

To enable NNPack must compile with `-d:nnpack`, user may want to install nnpack with scalar backend if they do not have a high end Intel CPU.

The nn module is completely independent from arraymancer tensor core (see that I haven't changed any arraymancer source, instead only added files), this can be a good practice because not everyone may use all the arraymancer interfaces.

To use user has to `import arraymancer/nn`

