### PR TITLE
Small optimizations

### DIFF
--- a/src/tensor/accessors.nim
+++ b/src/tensor/accessors.nim
@@ -26,7 +26,7 @@ proc atContiguousIndex*[T](t: var Tensor[T], idx: int): var T {.noSideEffect,inl
   ## i.e. as treat the tensor as flattened
   return t.data[t.getContiguousIndex(idx)]
 
-proc unsafeAtAxisIndex*[T](t: Tensor[T], axis, idx: int): Tensor[T] {.inline.} =
+proc unsafeAtAxisIndex*[T](t: Tensor[T], axis, idx: int): Tensor[T] {.noInit,inline.} =
   ## Returns a sliced tensor in the given axis index (unsafe)
   when compileOption("boundChecks"):
     check_axis_index(t, axis, idx)
@@ -35,7 +35,7 @@ proc unsafeAtAxisIndex*[T](t: Tensor[T], axis, idx: int): Tensor[T] {.inline.} =
   result.shape[axis] = 1
   result.offset += result.strides[axis]*idx
 
-proc atAxisIndex*[T](t: Tensor[T], axis, idx: int): Tensor[T] {.inline.} =
+proc atAxisIndex*[T](t: Tensor[T], axis, idx: int): Tensor[T] {.noInit,inline.} =
   ## Returns a sliced tensor in the given axis index
 
   # As contiguous is called to force a copy of the slice

--- a/src/tensor/aggregate.nim
+++ b/src/tensor/aggregate.nim
@@ -25,7 +25,7 @@ proc sum*[T: SomeNumber](t: Tensor[T]): T =
   t.reduceT():
     x+=y
 
-proc sum*[T: SomeNumber](t: Tensor[T], axis: int): Tensor[T] =
+proc sum*[T: SomeNumber](t: Tensor[T], axis: int): Tensor[T] {.noInit,noInit.} =
   ## Compute the sum of all elements of T along an axis
   t.reduceAxisT(axis):
     x+=y
@@ -34,6 +34,6 @@ proc mean*[T: SomeReal](t: Tensor[T]): T {.inline.}=
   ## Compute the mean of all elements of T
   t.sum / t.size.T
 
-proc mean*[T: SomeReal](t: Tensor[T], axis: int): Tensor[T] {.inline.}=
+proc mean*[T: SomeReal](t: Tensor[T], axis: int): Tensor[T] {.noInit,inline.}=
   ## Compute the mean of T along an axis
   t.sum(axis) / t.shape[axis].T

--- a/src/tensor/data_structure.nim
+++ b/src/tensor/data_structure.nim
@@ -81,7 +81,7 @@ proc size*(t: AnyTensor): int {.noSideEffect, inline.}=
   ##     - The total number of elements it contains
   t.shape.product
 
-proc shape_to_strides*(shape: MetadataArray, layout: OrderType = rowMajor): MetadataArray {.noSideEffect.} =
+proc shape_to_strides*(shape: MetadataArray, layout: OrderType = rowMajor, result: var MetadataArray) {.noSideEffect.} =
   ## Input:
   ##     - A shape (MetadataArray), for example [3,5] for a 3x5 matrix
   ##     - Optionally rowMajor (C layout - default) or colMajor (Fortran)

--- a/src/tensor/higher_order.nim
+++ b/src/tensor/higher_order.nim
@@ -85,7 +85,7 @@ template reduceAxisT*[T](t: Tensor[T], axis: int, op: untyped): untyped =
       op
   reduced.unsafeView()
 
-proc map*[T; U: not (ref|string|seq)](t: Tensor[T], f: T -> U): Tensor[U] =
+proc map*[T; U: not (ref|string|seq)](t: Tensor[T], f: T -> U): Tensor[U] {.noInit.} =
   ## Apply a unary function in an element-wise manner on Tensor[T], returning a new Tensor.
   ## Usage with Nim's ``future`` module:
   ##  .. code:: nim
@@ -107,7 +107,7 @@ proc map*[T; U: not (ref|string|seq)](t: Tensor[T], f: T -> U): Tensor[U] =
   result = newTensorUninit[U](t.shape)
   result.apply2_inline(t, f(y))
 
-proc map*[T; U: ref|string|seq](t: Tensor[T], f: T -> U): Tensor[U] {.noSideEffect.}=
+proc map*[T; U: ref|string|seq](t: Tensor[T], f: T -> U): Tensor[U] {.noInit,noSideEffect.}=
   ## Apply a unary function in an element-wise manner on Tensor[T], returning a new Tensor.
   ##
   ##
@@ -166,7 +166,7 @@ proc apply*[T](t: var Tensor[T], f: proc(x:var T)) =
 
 proc map2*[T, U; V: not (ref|string|seq)](t1: Tensor[T],
                                           f: (T,U) -> V,
-                                          t2: Tensor[U]): Tensor[V] =
+                                          t2: Tensor[U]): Tensor[V] {.noInit.} =
   ## Apply a binary function in an element-wise manner on two Tensor[T], returning a new Tensor.
   ##
   ## The function is applied on the elements with the same coordinates.
