### PR TITLE
Confining c++ to a single kernel file

### DIFF
--- a/arraymancer.nimble
+++ b/arraymancer.nimble
@@ -121,7 +121,7 @@ task test_cuda, "Run all tests - Cuda backend with CUBLAS":
   cudaSwitches  # Unfortunately the "switch" line doesn't also trigger
                 # the "when defined(cuda)" part of this nimble file
                 # hence the need to call cudaSwitches explicitly
-  test "tests_cuda", "cpp"
+  test "tests_cuda", "c"
 
 task test_deprecated, "Run all tests on deprecated static[Backend] procs":
   test "tests_cpu_deprecated"

--- a/arraymancer.nimble
+++ b/arraymancer.nimble
@@ -32,6 +32,9 @@ srcDir = "src"
 ## TODO: auto detection or at least check in common directories
 ## Note: It is import to gate compiler flags like -march=native  behind Xcompiler "-Xcompiler -march=native"
 
+## -fpermissive flag is needed to allow implicit cast of void pointers
+## which are used in Nim stdlib when compiling to C++
+
 template cudaSwitches() =
   switch("cincludes", "/opt/cuda/include")
   switch("cc", "gcc") # We trick Nim about nvcc being gcc, pending https://github.com/nim-lang/Nim/issues/6372
@@ -43,8 +46,8 @@ template cudaSwitches() =
   # we only support compute capabilities 3.5+
   # See here: http://docs.nvidia.com/cuda/pascal-compatibility-guide/index.html
   # And wikipedia for GPU capabilities: https://en.wikipedia.org/wiki/CUDA
-  switch("gcc.options.always", "-arch=sm_61 --x cu") # Interpret .c files as .cu
-  switch("gcc.cpp.options.always", "-arch=sm_61 --x cu -Xcompiler -fpermissive") # Interpret .c files as .cu, gate fpermissive behind Xcompiler
+  switch("gcc.options.always", "-arch=sm_61 -Xcompiler -fpermissive") # Interpret .c files as .cu
+  switch("gcc.cpp.options.always", "-arch=sm_61 -Xcompiler -fpermissive") # Interpret .cpp files as .cu, gate fpermissive behind Xcompiler
 
 when defined(cuda):
   cudaSwitches
@@ -76,8 +79,8 @@ template cuda_mkl_openmp() =
   switch("gcc.linkerexe", "/opt/cuda/bin/nvcc")
   switch("gcc.cpp.exe", "/opt/cuda/bin/nvcc")
   switch("gcc.cpp.linkerexe", "/opt/cuda/bin/nvcc")
-  switch("gcc.options.always", "-arch=sm_61 --x cu -Xcompiler -fopenmp -Xcompiler -march=native")
-  switch("gcc.cpp.options.always", "-arch=sm_61 --x cu -Xcompiler -fopenmp -Xcompiler -march=native")
+  switch("gcc.options.always", "-arch=sm_61 -Xcompiler -fopenmp -Xcompiler -march=native -Xcompiler -fpermissive")
+  switch("gcc.cpp.options.always", "-arch=sm_61 -Xcompiler -fopenmp -Xcompiler -march=native -Xcompiler -fpermissive")
 
 ########################################################
 # Optimization
@@ -108,11 +111,12 @@ task all_tests, "Run all tests - Intel MKL + OpenMP + Cuda + march=native + rele
   cuda_mkl_openmp
   switch("define","cuda")
   cuda_mkl_openmp
-  test "full_test_suite", "cpp"
+  test "full_test_suite", "c"
 
 task test, "Run all tests - Default BLAS":
   test "tests_cpu"
 
+# C++ backend is not supported. It is isolated internally to just be used with Cuda
 task test_cpp, "Run all tests - Cpp codegen":
   test "tests_cpu", "cpp"
 

--- a/src/tensor/operators_blas_l1_cuda.nim
+++ b/src/tensor/operators_blas_l1_cuda.nim
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import  ./backend/cublas,
-        ./private/p_kernels_cuda,
         ./private/p_kernels_interface_cuda,
         ./private/p_init_cuda,
         ./private/p_checks,

--- a/src/tensor/operators_blas_l1_cuda.nim
+++ b/src/tensor/operators_blas_l1_cuda.nim
@@ -14,13 +14,10 @@
 
 import  ./backend/cublas,
         ./private/p_kernels_interface_cuda,
+        ./private/p_kernels_cuda,
         ./private/p_init_cuda,
         ./private/p_checks,
         ./data_structure
-
-include ./private/incl_accessors_cuda,
-        ./private/incl_higher_order_cuda,
-        ./private/incl_kernels_cuda
 
 # ####################################################################
 # BLAS Level 1 (Vector dot product, Addition, Scalar to Vector/Matrix)
@@ -34,9 +31,6 @@ proc dot*[T: SomeReal](a, b: CudaTensor[T]): T {.inline.}=
               b.get_data_ptr, b.strides[0],
               addr result)
 
-proc cuda_inPlaceAdd = discard # This is a hack so that the symbol is open
-cuda_assign_glue(cuda_inPlaceAdd, "InPlaceAddOp")
-
 proc `+=`*[T: SomeReal](a: var CudaTensor[T], b: CudaTensor[T]) =
   ## CudaTensor in-place addition
 
@@ -47,9 +41,6 @@ proc `+=`*[T: SomeReal](a: var CudaTensor[T], b: CudaTensor[T]) =
 
   # TODO: if a and b share the same location, TEST
 
-proc cuda_Add = discard # This is a hack so that the symbol is open
-cuda_binary_glue(cuda_Add, "AddOp")
-
 proc `+`*[T: SomeReal](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.}=
   ## CudaTensor addition
 
@@ -58,9 +49,6 @@ proc `+`*[T: SomeReal](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.}=
 
   result = newCudaTensor[T](a.shape)
   cuda_binary_call(cuda_Add, result, a, b)
-
-proc cuda_inPlaceSub = discard # This is a hack so that the symbol is open
-cuda_assign_glue(cuda_inPlaceSub, "InPlaceSubOp")
 
 proc `-=`*[T: SomeReal](a: var CudaTensor[T], b: CudaTensor[T]) =
   ## CudaTensor in-place substraction
