### PR TITLE
OpenMP: Fix false sharing in parallel reduce and fallback GEMM (especially on macOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ The library is inspired by Numpy and PyTorch.
   - [Full documentation](#full-documentation)
   - [Features](#features)
     - [Speed](#speed)
+      - [Parallelism](#parallelism)
+      - [Memory allocation](#memory-allocation)
       - [Micro benchmark: Int64 matrix multiplication](#micro-benchmark-int64-matrix-multiplication)
       - [Logistic regression](#logistic-regression)
       - [DNN - 3 hidden layers](#dnn---3-hidden-layers)
@@ -103,6 +105,22 @@ For now Arraymancer is still at the ndarray stage, however a [vision package](ht
 You can also check the [detailed example](https://github.com/mratsim/Arraymancer/blob/master/examples/ex01_xor_perceptron_from_scratch.nim) or [benchmark](https://github.com/mratsim/Arraymancer/blob/master/benchmarks/ex01_xor.nim) perceptron for a preview of Arraymancer deep learning usage.
 
 ### Speed
+
+#### Parallelism
+
+Most operations in Arraymancer are parallelized through OpenMP including linear algebra functions, universal functions, `map`, `reduce` and `fold`.
+
+Note: On OSX in some cases, OpenMP might be significantly slower than the single-threaded load, probably due to memory allocation differences. Unfortunately this is platform specific, Linux doesn't have the same issue. See [here](https://github.com/mratsim/Arraymancer/issues/134#issuecomment-340425671) for details.
+
+#### Memory allocation
+
+For most operations in machine linear, memory and cache is the bottleneck, for example taking the log of a Tensor can use at most 20% of your theoretical max CPU speed (in GFLOPS) while matrix multiplication can use 70%-90%+ for the best implementations (MKL, OpenBLAS).
+
+In the log case, the processor gives a result faster than it can load data into its cache. In the matrix multiplication case, each element of a matrix can be reused several times before loading data again.
+
+Arraymancer strives hard to limit memory allocation with `inline` version of `map`, `apply`, `reduce`, `fold` (`map_inline`, `apply_inline`, `reduce_inline`, `fold_inline`)
+
+Furthermore while Arraymancer uses copy on assignment by default, most procedures have an `unsafe` equivalent that provides no-copy operations like `reshape` and `unsafeReshape`. Warning ⚠: Memory is shared in that case, modifying one of these tensors will modify the other.
 
 #### Micro benchmark: Int64 matrix multiplication
 

--- a/benchmarks/implementation/logsumexp.nim
+++ b/benchmarks/implementation/logsumexp.nim
@@ -107,8 +107,13 @@ when isMainModule:
   echo " Dummy value: ", dummy # This is to avoid compiler optimization
 
 
-## Results on i5-5257U (dual-core mobile 2.7GHz, turbo 3.1)
-## Note: OpenMP is significantly SLOWER
+## Results on i5-5257U (macOS High Sierra, dual-core mobile 2.7GHz, turbo 3.1)
+## Note: OpenMP is significantly SLOWER on macOS than single-threaded
+## while on Linux it scales with number of cores.
+## See https://github.com/mratsim/Arraymancer/issues/134#issuecomment-340425671
+## Potential reasons are:
+## - memory fragmentation due to OSX mmap implementation
+## - "False sharing"
 
 # Compilation flags
 # nim c -d:native -d:release --out:bin/logsumexp --nimcache:./nimcache benchmarks/implementation/logsumexp.nim

--- a/src/nn_primitives/fallback/conv.nim
+++ b/src/nn_primitives/fallback/conv.nim
@@ -34,7 +34,7 @@ proc im2col[T]( input: Tensor[T], kernel_size: Size2D,
 
   var odata = result.dataArray
   var idata = input.dataArray
-  for c in 0||(channels_col-1):
+  for c in `||`(0, channels_col-1, "simd"):
     let
       w_offset = (c mod kernel_size.width) - padding.width
       h_offset = ((c div kernel_size.width) mod kernel_size.height) - padding.height

--- a/src/tensor/backend/openmp.nim
+++ b/src/tensor/backend/openmp.nim
@@ -32,7 +32,7 @@ else:
   template omp_get_max_threads*(): cint = 1
   template omp_get_thread_num*(): cint = 0
 
-const OMP_FOR_ANNOTATION = "if(ompsize > " & $OMP_FOR_THRESHOLD & ")"
+const OMP_FOR_ANNOTATION = "simd if(ompsize > " & $OMP_FOR_THRESHOLD & ")"
 
 template omp_parallel_countup*(i: untyped, size: Natural, body: untyped): untyped =
   let ompsize = size
@@ -52,7 +52,7 @@ template omp_parallel_blocks*(block_offset, block_size: untyped, size: Natural, 
           let num_blocks = min(omp_get_max_threads(), size)
           if num_blocks > 1:
             let bsize = size div num_blocks
-            for block_index in 0||(num_blocks-1):
+            for block_index in `||`(0, num_blocks-1, "simd"):
               let block_offset = bsize*block_index
               let block_size = if block_index < num_blocks-1: bsize else: size - block_offset
               block:
@@ -88,7 +88,7 @@ template omp_parallel_reduce_blocks*(reduced: typed, block_offset, block_size: u
                   op_init
 
               # Reduce blocks
-              for block_index in 0||(num_blocks-1):
+              for block_index in `||`(0, num_blocks-1, "simd"):
                 var block_offset = bsize*block_index
                 let block_size = (if block_index < num_blocks-1: bsize else: size - block_offset) - 1
                 block_offset += 1

--- a/src/tensor/backend/openmp.nim
+++ b/src/tensor/backend/openmp.nim
@@ -45,7 +45,7 @@ template omp_parallel_forup*(i: untyped, start, size: Natural, body: untyped): u
     body
 
 template omp_parallel_blocks*(block_offset, block_size: untyped, size: Natural, body: untyped): untyped =
-  if size > 0:
+  if likely(size > 0):
     block ompblocks:
       when defined(openmp):
         if size >= OMP_FOR_THRESHOLD:
@@ -65,7 +65,7 @@ template omp_parallel_blocks*(block_offset, block_size: untyped, size: Natural, 
         body
 
 template omp_parallel_reduce_blocks*(reduced: typed, block_offset, block_size: untyped, size, weight: Natural, op_final, op_init, op_middle: untyped): untyped =
-  if size > 0:
+  if likely(size > 0):
     block ompblocks:
       when defined(openmp):
         if size*weight >= OMP_FOR_THRESHOLD:

--- a/src/tensor/backend/openmp.nim
+++ b/src/tensor/backend/openmp.nim
@@ -52,7 +52,7 @@ template omp_parallel_blocks*(block_offset, block_size: untyped, size: Natural, 
           let num_blocks = min(omp_get_max_threads(), size)
           if num_blocks > 1:
             let bsize = size div num_blocks
-            for block_index in `||`(0, num_blocks-1, "simd"):
+            for block_index in `||`(0, num_blocks-1, "simd schedule(static, 4)"):
               let block_offset = bsize*block_index
               let block_size = if block_index < num_blocks-1: bsize else: size - block_offset
               block:
@@ -64,14 +64,26 @@ template omp_parallel_blocks*(block_offset, block_size: untyped, size: Natural, 
       block:
         body
 
-template omp_parallel_reduce_blocks*(reduced: typed, block_offset, block_size: untyped, size, weight: Natural, op_final, op_init, op_middle: untyped): untyped =
+
+template omp_parallel_reduce_blocks*[T](reduced: T, block_offset, block_size: untyped, size, weight: Natural, op_final, op_init, op_middle: untyped): untyped =
+
+
+  # To prevent false sharing, results will be stored in an array but
+  # padded to be a cache line apart atleast.
+  # All CPUs cache line is 64B, 16 float32/int32 fits or 8 float64/int64
+
+  # TODO compile time evaluation depending of sizeof(T)
+  # Pending https://github.com/nim-lang/Nim/pull/5664
+  const maxItemsPerCacheLine = 16
+
   if likely(size > 0):
     block ompblocks:
       when defined(openmp):
         if size*weight >= OMP_FOR_THRESHOLD:
           let num_blocks = min(min(size, omp_get_max_threads()), OMP_MAX_REDUCE_BLOCKS)
           if num_blocks > 1:
-            var results : array[OMP_MAX_REDUCE_BLOCKS, type(reduced)]
+            {.pragma: align64, codegenDecl: "$# $# __attribute__((aligned(64)))".}
+            var results{.align64.}: array[OMP_MAX_REDUCE_BLOCKS * maxItemsPerCacheLine, type(reduced)]
             let bsize = size div num_blocks
 
             if bsize > 1:
@@ -82,7 +94,7 @@ template omp_parallel_reduce_blocks*(reduced: typed, block_offset, block_size: u
 
                 # Inject x using a template to able to mutate it
                 template x(): untyped =
-                  results[block_index]
+                  results[block_index * maxItemsPerCacheLine]
 
                 block:
                   op_init
@@ -95,7 +107,7 @@ template omp_parallel_reduce_blocks*(reduced: typed, block_offset, block_size: u
 
                 # Inject x using a template to able to mutate it
                 template x(): untyped =
-                  results[block_index]
+                  results[block_index * maxItemsPerCacheLine]
 
                 block:
                   op_middle
@@ -109,7 +121,7 @@ template omp_parallel_reduce_blocks*(reduced: typed, block_offset, block_size: u
                   reduced
 
                 for block_index in 1..<num_blocks:
-                  let y {.inject.} = results[block_index]
+                  let y {.inject.} = results[block_index * maxItemsPerCacheLine]
                   op_final
 
               break ompblocks

--- a/src/tensor/fallback/blas_l3_gemm_macro_kernel.nim
+++ b/src/tensor/fallback/blas_l3_gemm_macro_kernel.nim
@@ -28,13 +28,11 @@ proc gemm_macro_kernel[T](mc, nc, kc: int,
   let mod_mr = mc mod MR
   let mod_nr = nc mod NR
 
-  for j in `||`(0, np - 1, "simd"): # OpenMP loop
+  for j in 0 ..< np:
     let nr =  if (j != np-1 or mod_nr == 0): NR
               else: mod_nr
 
-    ## We can't declare private(i) in Nim OpenMP at the j level so we use a while loop instead of for loop.
-    var i = 0
-    while i < mp:
+    for i in 0 ..< mp:
       let mr =  if (i != mp-1 or mod_mr == 0): MR
                 else: mod_mr
 
@@ -61,5 +59,3 @@ proc gemm_macro_kernel[T](mc, nc, kc: int,
                 1, MR,
                 C, i*MR*incRowC+j*NR*incColC + offC,
                 incRowC, incColC)
-
-      inc i

--- a/src/tensor/fallback/blas_l3_gemm_macro_kernel.nim
+++ b/src/tensor/fallback/blas_l3_gemm_macro_kernel.nim
@@ -28,10 +28,13 @@ proc gemm_macro_kernel[T](mc, nc, kc: int,
   let mod_mr = mc mod MR
   let mod_nr = nc mod NR
 
-  for j in 0..<np:
+  for j in `||`(0, np - 1, "simd"): # OpenMP loop
     let nr =  if (j != np-1 or mod_nr == 0): NR
               else: mod_nr
-    for i in `||`(0, mp - 1, "simd"): # OpenMP loop
+
+    ## We can't declare private(i) in Nim OpenMP at the j level so we use a while loop instead of for loop.
+    var i = 0
+    while i < mp:
       let mr =  if (i != mp-1 or mod_mr == 0): MR
                 else: mod_mr
 
@@ -58,3 +61,5 @@ proc gemm_macro_kernel[T](mc, nc, kc: int,
                 1, MR,
                 C, i*MR*incRowC+j*NR*incColC + offC,
                 incRowC, incColC)
+
+      inc i

--- a/src/tensor/fallback/blas_l3_gemm_macro_kernel.nim
+++ b/src/tensor/fallback/blas_l3_gemm_macro_kernel.nim
@@ -29,11 +29,11 @@ proc gemm_macro_kernel[T](mc, nc, kc: int,
   let mod_nr = nc mod NR
 
   for j in 0..<np:
-    let nr = if (j != np-1 or mod_nr == 0): NR
-             else: mod_nr
-    for i in 0 || (mp - 1): # OpenMP loop
-      let mr = if (i != mp-1 or mod_mr == 0): MR
-               else: mod_mr
+    let nr =  if (j != np-1 or mod_nr == 0): NR
+              else: mod_nr
+    for i in `||`(0, mp - 1, "simd"): # OpenMP loop
+      let mr =  if (i != mp-1 or mod_mr == 0): MR
+                else: mod_mr
 
       if (mr==MR and nr==NR):
         gemm_micro_kernel(kc, alpha,


### PR DESCRIPTION
Unfortunately PR https://github.com/mratsim/Arraymancer/pull/137 had data races in GEMM.

After reverting, using a chunksize bigger than a 64kb cache line (16 for float32, 8 for int64, etc) i.e. setting `schedule(static, 16)` didn't help.
This solution is suggested to combat false sharing, when a cache line is modified it's invalidated for all the other thread, generating huge slowdown not unlike what was detected.

Resources:
- [Use of OpenMP chunk to break cache](https://stackoverflow.com/questions/18342033/use-of-openmp-chunk-to-break-cache)
- [False sharing in OpenMP loop array access](https://stackoverflow.com/questions/45032586/false-sharing-in-openmp-loop-array-access)
- Paper: [Detect false sharing in OpenMP application](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.221.7676&rep=rep1&type=pdf)

The false sharing issue might remain because the microkernel is 16 elements anyway so cache line sized.

Alternative would be to parallelize at a higher level. According to BLIS here are the suggestion:
 - BLIS retreat: [Parallelizing GEMM within BLIS](https://www.cs.utexas.edu/users/flame/BLISRetreat/BLISRetreatTalks/BLIS_RETREAT_TYLER.pdf)
 - Paper:[ Opportunities for parallelism in matrix multiplication](https://www.cs.utexas.edu/users/flame/pubs/FLAWN71.pdf)
- Blis [wiki on multithreading](https://github.com/flame/blis/wiki/Multithreading)

Loop around microkernel
![image](https://user-images.githubusercontent.com/22738317/32200982-ab642572-bdd4-11e7-98c6-931756596827.png)

5th loop | BLIS_JC_NT | n |  
4th loop | N/A | k | Not enabled
3rd loop | BLIS_IC_NT | m |  
2nd loop | BLIS_JR_NT | n |  
1st loop | BLIS_IR_NT | m

>When compute resources have private L3 caches (example: multi-socket systems), try parallelizing the JC loop. This means threads (or thread groups) will pack and compute with different row panels from matrix B.

> For compute resources that have private L2 caches but that share an L3 cache (example: cores on a socket), try parallelizing the IC loop. In this situation, threads will share the same packed row panel from matrix B, but pack and compute with different blocks of matrix A.

> If compute resources share an L2 cache but have private L1 caches (example: pairs of cores), try parallelizing the JR loop. Here, threads share the same packed block of matrix A but read different packed micro-panels of B into their private L1 caches. In some situations, parallelizing the IR loop may also be effective.