@@ -196,7 +196,7 @@ proc map2*[T, U; V: not (ref|string|seq)](t1: Tensor[T],
 
 proc map2*[T, U; V: ref|string|seq](t1: Tensor[T],
                                     f: (T,U) -> V,
-                                    t2: Tensor[U]): Tensor[V] {.noSideEffect.}=
+                                    t2: Tensor[U]): Tensor[V] {.noInit,noSideEffect.}=
   ## Apply a binary function in an element-wise manner on two Tensor[T], returning a new Tensor.
   ##
   ##
@@ -304,7 +304,7 @@ proc reduce*[T](t: Tensor[T],
 proc reduce*[T](t: Tensor[T],
                 f: (Tensor[T], Tensor[T])-> Tensor[T],
                 axis: int
-                ): Tensor[T] =
+                ): Tensor[T] {.noInit.} =
   ## Chain result = f(result, element) over all elements of the Tensor.
   ##
   ## The starting value is the first element of the Tensor.

--- a/src/tensor/init_cpu.nim
+++ b/src/tensor/init_cpu.nim
@@ -21,7 +21,7 @@ import  ../private/[functional, nested_containers, sequninit],
         sequtils,
         random
 
-proc unsafeView*[T](t: Tensor[T]): Tensor[T] {.noSideEffect, inline.}=
+proc unsafeView*[T](t: Tensor[T]): Tensor[T] {.noSideEffect,noInit,inline.}=
   ## Input:
   ##     - A tensor
   ## Returns:
@@ -35,7 +35,7 @@ proc unsafeView*[T](t: Tensor[T]): Tensor[T] {.noSideEffect, inline.}=
   result.offset = t.offset
   shallowCopy(result.data, t.data)
 
-proc newTensorUninit*[T](shape: varargs[int]): Tensor[T] {.noSideEffect, inline.} =
+proc newTensorUninit*[T](shape: varargs[int]): Tensor[T] {.noSideEffect,noInit, inline.} =
   ## Creates a new Tensor on Cpu backend
   ## Input:
   ##      - Shape of the Tensor