@@ -71,10 +59,6 @@ proc `-=`*[T: SomeReal](a: var CudaTensor[T], b: CudaTensor[T]) =
   cuda_assign_call(cuda_inPlaceSub, a, b)
 
   # TODO: if a and b share the same location, TEST
-
-
-proc cuda_Sub = discard # This is a hack so that the symbol is open
-cuda_binary_glue(cuda_Sub, "SubOp")
 
 proc `-`*[T: SomeReal](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   ## CudaTensor substraction

--- a/src/tensor/operators_blas_l1_cuda.nim
+++ b/src/tensor/operators_blas_l1_cuda.nim
@@ -37,7 +37,7 @@ proc `+=`*[T: SomeReal](a: var CudaTensor[T], b: CudaTensor[T]) =
   when compileOption("boundChecks"):
     check_elementwise(a,b)
 
-  cuda_assign_call(cuda_inPlaceAdd, a, b)
+  cuda_assign_call(cuda_mAdd, a, b)
 
   # TODO: if a and b share the same location, TEST
 
@@ -56,7 +56,7 @@ proc `-=`*[T: SomeReal](a: var CudaTensor[T], b: CudaTensor[T]) =
   when compileOption("boundChecks"):
     check_elementwise(a,b)
 
-  cuda_assign_call(cuda_inPlaceSub, a, b)
+  cuda_assign_call(cuda_mSub, a, b)
 
   # TODO: if a and b share the same location, TEST
 
@@ -70,7 +70,7 @@ proc `-`*[T: SomeReal](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   cuda_binary_call(cuda_Sub, result, a, b)
 
 proc `*=`*[T:SomeReal](t: var CudaTensor[T]; a: T) {.inline.}=
-  ## CudaTensor inplace multiplication by a scalar
+  ## CudaTensor m multiplication by a scalar
 
   # We multiply all elements of the CudaTensor regardless of shape/strides
   # So this operation can be applied to tensors of all ranks.

--- a/src/tensor/operators_blas_l1_cuda.nim
+++ b/src/tensor/operators_blas_l1_cuda.nim
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import  ./backend/cublas,
-        ./private/p_kernels_interface_cuda,
         ./private/p_kernels_cuda,
+        ./private/p_kernels_interface_cuda,
         ./private/p_init_cuda,
         ./private/p_checks,
         ./data_structure

--- a/src/tensor/private/incl_kernels_cuda.nim
+++ b/src/tensor/private/incl_kernels_cuda.nim
@@ -110,16 +110,16 @@ template cuda_unary_op(op_name, op_symbol: string)=
   """].}
 
 cuda_assign_op("CopyOp", "=")
-cuda_assign_op("InPlaceAddOp", "+=")
-cuda_assign_op("InPlaceSubOp", "-=")
-cuda_assign_op("InPlaceMulOp", "*=")
-cuda_assign_op("InPlaceDivOp", "/=")
+cuda_assign_op("mAddOp", "+=")
+cuda_assign_op("mSubOp", "-=")
+cuda_assign_op("mMulOp", "*=")
+cuda_assign_op("mDivOp", "/=")
 
 cuda_assignscal_op("CopyScalOp", "=")
-cuda_assignscal_op("InPscalAddOp", "+=")
-cuda_assignscal_op("InPscalSubOp", "-=")
-cuda_assignscal_op("InPscalMulOp", "*=")
-cuda_assignscal_op("InPscalDivOp", "/=")
+cuda_assignscal_op("mscalAddOp", "+=")
+cuda_assignscal_op("mscalSubOp", "-=")
+cuda_assignscal_op("mscalMulOp", "*=")
+cuda_assignscal_op("mscalDivOp", "/=")
 
 cuda_binary_op("AddOp", "+")
 cuda_binary_op("SubOp", "-")

--- a/src/tensor/private/p_kernels_cuda.nim
+++ b/src/tensor/private/p_kernels_cuda.nim
@@ -1,0 +1,34 @@
+# Copyright 2017 Mamy André-Ratsimbazafy
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ./p_kernels_interface_cuda
+
+include incl_kernels_cuda,
+        incl_higher_order_cuda,
+        incl_accessors_cuda
+
+proc cuda_inPlaceAdd = discard # This is a hack so that the symbol is open
+cuda_assign_glue(cuda_inPlaceAdd, "InPlaceAddOp")
+
+proc cuda_inPlaceSub = discard # This is a hack so that the symbol is open
+cuda_assign_glue(cuda_inPlaceSub, "InPlaceSubOp")
+
+proc cuda_unsafeContiguous = discard # This is a hack so that the symbol is open
+cuda_assign_glue(cuda_unsafeContiguous, "CopyOp")
+
+proc cuda_Add = discard # This is a hack so that the symbol is open
+cuda_binary_glue(cuda_Add, "AddOp")
+
+proc cuda_Sub = discard # This is a hack so that the symbol is open
+cuda_binary_glue(cuda_Sub, "SubOp")

--- a/src/tensor/private/p_kernels_cuda.nim
+++ b/src/tensor/private/p_kernels_cuda.nim
@@ -34,17 +34,9 @@ include incl_accessors_cuda,
 # Important: this file will be compiled to C++, only primitive types like pointers and float should be used,
 # other here be dragons during linking with C code.
 
-proc cuda_mAdd_cpp = discard # This is a hack so that the symbol is open
-cuda_genkernel_assign(cuda_mAdd_cpp, "mAddOp")
 
-proc cuda_mSub_cpp = discard # This is a hack so that the symbol is open
-cuda_genkernel_assign(cuda_mSub_cpp, "mSubOp")
-
-proc cuda_unsafeContiguous_cpp = discard # This is a hack so that the symbol is open
-cuda_genkernel_assign(cuda_unsafeContiguous_cpp, "CopyOp")
-
-proc cuda_Add_cpp = discard # This is a hack so that the symbol is open
-cuda_genkernel_binary(cuda_Add_cpp, "AddOp")
-
-proc cuda_Sub_cpp = discard # This is a hack so that the symbol is open
-cuda_genkernel_binary(cuda_Sub_cpp, "SubOp")
+cuda_genkernel_assign("cuda_mAdd", "mAddOp", cuda_mAdd_f32, cuda_mAdd_f64)
+cuda_genkernel_assign("cuda_mSub", "mSubOp", cuda_mSub_f32, cuda_mSub_f64)
+cuda_genkernel_assign("cuda_unsafeContiguous", "CopyOp", cuda_unsfeContiguous_f32, cuda_unsafeContiguous_f64)
+cuda_genkernel_binary("cuda_Add", "AddOp", cuda_Add_f32, cuda_Add_f64)
+cuda_genkernel_binary("cuda_Sub", "SubOp", cuda_Sub_f32, cuda_Sub_f64)

--- a/src/tensor/private/p_kernels_cuda.nim
+++ b/src/tensor/private/p_kernels_cuda.nim
@@ -14,21 +14,94 @@
 
 import ./p_kernels_interface_cuda
 
-include incl_kernels_cuda,
-        incl_higher_order_cuda,
-        incl_accessors_cuda
+include incl_accessors_cuda,
+        incl_kernels_cuda,
+        incl_higher_order_cuda
 
-proc cuda_inPlaceAdd = discard # This is a hack so that the symbol is open
-cuda_assign_glue(cuda_inPlaceAdd, "InPlaceAddOp")
+# Design: due to limitations and difficulties in C++
+# (no mutable iterators, stack hidden from GC, exception issue, casting workaround for builtin_assume_aligned)
+# I choose to sacrifice readability here to avoid a plethora of "when not defined(cpp) in the codebase.
+# This file will serve as a bridge between Cuda C++ and Nim C.
 
-proc cuda_inPlaceSub = discard # This is a hack so that the symbol is open
-cuda_assign_glue(cuda_inPlaceSub, "InPlaceSubOp")
+# Explanation:
+#
+# - To avoid creating a proc AST from scratch: we create a dummy proc.
+# - pass it to an overloading template (cuda_assign_glue for in-place/assignments)
+# - overloading template creates the cuda code, the import and a Nim wrapper
+# - Unfortunately the Nim wrapper cannot be called as-is in other file as it uses C++ semantics
+# - So we add an indirection that will be exported.
 
-proc cuda_unsafeContiguous = discard # This is a hack so that the symbol is open
-cuda_assign_glue(cuda_unsafeContiguous, "CopyOp")
+proc cuda_inPlaceAdd_cpp = discard # This is a hack so that the symbol is open
+cuda_assign_glue(cuda_inPlaceAdd_cpp, "InPlaceAddOp")
 
-proc cuda_Add = discard # This is a hack so that the symbol is open
-cuda_binary_glue(cuda_Add, "AddOp")
+proc cuda_inPlaceAdd*[T: SomeReal](
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
+  ) =
+  cuda_inPlaceAdd_cpp[T](blocksPerGrid, threadsPerBlock, rank, len,
+  dst_shape, dst_strides, dst_offset, dst_data,
+  src_shape, src_strides, src_offset, src_data)
 
-proc cuda_Sub = discard # This is a hack so that the symbol is open
-cuda_binary_glue(cuda_Sub, "SubOp")
+proc cuda_inPlaceSub_cpp = discard # This is a hack so that the symbol is open
+cuda_assign_glue(cuda_inPlaceSub_cpp, "InPlaceSubOp")
+
+proc cuda_inPlaceSub*[T: SomeReal](
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
+  ) =
+  cuda_inPlaceSub_cpp[T](blocksPerGrid, threadsPerBlock, rank, len,
+  dst_shape, dst_strides, dst_offset, dst_data,
+  src_shape, src_strides, src_offset, src_data)
+
+proc cuda_unsafeContiguous_cpp = discard # This is a hack so that the symbol is open
+cuda_assign_glue(cuda_unsafeContiguous_cpp, "CopyOp")
+
+proc cuda_unsafeContiguous*[T: SomeReal](
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
+  ) =
+  cuda_unsafeContiguous_cpp[T](blocksPerGrid, threadsPerBlock, rank, len,
+  dst_shape, dst_strides, dst_offset, dst_data,
+  src_shape, src_strides, src_offset, src_data)
+
+proc cuda_Add_cpp = discard # This is a hack so that the symbol is open
+cuda_binary_glue(cuda_Add_cpp, "AddOp")
+
+proc cuda_Add*[T: SomeReal](
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
+    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr T,
+    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr T
+  ) =
+  cuda_Add_cpp[T](
+    blocksPerGrid, threadsPerBlock,
+    rank, len,
+    dst_shape, dst_strides, dst_offset, dst_data,
+    a_shape, a_strides, a_offset, a_data,
+    b_shape, b_strides, b_offset, b_data
+  )
+
+proc cuda_Sub_cpp = discard # This is a hack so that the symbol is open
+cuda_binary_glue(cuda_Sub_cpp, "SubOp")
+
+proc cuda_Sub*[T: SomeReal](
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
+    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr T,
+    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr T
+  ) =
+  cuda_Sub_cpp[T](
+    blocksPerGrid, threadsPerBlock,
+    rank, len,
+    dst_shape, dst_strides, dst_offset, dst_data,
+    a_shape, a_strides, a_offset, a_data,
+    b_shape, b_strides, b_offset, b_data
+  )

--- a/src/tensor/private/p_kernels_cuda.nim
+++ b/src/tensor/private/p_kernels_cuda.nim
@@ -31,29 +31,32 @@ include incl_accessors_cuda,
 # - Unfortunately the Nim wrapper cannot be called as-is in other file as it uses C++ semantics
 # - So we add an indirection that will be exported.
 
-proc cuda_inPlaceAdd_cpp = discard # This is a hack so that the symbol is open
-cuda_assign_glue(cuda_inPlaceAdd_cpp, "InPlaceAddOp")
+# Important: this file will be compiled to C++, only primitive types like pointers and float should be used,
+# other here be dragons during linking with C code.
 
-proc cuda_inPlaceAdd*[T: SomeReal](
+proc cuda_mAdd_cpp = discard # This is a hack so that the symbol is open
+cuda_assign_glue(cuda_mAdd_cpp, "mAddOp")
+
+proc cuda_mAdd*[T: SomeReal](
     blocksPerGrid, threadsPerBlock: cint,
     rank, len: cint,
     dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
     src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
   ) =
-  cuda_inPlaceAdd_cpp[T](blocksPerGrid, threadsPerBlock, rank, len,
+  cuda_mAdd_cpp[T](blocksPerGrid, threadsPerBlock, rank, len,
   dst_shape, dst_strides, dst_offset, dst_data,
   src_shape, src_strides, src_offset, src_data)
 
-proc cuda_inPlaceSub_cpp = discard # This is a hack so that the symbol is open
-cuda_assign_glue(cuda_inPlaceSub_cpp, "InPlaceSubOp")
+proc cuda_mSub_cpp = discard # This is a hack so that the symbol is open
+cuda_assign_glue(cuda_mSub_cpp, "mSubOp")
 
-proc cuda_inPlaceSub*[T: SomeReal](
+proc cuda_mSub*[T: SomeReal](
     blocksPerGrid, threadsPerBlock: cint,
     rank, len: cint,
     dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
     src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
   ) =
-  cuda_inPlaceSub_cpp[T](blocksPerGrid, threadsPerBlock, rank, len,
+  cuda_mSub_cpp[T](blocksPerGrid, threadsPerBlock, rank, len,
   dst_shape, dst_strides, dst_offset, dst_data,
   src_shape, src_strides, src_offset, src_data)
 

--- a/src/tensor/private/p_kernels_cuda.nim
+++ b/src/tensor/private/p_kernels_cuda.nim
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ./p_kernels_interface_cuda
+import ./p_kernels_generate
 
 include incl_accessors_cuda,
         incl_kernels_cuda,
@@ -26,85 +26,25 @@ include incl_accessors_cuda,
 # Explanation:
 #
 # - To avoid creating a proc AST from scratch: we create a dummy proc.
-# - pass it to an overloading template (cuda_assign_glue for in-place/assignments)
+# - pass it to an overloading template (cuda_genkernel_assign for in-place/assignments)
 # - overloading template creates the cuda code, the import and a Nim wrapper
 # - Unfortunately the Nim wrapper cannot be called as-is in other file as it uses C++ semantics
-# - So we add an indirection that will be exported.
+# - So we compile this file first to C++, rename it to .cu and tell nvcc to use the new .cu file
 
 # Important: this file will be compiled to C++, only primitive types like pointers and float should be used,
 # other here be dragons during linking with C code.
 
 proc cuda_mAdd_cpp = discard # This is a hack so that the symbol is open
-cuda_assign_glue(cuda_mAdd_cpp, "mAddOp")
-
-proc cuda_mAdd*[T: SomeReal](
-    blocksPerGrid, threadsPerBlock: cint,
-    rank, len: cint,
-    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
-    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
-  ) =
-  cuda_mAdd_cpp[T](blocksPerGrid, threadsPerBlock, rank, len,
-  dst_shape, dst_strides, dst_offset, dst_data,
-  src_shape, src_strides, src_offset, src_data)
+cuda_genkernel_assign(cuda_mAdd_cpp, "mAddOp")
 
 proc cuda_mSub_cpp = discard # This is a hack so that the symbol is open
-cuda_assign_glue(cuda_mSub_cpp, "mSubOp")
-
-proc cuda_mSub*[T: SomeReal](
-    blocksPerGrid, threadsPerBlock: cint,
-    rank, len: cint,
-    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
-    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
-  ) =
-  cuda_mSub_cpp[T](blocksPerGrid, threadsPerBlock, rank, len,
-  dst_shape, dst_strides, dst_offset, dst_data,
-  src_shape, src_strides, src_offset, src_data)
+cuda_genkernel_assign(cuda_mSub_cpp, "mSubOp")
 
 proc cuda_unsafeContiguous_cpp = discard # This is a hack so that the symbol is open
-cuda_assign_glue(cuda_unsafeContiguous_cpp, "CopyOp")
-
-proc cuda_unsafeContiguous*[T: SomeReal](
-    blocksPerGrid, threadsPerBlock: cint,
-    rank, len: cint,
-    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
-    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
-  ) =
-  cuda_unsafeContiguous_cpp[T](blocksPerGrid, threadsPerBlock, rank, len,
-  dst_shape, dst_strides, dst_offset, dst_data,
-  src_shape, src_strides, src_offset, src_data)
+cuda_genkernel_assign(cuda_unsafeContiguous_cpp, "CopyOp")
 
 proc cuda_Add_cpp = discard # This is a hack so that the symbol is open
-cuda_binary_glue(cuda_Add_cpp, "AddOp")
-
-proc cuda_Add*[T: SomeReal](
-    blocksPerGrid, threadsPerBlock: cint,
-    rank, len: cint,
-    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
-    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr T,
-    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr T
-  ) =
-  cuda_Add_cpp[T](
-    blocksPerGrid, threadsPerBlock,
-    rank, len,
-    dst_shape, dst_strides, dst_offset, dst_data,
-    a_shape, a_strides, a_offset, a_data,
-    b_shape, b_strides, b_offset, b_data
-  )
+cuda_genkernel_binary(cuda_Add_cpp, "AddOp")
 
 proc cuda_Sub_cpp = discard # This is a hack so that the symbol is open
-cuda_binary_glue(cuda_Sub_cpp, "SubOp")
-
-proc cuda_Sub*[T: SomeReal](
-    blocksPerGrid, threadsPerBlock: cint,
-    rank, len: cint,
-    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
-    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr T,
-    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr T
-  ) =
-  cuda_Sub_cpp[T](
-    blocksPerGrid, threadsPerBlock,
-    rank, len,
-    dst_shape, dst_strides, dst_offset, dst_data,
-    a_shape, a_strides, a_offset, a_data,
-    b_shape, b_strides, b_offset, b_data
-  )
+cuda_genkernel_binary(cuda_Sub_cpp, "SubOp")

--- a/src/tensor/private/p_kernels_generate.nim
+++ b/src/tensor/private/p_kernels_generate.nim
@@ -1,0 +1,110 @@
+# Copyright 2017 Mamy André-Ratsimbazafy
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generate Cuda kernels
+
+# ##################################################
+# # Assignements, copy and in-place operations
+template cuda_genkernel_assign*(
+  kernel_name: untyped, op_name: string): untyped =
+  # Kernel_name must be an open symbol
+  # As a hack to avoid building an AST macro with new call
+  # declare a dummy proc with `proc kernel_name = discard`
+
+  {.emit:["""
+  template<typename T>
+  inline void """,kernel_name.astToStr,"""(
+    const int blocksPerGrid, const int threadsPerBlock,
+    const int rank,
+    const int len,
+    const int * __restrict__ dst_shape,
+    const int * __restrict__ dst_strides,
+    const int dst_offset,
+    T * __restrict__ dst_data,
+    const int * __restrict__ src_shape,
+    const int * __restrict__ src_strides,
+    const int src_offset,
+    const T * __restrict__ src_data){
+
+      cuda_apply2<<<blocksPerGrid, threadsPerBlock>>>(
+        rank, len,
+        dst_shape, dst_strides, dst_offset, dst_data,
+        """,op_name,"""<T>(),
+        src_shape, src_strides, src_offset, src_data
+      );
+    }
+    """].}
+
+  const import_string:string = kernel_name.astToStr & "<'*8>(@)"
+  # We pass the 8th parameter type to the template.
+  # The "*" in '*8 is needed to remove the pointer *
+
+  proc kernel_name[T: SomeReal](
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
+  ) {.importcpp: import_string, noSideEffect, exportc.}
+
+
+# ##################################################
+# # Binary operations
+template cuda_genkernel_binary*(
+  kernel_name: untyped, op_name: string): untyped =
+  # Kernel_name must be an open symbol
+  # As a hack to avoid building an AST macro with new call
+  # declare a dummy proc with `proc kernel_name = discard`
+
+  # TODO: optimize number of args to reduce register pressure
+
+  {.emit:["""
+  template<typename T>
+  inline void """,kernel_name.astToStr,"""(
+    const int blocksPerGrid, const int threadsPerBlock,
+    const int rank,
+    const int len,
+    const int * __restrict__ dst_shape,
+    const int * __restrict__ dst_strides,
+    const int dst_offset,
+    T * __restrict__ dst_data,
+    const int * __restrict__ A_shape,
+    const int * __restrict__ A_strides,
+    const int A_offset,
+    const T * __restrict__ A_data,
+    const int * __restrict__ B_shape,
+    const int * __restrict__ B_strides,
+    const int B_offset,
+    const T * __restrict__ B_data){
+
+      cuda_apply3<<<blocksPerGrid, threadsPerBlock>>>(
+        rank, len,
+        dst_shape, dst_strides, dst_offset, dst_data,
+        A_shape, A_strides, A_offset, A_data,
+        """,op_name,"""<T>(),
+        B_shape, B_strides, B_offset, B_data
+      );
+    }
+    """].}
+
+  const import_string:string = kernel_name.astToStr & "<'*8>(@)"
+  # We pass the 8th parameter type to the template.
+  # The "*" in '*8 is needed to remove the pointer *
+
+  proc kernel_name[T: SomeReal](
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
+    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr T,
+    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr T
+  ) {.importcpp: import_string, noSideEffect, exportc.}

--- a/src/tensor/private/p_kernels_interface_cuda.nim
+++ b/src/tensor/private/p_kernels_interface_cuda.nim
@@ -1,4 +1,4 @@
-# Copyright 2017 Mamy André-Ratsimbazafy
+# Copyright 2017 the Arraymancer contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,61 +23,30 @@ import  ../backend/cuda,
 
 # Explanation:
 #
-# - To avoid creating a proc AST from scratch: we create a dummy proc.
-# - pass it to an overloading template (cuda_assign_glue for in-place/assignments)
-# - overloading template creates the cuda code, the import and a Nim wrapper
-# - Unfortunately the Nim wrapper cannot be called as-is in other file as it uses C++ semantics
-# - So we add an indirection that will be exported.
+# - Cuda C++ code is handled by p_kernels_cuda
+# - p_kernels_cuda is compiled separately as a C++ file to avoid polluting the whole project with C++ semantics
+# - The compiled C++ is renamed to .cu to make NVCC happy
+# - We tell Nim not to forget to compile/link to this .cu
+
+# #########################################################
+# Compiling cuda kernels separately
+
+const nimCliArgs = "nim e script_kernels_interface_cuda.nims"
+const execCmd {.used.}= staticExec(nimCliArgs,"","")
+
+static:
+  echo  " ### Begin: cuda kernels compilation ###\n" &
+        execCmd &
+        "\n ### End: cuda kernels compilation ###"
 
 
-# Important: the glue templates must be isolated in files like "p_kernels" that should
-# only depends on this file. Those files will be compiled to C++.
-# Linking won't happen properly if that file uses non-primitive type like CudaTensor.
+# Tell Nim/NVCC to compile and link against the kernels file
+# We go from "./src/tensor/private" to "./nimcache"
+{.compile: "../../../nimcache/arraymancer_p_kernels_cuda.cu".}
 
-# The call templates should be used to interact with the "p_kernels" file.
 
-# ##################################################
-# # Assignements, copy and in-place operations
-template cuda_assign_glue*(
-  kernel_name: untyped, op_name: string): untyped =
-  # Kernel_name must be an open symbol
-  # As a hack to avoid building an AST macro with new call
-  # declare a dummy proc with `proc kernel_name = discard`
-
-  {.emit:["""
-  template<typename T>
-  inline void """,kernel_name.astToStr,"""(
-    const int blocksPerGrid, const int threadsPerBlock,
-    const int rank,
-    const int len,
-    const int * __restrict__ dst_shape,
-    const int * __restrict__ dst_strides,
-    const int dst_offset,
-    T * __restrict__ dst_data,
-    const int * __restrict__ src_shape,
-    const int * __restrict__ src_strides,
-    const int src_offset,
-    const T * __restrict__ src_data){
-
-      cuda_apply2<<<blocksPerGrid, threadsPerBlock>>>(
-        rank, len,
-        dst_shape, dst_strides, dst_offset, dst_data,
-        """,op_name,"""<T>(),
-        src_shape, src_strides, src_offset, src_data
-      );
-    }
-    """].}
-
-  const import_string:string = kernel_name.astToStr & "<'*8>(@)"
-  # We pass the 8th parameter type to the template.
-  # The "*" in '*8 is needed to remove the pointer *
-
-  proc kernel_name[T: SomeReal](
-    blocksPerGrid, threadsPerBlock: cint,
-    rank, len: cint,
-    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
-    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
-  ) {.importcpp: import_string, noSideEffect.}
+# #########################################################
+# # Call assignements, copy and in-place operations kernels
 
 template cuda_assign_call*[T: SomeReal](
   kernel_name: untyped, destination: var CudaTensor[T], source: CudaTensor[T]): untyped =
@@ -97,55 +66,7 @@ template cuda_assign_call*[T: SomeReal](
   )
 
 # ##################################################
-# # Binary operations
-template cuda_binary_glue*(
-  kernel_name: untyped, op_name: string): untyped =
-  # Kernel_name must be an open symbol
-  # As a hack to avoid building an AST macro with new call
-  # declare a dummy proc with `proc kernel_name = discard`
-
-  # TODO: optimize number of args to reduce register pressure
-
-  {.emit:["""
-  template<typename T>
-  inline void """,kernel_name.astToStr,"""(
-    const int blocksPerGrid, const int threadsPerBlock,
-    const int rank,
-    const int len,
-    const int * __restrict__ dst_shape,
-    const int * __restrict__ dst_strides,
-    const int dst_offset,
-    T * __restrict__ dst_data,
-    const int * __restrict__ A_shape,
-    const int * __restrict__ A_strides,
-    const int A_offset,
-    const T * __restrict__ A_data,
-    const int * __restrict__ B_shape,
-    const int * __restrict__ B_strides,
-    const int B_offset,
-    const T * __restrict__ B_data){
-
-      cuda_apply3<<<blocksPerGrid, threadsPerBlock>>>(
-        rank, len,
-        dst_shape, dst_strides, dst_offset, dst_data,
-        A_shape, A_strides, A_offset, A_data,
-        """,op_name,"""<T>(),
-        B_shape, B_strides, B_offset, B_data
-      );
-    }
-    """].}
-
-  const import_string:string = kernel_name.astToStr & "<'*8>(@)"
-  # We pass the 8th parameter type to the template.
-  # The "*" in '*8 is needed to remove the pointer *
-
-  proc kernel_name[T: SomeReal](
-    blocksPerGrid, threadsPerBlock: cint,
-    rank, len: cint,
-    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
-    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr T,
-    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr T
-  ) {.importcpp: import_string, noSideEffect.}
+# # Call binary operations kernels
 
 template cuda_binary_call*[T: SomeReal](
   kernel_name: untyped, destination: var CudaTensor[T], a, b: CudaTensor[T]): untyped =
@@ -165,4 +86,111 @@ template cuda_binary_call*[T: SomeReal](
     src_a.offset, src_a.data,
     src_b.shape[], src_b.strides[],
     src_b.offset, src_b.data
+  )
+
+###########################
+
+proc cuda_mAdd_cpp*[T: SomeReal](
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
+  ) {.importc.}
+
+proc cuda_mAdd*[T: SomeReal](
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
+  ) =
+  cuda_mAdd_cpp[T](blocksPerGrid, threadsPerBlock, rank, len,
+  dst_shape, dst_strides, dst_offset, dst_data,
+  src_shape, src_strides, src_offset, src_data)
+
+
+
+proc cuda_mSub_cpp*[T: SomeReal](
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
+  ) {.importc.}
+
+proc cuda_mSub*[T: SomeReal](
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
+  ) =
+  cuda_mSub_cpp[T](blocksPerGrid, threadsPerBlock, rank, len,
+  dst_shape, dst_strides, dst_offset, dst_data,
+  src_shape, src_strides, src_offset, src_data)
+
+
+
+proc cuda_unsafeContiguous_cpp*[T: SomeReal](
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
+  ) {.importc.}
+
+proc cuda_unsafeContiguous*[T: SomeReal](
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
+  ) =
+  cuda_unsafeContiguous_cpp[T](blocksPerGrid, threadsPerBlock, rank, len,
+  dst_shape, dst_strides, dst_offset, dst_data,
+  src_shape, src_strides, src_offset, src_data)
+
+
+
+proc cuda_Add_cpp*[T: SomeReal](
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
+    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr T,
+    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr T
+  ) {.importc.}
+
+proc cuda_Add*[T: SomeReal](
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
+    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr T,
+    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr T
+  ) =
+  cuda_Add_cpp[T](
+    blocksPerGrid, threadsPerBlock,
+    rank, len,
+    dst_shape, dst_strides, dst_offset, dst_data,
+    a_shape, a_strides, a_offset, a_data,
+    b_shape, b_strides, b_offset, b_data
+  )
+
+
+
+proc cuda_Sub_cpp*[T: SomeReal](
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
+    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr T,
+    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr T
+  ) {.importc.}
+
+proc cuda_Sub*[T: SomeReal](
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
+    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr T,
+    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr T
+  ) =
+  cuda_Sub_cpp[T](
+    blocksPerGrid, threadsPerBlock,
+    rank, len,
+    dst_shape, dst_strides, dst_offset, dst_data,
+    a_shape, a_strides, a_offset, a_data,
+    b_shape, b_strides, b_offset, b_data
   )

--- a/src/tensor/private/p_kernels_interface_cuda.nim
+++ b/src/tensor/private/p_kernels_interface_cuda.nim
@@ -54,7 +54,7 @@ template cuda_assign_glue*(
   # We pass the 8th parameter type to the template.
   # The "*" in '*8 is needed to remove the pointer *
 
-  proc kernel_name*[T: SomeReal](
+  proc kernel_name[T: SomeReal](
     blocksPerGrid, threadsPerBlock: cint,
     rank, len: cint,
     dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
@@ -121,7 +121,7 @@ template cuda_binary_glue*(
   # We pass the 8th parameter type to the template.
   # The "*" in '*8 is needed to remove the pointer *
 
-  proc kernel_name*[T: SomeReal](
+  proc kernel_name[T: SomeReal](
     blocksPerGrid, threadsPerBlock: cint,
     rank, len: cint,
     dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,

--- a/src/tensor/private/p_kernels_interface_cuda.nim
+++ b/src/tensor/private/p_kernels_interface_cuda.nim
@@ -90,79 +90,130 @@ template cuda_binary_call*[T: SomeReal](
 
 ###########################
 
-proc cuda_mAdd_cpp*[T: SomeReal](
+proc cuda_mAdd_f32*(
     blocksPerGrid, threadsPerBlock: cint,
     rank, len: cint,
-    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
-    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float32,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr float32
   ) {.importc.}
 
-proc cuda_mAdd*[T: SomeReal](
+proc cuda_mAdd*(
     blocksPerGrid, threadsPerBlock: cint,
     rank, len: cint,
-    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
-    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float32,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr float32
   ) =
-  cuda_mAdd_cpp[T](blocksPerGrid, threadsPerBlock, rank, len,
+  cuda_mAdd_f32(blocksPerGrid, threadsPerBlock, rank, len,
+  dst_shape, dst_strides, dst_offset, dst_data,
+  src_shape, src_strides, src_offset, src_data)
+
+proc cuda_mAdd_f64*(
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float64,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr float64
+  ) {.importc.}
+
+proc cuda_mAdd*(
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float64,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr float64
+  ) =
+  cuda_mAdd_f64(blocksPerGrid, threadsPerBlock, rank, len,
   dst_shape, dst_strides, dst_offset, dst_data,
   src_shape, src_strides, src_offset, src_data)
 
 
-
-proc cuda_mSub_cpp*[T: SomeReal](
+############################################
+proc cuda_mSub_f32*(
     blocksPerGrid, threadsPerBlock: cint,
     rank, len: cint,
-    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
-    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float32,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr float32
   ) {.importc.}
 
-proc cuda_mSub*[T: SomeReal](
+proc cuda_mSub*(
     blocksPerGrid, threadsPerBlock: cint,
     rank, len: cint,
-    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
-    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float32,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr float32
   ) =
-  cuda_mSub_cpp[T](blocksPerGrid, threadsPerBlock, rank, len,
+  cuda_mSub_f32(blocksPerGrid, threadsPerBlock, rank, len,
+  dst_shape, dst_strides, dst_offset, dst_data,
+  src_shape, src_strides, src_offset, src_data)
+
+proc cuda_mSub_f64*(
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float64,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr float64
+  ) {.importc.}
+
+proc cuda_mSub*(
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float64,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr float64
+  ) =
+  cuda_mSub_f64(blocksPerGrid, threadsPerBlock, rank, len,
+  dst_shape, dst_strides, dst_offset, dst_data,
+  src_shape, src_strides, src_offset, src_data)
+
+##############################################
+proc cuda_unsafeContiguous_f32*(
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float32,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr float32
+  ) {.importc.}
+
+proc cuda_unsafeContiguous*(
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float32,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr float32
+  ) =
+  cuda_unsafeContiguous_f32(blocksPerGrid, threadsPerBlock, rank, len,
+  dst_shape, dst_strides, dst_offset, dst_data,
+  src_shape, src_strides, src_offset, src_data)
+
+proc cuda_unsafeContiguous_f64*(
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float64,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr float64
+  ) {.importc.}
+
+proc cuda_unsafeContiguous*(
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float64,
+    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr float64
+  ) =
+  cuda_unsafeContiguous_f64(blocksPerGrid, threadsPerBlock, rank, len,
   dst_shape, dst_strides, dst_offset, dst_data,
   src_shape, src_strides, src_offset, src_data)
 
 
+################################################
 
-proc cuda_unsafeContiguous_cpp*[T: SomeReal](
+proc cuda_Add_f32*(
     blocksPerGrid, threadsPerBlock: cint,
     rank, len: cint,
-    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
-    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float32,
+    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr float32,
+    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr float32
   ) {.importc.}
 
-proc cuda_unsafeContiguous*[T: SomeReal](
+proc cuda_Add*(
     blocksPerGrid, threadsPerBlock: cint,
     rank, len: cint,
-    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
-    src_shape, src_strides: ptr cint, src_offset: cint, src_data: ptr T
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float32,
+    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr float32,
+    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr float32
   ) =
-  cuda_unsafeContiguous_cpp[T](blocksPerGrid, threadsPerBlock, rank, len,
-  dst_shape, dst_strides, dst_offset, dst_data,
-  src_shape, src_strides, src_offset, src_data)
-
-
-
-proc cuda_Add_cpp*[T: SomeReal](
-    blocksPerGrid, threadsPerBlock: cint,
-    rank, len: cint,
-    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
-    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr T,
-    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr T
-  ) {.importc.}
-
-proc cuda_Add*[T: SomeReal](
-    blocksPerGrid, threadsPerBlock: cint,
-    rank, len: cint,
-    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
-    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr T,
-    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr T
-  ) =
-  cuda_Add_cpp[T](
+  cuda_Add_f32(
     blocksPerGrid, threadsPerBlock,
     rank, len,
     dst_shape, dst_strides, dst_offset, dst_data,
@@ -171,23 +222,69 @@ proc cuda_Add*[T: SomeReal](
   )
 
 
-
-proc cuda_Sub_cpp*[T: SomeReal](
+proc cuda_Add_f64*(
     blocksPerGrid, threadsPerBlock: cint,
     rank, len: cint,
-    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
-    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr T,
-    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr T
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float64,
+    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr float64,
+    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr float64
   ) {.importc.}
 
-proc cuda_Sub*[T: SomeReal](
+proc cuda_Add*(
     blocksPerGrid, threadsPerBlock: cint,
     rank, len: cint,
-    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
-    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr T,
-    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr T
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float64,
+    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr float64,
+    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr float64
   ) =
-  cuda_Sub_cpp[T](
+  cuda_Add_f64(
+    blocksPerGrid, threadsPerBlock,
+    rank, len,
+    dst_shape, dst_strides, dst_offset, dst_data,
+    a_shape, a_strides, a_offset, a_data,
+    b_shape, b_strides, b_offset, b_data
+  )
+
+############################################
+proc cuda_Sub_f32*(
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float32,
+    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr float32,
+    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr float32
+  ) {.importc.}
+
+proc cuda_Sub*(
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float32,
+    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr float32,
+    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr float32
+  ) =
+  cuda_Sub_f32(
+    blocksPerGrid, threadsPerBlock,
+    rank, len,
+    dst_shape, dst_strides, dst_offset, dst_data,
+    a_shape, a_strides, a_offset, a_data,
+    b_shape, b_strides, b_offset, b_data
+  )
+
+proc cuda_Sub_f64*(
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float64,
+    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr float64,
+    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr float64
+  ) {.importc.}
+
+proc cuda_Sub*(
+    blocksPerGrid, threadsPerBlock: cint,
+    rank, len: cint,
+    dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr float64,
+    a_shape, a_strides: ptr cint, a_offset: cint, a_data: ptr float64,
+    b_shape, b_strides: ptr cint, b_offset: cint, b_data: ptr float64
+  ) =
+  cuda_Sub_f64(
     blocksPerGrid, threadsPerBlock,
     rank, len,
     dst_shape, dst_strides, dst_offset, dst_data,

--- a/src/tensor/private/p_kernels_interface_cuda.nim
+++ b/src/tensor/private/p_kernels_interface_cuda.nim
@@ -54,7 +54,7 @@ template cuda_assign_glue*(
   # We pass the 8th parameter type to the template.
   # The "*" in '*8 is needed to remove the pointer *
 
-  proc kernel_name[T: SomeReal](
+  proc kernel_name*[T: SomeReal](
     blocksPerGrid, threadsPerBlock: cint,
     rank, len: cint,
     dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
@@ -121,7 +121,7 @@ template cuda_binary_glue*(
   # We pass the 8th parameter type to the template.
   # The "*" in '*8 is needed to remove the pointer *
 
-  proc kernel_name[T: SomeReal](
+  proc kernel_name*[T: SomeReal](
     blocksPerGrid, threadsPerBlock: cint,
     rank, len: cint,
     dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,

--- a/src/tensor/private/p_kernels_interface_cuda.nim
+++ b/src/tensor/private/p_kernels_interface_cuda.nim
@@ -16,7 +16,25 @@ import  ../backend/cuda,
         ../backend/global_config,
         ../data_structure
 
-# Auto-generate glue between Nim functions, cuda higher-order functions and basic op
+# Design: due to limitations and difficulties in C++
+# (no mutable iterators, stack hidden from GC, exception issue, casting workaround for builtin_assume_aligned)
+# I choose to sacrifice readability here to avoid a plethora of "when not defined(cpp) in the codebase.
+# This file will serve as a bridge between Cuda C++ and Nim C.
+
+# Explanation:
+#
+# - To avoid creating a proc AST from scratch: we create a dummy proc.
+# - pass it to an overloading template (cuda_assign_glue for in-place/assignments)
+# - overloading template creates the cuda code, the import and a Nim wrapper
+# - Unfortunately the Nim wrapper cannot be called as-is in other file as it uses C++ semantics
+# - So we add an indirection that will be exported.
+
+
+# Important: the glue templates must be isolated in files like "p_kernels" that should
+# only depends on this file. Those files will be compiled to C++.
+# Linking won't happen properly if that file uses non-primitive type like CudaTensor.
+
+# The call templates should be used to interact with the "p_kernels" file.
 
 # ##################################################
 # # Assignements, copy and in-place operations

--- a/src/tensor/private/script_kernels_interface_cuda.nims
+++ b/src/tensor/private/script_kernels_interface_cuda.nims
@@ -1,0 +1,38 @@
+# Copyright 2017 the Arraymancer contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Explanation:
+#
+# - Cuda C++ code is handled by p_kernels_cuda
+# - p_kernels_cuda is compiled separately as a C++ file to avoid polluting the whole project with C++ semantics
+# - The compiled C++ is renamed to .cu to make NVCC happy
+# - We tell Nim not to forget to compile/link to this .cu
+
+mode = ScriptMode.Verbose
+
+# We must go back "./src/tensor/private/"
+const par_nimcache = thisDir() & "/../../../nimcache/"
+const compiled_name = par_nimcache & "arraymancer_p_kernels_cuda"
+
+const par_nimcache_esc = "\"" & thisDir() & "\"/../../../nimcache/"
+
+# Compile the Cuda kernels as stand-alone
+selfExec "cpp --nimcache:" & par_nimcache_esc & " -c p_kernels_cuda"
+
+# Rename the .cpp to .cu to keep NVCC happy
+if fileExists(compiled_name & ".cpp"):
+  mvFile(compiled_name & ".cpp", compiled_name & ".cu")
+else:
+  echo "ERROR: File " & compiled_name & ".cpp was not found"

--- a/src/tensor/shapeshifting_cuda.nim
+++ b/src/tensor/shapeshifting_cuda.nim
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import  ./private/p_kernels_interface_cuda,
-        ./private/p_kernels_cuda,
         ./private/p_init_cuda,
         ./private/p_shapeshifting,
         ./data_structure

--- a/src/tensor/shapeshifting_cuda.nim
+++ b/src/tensor/shapeshifting_cuda.nim
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ./private/p_kernels_interface_cuda,
-       ./private/p_init_cuda,
-       ./private/p_shapeshifting,
-       ./data_structure
-
-include ./private/incl_accessors_cuda,
-        ./private/incl_higher_order_cuda,
-        ./private/incl_kernels_cuda
+import  ./private/p_kernels_interface_cuda,
+        ./private/p_kernels_cuda,
+        ./private/p_init_cuda,
+        ./private/p_shapeshifting,
+        ./data_structure
 
 proc unsafeTranspose*(t: CudaTensor): CudaTensor {.noSideEffect.}=
   ## Transpose a Tensor.
@@ -34,9 +31,6 @@ proc unsafeTranspose*(t: CudaTensor): CudaTensor {.noSideEffect.}=
   t.strides.reversed(result.strides)
   result.offset = t.offset
   result.data = t.data
-
-proc cuda_unsafeContiguous = discard # This is a hack so that the symbol is open
-cuda_assign_glue(cuda_unsafeContiguous, "CopyOp")
 
 proc unsafeContiguous*[T: SomeReal](t: CudaTensor[T], layout: OrderType = colMajor, force: bool = false):
   CudaTensor[T] {.noSideEffect.}=


### PR DESCRIPTION
C++ codegen is problematic:
- https://github.com/mratsim/Arraymancer/issues/116
- https://github.com/mratsim/Arraymancer/issues/91

And leads to Cthulhu monstruosity like this: https://github.com/mratsim/Arraymancer/pull/114
 Sample
https://github.com/mratsim/Arraymancer/blob/6af53584bea21b35b61ed80c538689259b6f1a38/src/tensor/higher_order.nim#L39-L48

This is not sustainable.

Various scheme could be explored:
1. compile C++ and C separately (I'd like to avoid that, it makes the build system non-trivial)
2. have a .cu and .cuh isolated kernels
3. Find a way to isolate Nim C++ (My preference)

Note that solution 2 probably require C++ template headers in that case the problem will become "how to interact with the module that loads this header. Furthermore {.compile.} pragma has path issue in nimcache https://forum.nim-lang.org/t/2668.

