### PR TITLE
Revert "Fix OpenMP macOS huge slowdown + use SIMD in OMP section + Perf doc"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ The library is inspired by Numpy and PyTorch.
   - [Full documentation](#full-documentation)
   - [Features](#features)
     - [Speed](#speed)
-      - [Parallelism](#parallelism)
-      - [Memory allocation](#memory-allocation)
       - [Micro benchmark: Int64 matrix multiplication](#micro-benchmark-int64-matrix-multiplication)
       - [Logistic regression](#logistic-regression)
       - [DNN - 3 hidden layers](#dnn---3-hidden-layers)
@@ -105,22 +103,6 @@ For now Arraymancer is still at the ndarray stage, however a [vision package](ht
 You can also check the [detailed example](https://github.com/mratsim/Arraymancer/blob/master/examples/ex01_xor_perceptron_from_scratch.nim) or [benchmark](https://github.com/mratsim/Arraymancer/blob/master/benchmarks/ex01_xor.nim) perceptron for a preview of Arraymancer deep learning usage.
 
 ### Speed
-
-#### Parallelism
-
-Most operations in Arraymancer are parallelized through OpenMP including linear algebra functions, universal functions, `map`, `reduce` and `fold`.
-
-Note: On OSX in some cases, OpenMP might be significantly slower than the single-threaded load, probably due to memory allocation differences. Unfortunately this is platform specific, Linux doesn't have the same issue. See [here](https://github.com/mratsim/Arraymancer/issues/134#issuecomment-340425671) for details.
-
-#### Memory allocation
-
-For most operations in machine linear, memory and cache is the bottleneck, for example taking the log of a Tensor can use at most 20% of your theoretical max CPU speed (in GFLOPS) while matrix multiplication can use 70%-90%+ for the best implementations (MKL, OpenBLAS).
-
-In the log case, the processor gives a result faster than it can load data into its cache. In the matrix multiplication case, each element of a matrix can be reused several times before loading data again.
-
-Arraymancer strives hard to limit memory allocation with `inline` version of `map`, `apply`, `reduce`, `fold` (`map_inline`, `apply_inline`, `reduce_inline`, `fold_inline`)
-
-Furthermore while Arraymancer uses copy on assignment by default, most procedures have an `unsafe` equivalent that provides no-copy operations like `reshape` and `unsafeReshape`. Warning ⚠: Memory is shared in that case, modifying one of these tensors will modify the other.
 
 #### Micro benchmark: Int64 matrix multiplication
 

--- a/benchmarks/implementation/logsumexp.nim
+++ b/benchmarks/implementation/logsumexp.nim
@@ -107,13 +107,8 @@ when isMainModule:
   echo " Dummy value: ", dummy # This is to avoid compiler optimization
 
 
-## Results on i5-5257U (macOS High Sierra, dual-core mobile 2.7GHz, turbo 3.1)
-## Note: OpenMP is significantly SLOWER on macOS than single-threaded
-## while on Linux it scales with number of cores.
-## See https://github.com/mratsim/Arraymancer/issues/134#issuecomment-340425671
-## Potential reasons are:
-## - memory fragmentation due to OSX mmap implementation
-## - "False sharing"
+## Results on i5-5257U (dual-core mobile 2.7GHz, turbo 3.1)
+## Note: OpenMP is significantly SLOWER
 
 # Compilation flags
 # nim c -d:native -d:release --out:bin/logsumexp --nimcache:./nimcache benchmarks/implementation/logsumexp.nim

--- a/src/nn_primitives/fallback/conv.nim
+++ b/src/nn_primitives/fallback/conv.nim
@@ -34,7 +34,7 @@ proc im2col[T]( input: Tensor[T], kernel_size: Size2D,
 
   var odata = result.dataArray
   var idata = input.dataArray
-  for c in `||`(0, channels_col-1, "simd"):
+  for c in 0||(channels_col-1):
     let
       w_offset = (c mod kernel_size.width) - padding.width
       h_offset = ((c div kernel_size.width) mod kernel_size.height) - padding.height

--- a/src/tensor/backend/openmp.nim
+++ b/src/tensor/backend/openmp.nim
@@ -32,7 +32,7 @@ else:
   template omp_get_max_threads*(): cint = 1
   template omp_get_thread_num*(): cint = 0
 
-const OMP_FOR_ANNOTATION = "simd if(ompsize > " & $OMP_FOR_THRESHOLD & ")"
+const OMP_FOR_ANNOTATION = "if(ompsize > " & $OMP_FOR_THRESHOLD & ")"
 
 template omp_parallel_countup*(i: untyped, size: Natural, body: untyped): untyped =
   let ompsize = size
@@ -52,7 +52,7 @@ template omp_parallel_blocks*(block_offset, block_size: untyped, size: Natural, 
           let num_blocks = min(omp_get_max_threads(), size)
           if num_blocks > 1:
             let bsize = size div num_blocks
-            for block_index in `||`(0, num_blocks-1, "simd"):
+            for block_index in 0||(num_blocks-1):
               let block_offset = bsize*block_index
               let block_size = if block_index < num_blocks-1: bsize else: size - block_offset
               block:
@@ -88,7 +88,7 @@ template omp_parallel_reduce_blocks*(reduced: typed, block_offset, block_size: u
                   op_init
 
               # Reduce blocks
-              for block_index in `||`(0, num_blocks-1, "simd"):
+              for block_index in 0||(num_blocks-1):
                 var block_offset = bsize*block_index
                 let block_size = (if block_index < num_blocks-1: bsize else: size - block_offset) - 1
                 block_offset += 1


### PR DESCRIPTION
Reverts mratsim/Arraymancer#136

--> Conv2D benchmark again fails and succeeds with no obvious patterns