@@ -47,7 +47,7 @@ proc newTensorUninit*[T](shape: varargs[int]): Tensor[T] {.noSideEffect, inline.
   tensorCpu(shape, result)
   result.data = newSeqUninit[T](result.size)
 
-proc newTensorUninit*[T](shape: MetadataArray): Tensor[T] {.noSideEffect, inline.} =
+proc newTensorUninit*[T](shape: MetadataArray): Tensor[T] {.noSideEffect,noInit, inline.} =
   ## Creates a new Tensor on Cpu backend
   ## Input:
   ##      - Shape of the Tensor
@@ -59,7 +59,7 @@ proc newTensorUninit*[T](shape: MetadataArray): Tensor[T] {.noSideEffect, inline
   tensorCpu(shape, result)
   result.data = newSeqUninit[T](result.size)
 
-proc newTensor*[T](shape: varargs[int]): Tensor[T] {.noSideEffect, inline.} =
+proc newTensor*[T](shape: varargs[int]): Tensor[T] {.noSideEffect,noInit, inline.} =
   ## Creates a new Tensor on Cpu backend
   ## Input:
   ##      - Shape of the Tensor
@@ -70,7 +70,7 @@ proc newTensor*[T](shape: varargs[int]): Tensor[T] {.noSideEffect, inline.} =
   tensorCpu(shape, result)
   result.data = newSeq[T](result.size)
 
-proc newTensorWith*[T](shape: varargs[int], value: T): Tensor[T] {.noSideEffect, inline.} =
+proc newTensorWith*[T](shape: varargs[int], value: T): Tensor[T] {.noSideEffect,noInit, inline.} =
   ## Creates a new Tensor filled with the given value
   ## Input:
   ##      - Shape of the Tensor
@@ -94,7 +94,7 @@ proc toTensor*(s:openarray, dummy_bugfix: static[int] = 0 ): auto {.noSideEffect
   # TODO: remove 'dummy_bugfix' - https://github.com/nim-lang/Nim/issues/6343
   toTensorCpu(s)
 
-proc unsafeToTensor*[T: SomeNumber](data: seq[T]): Tensor[T] {.noSideEffect.} =
+proc unsafeToTensor*[T: SomeNumber](data: seq[T]): Tensor[T] {.noInit,noSideEffect.} =
   ## Convert a seq to a Tensor, sharing the seq data
   ## Input:
   ##      - A seq with the tensor data
@@ -111,7 +111,7 @@ proc toTensor*(s:string): auto {.noSideEffect.} =
   toTensorCpu(s)
 
 # TODO add tests for randomTensor
-proc zeros*[T: SomeNumber](shape: varargs[int]): Tensor[T] {.noSideEffect, inline.} =
+proc zeros*[T: SomeNumber](shape: varargs[int]): Tensor[T] {.noInit,noSideEffect, inline.} =
   ## Creates a new Tensor filled with 0
   ##
   ## Input:
@@ -122,7 +122,7 @@ proc zeros*[T: SomeNumber](shape: varargs[int]): Tensor[T] {.noSideEffect, inlin
   tensorCpu(shape, result)
   result.data = newSeq[T](result.size)
 
-proc zeros*[T: SomeNumber](shape: MetadataArray): Tensor[T] {.noSideEffect, inline.} =
+proc zeros*[T: SomeNumber](shape: MetadataArray): Tensor[T] {.noInit,noSideEffect, inline.} =
   ## Creates a new Tensor filled with 0
   ##
   ## Input:
@@ -133,7 +133,7 @@ proc zeros*[T: SomeNumber](shape: MetadataArray): Tensor[T] {.noSideEffect, inli
   tensorCpu(shape, result)
   result.data = newSeq[T](result.size)
 
-proc zeros_like*[T: SomeNumber](t: Tensor[T]): Tensor[T] {.noSideEffect, inline.} =
+proc zeros_like*[T: SomeNumber](t: Tensor[T]): Tensor[T] {.noInit,noSideEffect, inline.} =
   ## Creates a new Tensor filled with 0 with the same shape as the input
   ## Input:
   ##      - Shape of the Tensor
@@ -142,7 +142,7 @@ proc zeros_like*[T: SomeNumber](t: Tensor[T]): Tensor[T] {.noSideEffect, inline.
   ##      - A zero-ed Tensor of the same shape
   return zeros[T](t.shape)
 
-proc ones*[T: SomeNumber](shape: varargs[int]): Tensor[T] {.noSideEffect,inline.} =
+proc ones*[T: SomeNumber](shape: varargs[int]): Tensor[T] {.noInit,noSideEffect,inline.} =
   ## Creates a new Tensor filled with 1
   ## Input:
   ##      - Shape of the Tensor
@@ -152,7 +152,7 @@ proc ones*[T: SomeNumber](shape: varargs[int]): Tensor[T] {.noSideEffect,inline.
   tensorCpu(shape, result)
   result.data = newSeqWith(result.size, 1.T)
 
-proc ones*[T: SomeNumber](shape: MetadataArray): Tensor[T] {.noSideEffect,inline.} =
+proc ones*[T: SomeNumber](shape: MetadataArray): Tensor[T] {.noInit,noSideEffect,inline.} =
   ## Creates a new Tensor filled with 1
   ## Input:
   ##      - Shape of the Tensor
@@ -162,7 +162,7 @@ proc ones*[T: SomeNumber](shape: MetadataArray): Tensor[T] {.noSideEffect,inline
   tensorCpu(shape, result)
   result.data = newSeqWith(result.size, 1.T)
 
-proc ones_like*[T: SomeNumber](t: AnyTensor[T]): auto {.noSideEffect, inline.} =
+proc ones_like*[T: SomeNumber](t: AnyTensor[T]): auto {.noInit,noSideEffect, inline.} =
   ## Creates a new Tensor filled with 0 with the same shape as the input
   ## and filled with 1
   ## Input:
@@ -175,7 +175,7 @@ template randomTensorCpu[T](t: Tensor[T], shape: varargs[int], max_or_range: typ
   tensorCpu(shape, t)
   t.data = newSeqWith(t.size, T(random(max_or_range))) # Due to automatic converter (float32 -> float64), we must force T #68
 
-proc randomTensor*[T:SomeReal](shape: varargs[int], max: T): Tensor[T] =
+proc randomTensor*[T:SomeReal](shape: varargs[int], max: T): Tensor[T] {.noInit.} =
   ## Creates a new float Tensor filled with values between 0 and max.
   ##
   ## Random seed can be set by importing ``random`` and ``randomize(seed)``
@@ -187,7 +187,7 @@ proc randomTensor*[T:SomeReal](shape: varargs[int], max: T): Tensor[T] =
   ##      - A tensor of the input shape filled with random value between 0 and max input value
   randomTensorCpu(result, shape, max)
 
-proc randomTensor*(shape: varargs[int], max: int): Tensor[int] =
+proc randomTensor*(shape: varargs[int], max: int): Tensor[int] {.noInit.} =
   ## Creates a new int Tensor filled with values between 0 and max-1.
   ##
   ## Random seed can be set by importing ``random`` and ``randomize(seed)``
@@ -199,7 +199,7 @@ proc randomTensor*(shape: varargs[int], max: int): Tensor[int] =
   ##      - A tensor of the input shape filled with random value between 0 and max input value (excluded)
   randomTensorCpu(result, shape, max)
 
-proc randomTensor*[T](shape: varargs[int], slice: Slice[T]): Tensor[T] =
+proc randomTensor*[T](shape: varargs[int], slice: Slice[T]): Tensor[T] {.noInit.} =
   ## Creates a new int Tensor filled with values in the Slice range.
   ##
   ## Random seed can be set by importing ``random`` and ``randomize(seed)``

--- a/src/tensor/init_cuda.nim
+++ b/src/tensor/init_cuda.nim
@@ -86,7 +86,7 @@ proc newCudaTensor[T: SomeReal](shape: varargs[int], layout: OrderType = colMajo
   # for inplace operation that requires column major layout.
 
   result.shape = @shape
-  result.strides = shape_to_strides(result.shape, layout)
+  shape_to_strides(result.shape, layout, result.strides)
   result.offset = 0
   result.data = newCudaSeq[T](result.size)
 

--- a/src/tensor/math_functions.nim
+++ b/src/tensor/math_functions.nim
@@ -17,7 +17,7 @@ import  ./data_structure,
 
 # Non-operator math functions
 
-proc reciprocal*[T: SomeReal](t: Tensor[T]): Tensor[T] =
+proc reciprocal*[T: SomeReal](t: Tensor[T]): Tensor[T] {.noInit.} =
   # Return a tensor with the reciprocal 1/x of all elements
   t.map_inline(1.T/x)
 
@@ -25,7 +25,7 @@ proc mreciprocal*[T: SomeReal](t: var Tensor[T]) =
   # Apply the reciprocal 1/x in-place to all elements of the Tensor
   t.apply_inline(1.T/x)
 
-proc negate*[T: SomeSignedInt|SomeReal](t: Tensor[T]): Tensor[T] =
+proc negate*[T: SomeSignedInt|SomeReal](t: Tensor[T]): Tensor[T] {.noInit.} =
   # Return a tensor with all elements negated (10 -> -10)
   t.map_inline(-x)
 
@@ -33,15 +33,15 @@ proc mnegate*[T: SomeSignedInt|SomeReal](t: var Tensor[T]) =
   # Negate in-place all elements of the tensor (10 -> -10)
   t.apply_inline(-x)
 
-proc `-`*[T: SomeNumber](t: Tensor[T]): Tensor[T] =
+proc `-`*[T: SomeNumber](t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Negate all values of a Tensor
   t.map_inline(-x)
 
 # Built-in nim function that doesn't work with makeUniversal
-proc abs*[T](t: Tensor[T]): Tensor[T] =
+proc abs*[T](t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Return a Tensor with absolute values of all elements
   t.map_inline(abs(x))
 
-proc mabs*[T](t: Tensor[T]): Tensor[T] =
+proc mabs*[T](t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Return a Tensor with absolute values of all elements
   t.apply_inline(abs(x))

--- a/src/tensor/operators_blas_l1.nim
+++ b/src/tensor/operators_blas_l1.nim
@@ -39,11 +39,11 @@ proc dot*[T: SomeInteger](a, b: Tensor[T]): T {.noSideEffect.} =
 # # Tensor-Tensor linear algebra
 # # shape checks are done in map2 proc
 
-proc `+`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] =
+proc `+`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Tensor addition
   map2_inline(a, b, x + y)
 
-proc `-`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] =
+proc `-`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Tensor substraction
   map2_inline(a, b, x - y)
 
@@ -61,19 +61,19 @@ proc `-=`*[T: SomeNumber](a: var Tensor[T], b: Tensor[T]) =
 # #########################################################
 # # Tensor-scalar linear algebra
 
-proc `*`*[T: SomeNumber](a: T, t: Tensor[T]): Tensor[T] =
+proc `*`*[T: SomeNumber](a: T, t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Element-wise multiplication by a scalar
   t.map_inline(x * a)
 
-proc `*`*[T: SomeNumber](t: Tensor[T], a: T): Tensor[T] =
+proc `*`*[T: SomeNumber](t: Tensor[T], a: T): Tensor[T] {.noInit.} =
   ## Element-wise multiplication by a scalar
   a * t
 
-proc `/`*[T: SomeReal](t: Tensor[T], a: T): Tensor[T] =
+proc `/`*[T: SomeReal](t: Tensor[T], a: T): Tensor[T] {.noInit.} =
   ## Element-wise division by a float scalar
   t.map_inline(x / a)
 
-proc `div`*[T: SomeInteger](t: Tensor[T], a: T): Tensor[T] =
+proc `div`*[T: SomeInteger](t: Tensor[T], a: T): Tensor[T] {.noInit.} =
   ## Element-wise division by an integer
   t.map_inline(x div a)
 

--- a/src/tensor/operators_blas_l2l3.nim
+++ b/src/tensor/operators_blas_l2l3.nim
@@ -80,7 +80,7 @@ proc gemm*[T: SomeInteger](
 
   fallbackMM_C_eq_aAB_p_bC(alpha, A, B, beta, C)
 
-proc `*`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] =
+proc `*`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Matrix multiplication (Matrix-Matrix and Matrix-Vector)
   ##
   ## Float operations use optimized BLAS like OpenBLAS, Intel MKL or BLIS.

--- a/src/tensor/operators_broadcasted.nim
+++ b/src/tensor/operators_broadcasted.nim
@@ -21,17 +21,17 @@ import  ./data_structure,
 # # Broadcasting Tensor-Tensor
 # # And element-wise multiplication (Hadamard) and division
 
-proc `.+`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] {.inline.} =
+proc `.+`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] {.noInit,inline.} =
   ## Broadcasted addition for tensors of incompatible but broadcastable shape.
   let (tmp_a, tmp_b) = unsafeBroadcast2(a, b)
   return tmp_a + tmp_b
 
-proc `.-`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] {.inline.} =
+proc `.-`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] {.noInit,inline.} =
   ## Broadcasted addition for tensors of incompatible but broadcastable shape.
   let (tmp_a, tmp_b) = unsafeBroadcast2(a, b)
   return tmp_a - tmp_b
 
-proc `.*`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] =
+proc `.*`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Element-wise multiplication (Hadamard product).
   ##
   ## And broadcasted element-wise multiplication.
@@ -39,14 +39,14 @@ proc `.*`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] =
   let (tmp_a, tmp_b) = unsafeBroadcast2(a, b)
   return map2_inline(tmp_a, tmp_b, x * y)
 
-proc `./`*[T: SomeInteger](a, b: Tensor[T]): Tensor[T] =
+proc `./`*[T: SomeInteger](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Tensor element-wise division for integer numbers.
   ##
   ## And broadcasted element-wise division.
   let (tmp_a, tmp_b) = unsafeBroadcast2(a, b)
   return map2_inline(tmp_a, tmp_b, x div y)
 
-proc `./`*[T: SomeReal](a, b: Tensor[T]): Tensor[T] =
+proc `./`*[T: SomeReal](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Tensor element-wise division for real numbers.
   ##
   ## And broadcasted element-wise division.
@@ -105,31 +105,31 @@ proc `./=`*[T: SomeReal](a: var Tensor[T], b: Tensor[T]) =
 # ##############################################
 # # Broadcasting Tensor-Scalar and Scalar-Tensor
 
-proc `.+`*[T: SomeNumber](val: T, t: Tensor[T]): Tensor[T] =
+proc `.+`*[T: SomeNumber](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Broadcasted addition for tensor + scalar.
   return t.map_inline(x + val)
 
-proc `.+`*[T: SomeNumber](t: Tensor[T], val: T): Tensor[T] =
+proc `.+`*[T: SomeNumber](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
   ## Broadcasted addition for scalar + tensor.
   return t.map_inline(x + val)
 
-proc `.-`*[T: SomeNumber](val: T, t: Tensor[T]): Tensor[T] =
+proc `.-`*[T: SomeNumber](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Broadcasted substraction for tensor - scalar.
   return t.map_inline(val - x)
 
-proc `.-`*[T: SomeNumber](t: Tensor[T], val: T): Tensor[T] =
+proc `.-`*[T: SomeNumber](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
   ## Broadcasted substraction for scalar - tensor.
   return t.map_inline(x - val)
 
-proc `./`*[T: SomeInteger](val: T, t: Tensor[T]): Tensor[T] =
+proc `./`*[T: SomeInteger](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Broadcasted division of an integer by a tensor of integers.
   return t.map_inline(val div x)
 
-proc `./`*[T: SomeReal](val: T, t: Tensor[T]): Tensor[T] =
+proc `./`*[T: SomeReal](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Broadcasted division of a float by a tensor of floats.
   return t.map_inline(val / x)
 
-proc `.^`*[T: SomeReal](t: Tensor[T], exponent: T): Tensor[T] =
+proc `.^`*[T: SomeReal](t: Tensor[T], exponent: T): Tensor[T] {.noInit.} =
   ## Compute element-wise exponentiation
   return t.map_inline pow(x, exponent)
 

--- a/src/tensor/private/p_accessors_macros_read.nim
+++ b/src/tensor/private/p_accessors_macros_read.nim
@@ -42,7 +42,7 @@ template slicerT[T](result: AnyTensor[T], slices: varargs[SteppedSlice]): untype
     result.strides[i] *= slice.step
     result.shape[i] = abs((b-a) div slice.step) + 1
 
-proc slicer[T](t: AnyTensor[T], slices: varargs[SteppedSlice]): AnyTensor[T] {.noSideEffect.}=
+proc slicer[T](t: AnyTensor[T], slices: varargs[SteppedSlice]): AnyTensor[T] {.noInit,noSideEffect.}=
   ## Take a Tensor and SteppedSlices
   ## Returns:
   ##    A copy of the original Tensor
@@ -53,7 +53,7 @@ proc slicer[T](t: AnyTensor[T], slices: varargs[SteppedSlice]): AnyTensor[T] {.n
 
 proc slicer[T](t: AnyTensor[T],
                 slices: varargs[SteppedSlice],
-                ellipsis: Ellipsis): AnyTensor[T] {.noSideEffect.}=
+                ellipsis: Ellipsis): AnyTensor[T] {.noInit,noSideEffect.}=
   ## Take a Tensor, SteppedSlices and Ellipsis
   ## Returns:
   ##    A copy of the original Tensor
@@ -66,7 +66,7 @@ proc slicer[T](t: AnyTensor[T],
 proc slicer[T](t: AnyTensor[T],
                 ellipsis: Ellipsis,
                 slices: varargs[SteppedSlice]
-                ): AnyTensor[T] {.noSideEffect.}=
+                ): AnyTensor[T] {.noInit,noSideEffect.}=
   ## Take a Tensor, Ellipsis and SteppedSlices
   ## Returns:
   ##    A copy of the original Tensor
@@ -80,7 +80,7 @@ proc slicer[T](t: AnyTensor[T],
                 slices1: varargs[SteppedSlice],
                 ellipsis: Ellipsis,
                 slices2: varargs[SteppedSlice]
-                ): AnyTensor[T] {.noSideEffect.}=
+                ): AnyTensor[T] {.noInit,noSideEffect.}=
   ## Take a Tensor, Ellipsis and SteppedSlices
   ## Returns:
   ##    A copy of the original Tensor
@@ -92,7 +92,7 @@ proc slicer[T](t: AnyTensor[T],
                             @slices2)
   slicerT(result, full_slices)
 
-proc unsafeSlicer*[T](t: Tensor[T], slices: varargs[SteppedSlice]): Tensor[T] {.noSideEffect.}=
+proc unsafeSlicer*[T](t: Tensor[T], slices: varargs[SteppedSlice]): Tensor[T] {.noInit,noSideEffect.}=
   ## Take a Tensor and SteppedSlices
   ## Returns:
   ##    A view of the original Tensor
@@ -107,7 +107,7 @@ proc unsafeSlicer*[T](t: Tensor[T], slices: varargs[SteppedSlice]): Tensor[T] {.
 
 proc unsafeSlicer*[T](t: AnyTensor[T],
                       slices: varargs[SteppedSlice],
-                      ellipsis: Ellipsis): AnyTensor[T] {.noSideEffect.}=
+                      ellipsis: Ellipsis): AnyTensor[T] {.noInit,noSideEffect.}=
   ## Take a Tensor, SteppedSlices and Ellipsis
   ## Returns:
   ##    A view of the original Tensor
@@ -123,7 +123,7 @@ proc unsafeSlicer*[T](t: AnyTensor[T],
 proc unsafeSlicer*[T](t: AnyTensor[T],
                       ellipsis: Ellipsis,
                       slices: varargs[SteppedSlice]
-                      ): AnyTensor[T] {.noSideEffect.}=
+                      ): AnyTensor[T] {.noInit,noSideEffect.}=
   ## Take a Tensor, Ellipsis and SteppedSlices
   ## Returns:
   ##    A view of the original Tensor
@@ -140,7 +140,7 @@ proc unsafeSlicer*[T](t: AnyTensor[T],
                       slices1: varargs[SteppedSlice],
                       ellipsis: Ellipsis,
                       slices2: varargs[SteppedSlice]
-                      ): AnyTensor[T] {.noSideEffect.}=
+                      ): AnyTensor[T] {.noInit,noSideEffect.}=
   ## Take a Tensor, SteppedSlices, Ellipsis and SteppedSlices
   ## Returns:
   ##    A view of the original Tensor

--- a/src/tensor/private/p_init_cpu.nim
+++ b/src/tensor/private/p_init_cpu.nim
@@ -20,13 +20,13 @@ import  ../../private/nested_containers,
         sequtils
 
 template tensorCpu*[T](out_shape: varargs[int], t: Tensor[T], layout: OrderType = rowMajor): untyped =
-  t.shape = toMetadataArray(out_shape)
-  t.strides = shape_to_strides(t.shape, layout)
+  t.shape.copyFrom(out_shape)
+  shape_to_strides(t.shape, layout, t.strides)
   t.offset = 0
 
 template tensorCpu*[T](out_shape: MetadataArray, t: Tensor[T], layout: OrderType = rowMajor): untyped =
-  t.shape = out_shape
-  t.strides = shape_to_strides(t.shape, layout)
+  t.shape.copyFrom(out_shape)
+  shape_to_strides(t.shape, layout, t.strides)
   t.offset = 0
 
 template toTensorCpu*(s: typed): untyped =

--- a/src/tensor/shapeshifting_cuda.nim
+++ b/src/tensor/shapeshifting_cuda.nim
@@ -21,8 +21,8 @@ proc unsafeTranspose*(t: CudaTensor): CudaTensor {.noSideEffect.}=
   ##   This is a no-copy operation, data is shared with the input.
   ##   This proc does not guarantee that a ``let`` value is immutable.
 
-  result.shape = t.shape.reversed
-  result.strides = t.strides.reversed
+  t.shape.reversed(result.shape)
+  t.strides.reversed(result.strides)
   result.offset = t.offset
   result.data = t.data
 

--- a/src/tensor/term_rewriting.nim
+++ b/src/tensor/term_rewriting.nim
@@ -87,14 +87,14 @@ template toTensorReshapeT(oa: typed, shape: varargs[int]): untyped =
   shallowCopy(t.data, data)
   return t
 
-proc toTensorReshape(oa: string, shape: varargs[int]): auto {.noSideEffect.}=
+proc toTensorReshape(oa: string, shape: varargs[int]): auto {.noInit,noSideEffect.}=
   ## Fuse toTensor and reshape in one operation.
   ##
   ## Deal specifically with strings/seq[char]
 
   toTensorReshapeT(oa, shape)
 
-proc toTensorReshape(oa: openarray, shape: varargs[int], dummy_bugfix: static[int] = 0): auto {.noSideEffect.}=
+proc toTensorReshape(oa: openarray, shape: varargs[int], dummy_bugfix: static[int] = 0): auto {.noInit,noSideEffect.}=
   ## Fuse toTensor and reshape in one operation
   ##
   # Dummy_bugfix param is necessary due to: https://github.com/nim-lang/Nim/issues/6343

--- a/src/tensor/ufunc.nim
+++ b/src/tensor/ufunc.nim
@@ -16,7 +16,7 @@ import  ./data_structure,
         ./higher_order,
         future, math
 
-proc astype*[T, U](t: Tensor[T], typ: typedesc[U]): Tensor[U] =
+proc astype*[T, U](t: Tensor[T], typ: typedesc[U]): Tensor[U] {.noInit.} =
   ## Apply type conversion on the whole tensor
   result = t.map(x => x.U)
 
@@ -33,7 +33,7 @@ template makeUniversal*(func_name: untyped) =
   # ``makeUniversal`` does not work when the internal type of the Tensor changes,
   # for example, a function "isEven: int -> bool".
   # Use ``map`` in this case instead instead
-  proc func_name*(t: Tensor): Tensor =
+  proc func_name*(t: Tensor): Tensor {.noInit.} =
     ## Auto-generated universal version of the function.
     ##
     ## The function can be used directly on tensors and will work element-wise.
@@ -48,7 +48,7 @@ template makeUniversalLocal*(func_name: untyped) =
   # ``makeUniversalLocal`` does not work when the internal type of the Tensor changes,
   # for example, a function "isEven: int -> bool".
   # Use ``map`` in this case instead instead
-  proc func_name(t: Tensor): Tensor =
+  proc func_name(t: Tensor): Tensor {.noInit.} =
     t.map_inline(func_name(x))
 
 # Unary functions from Nim math library


### PR DESCRIPTION
- Use noInit in all functions returning a Tensor to avoid genericReset
- Rework unsafeReshape algorithm to be faster
- Use MetadataArray as var parameters to avoid an extra copy
