### PR TITLE
[WIP] CuDNN convolution backward

### DIFF
--- a/src/nn_primitives/backend/cudnn.nim
+++ b/src/nn_primitives/backend/cudnn.nim
@@ -45,6 +45,16 @@ template asCudnnType*[T: SomeReal](typ: typedesc[T]): cudnnDataType_t =
   elif T is float64:
     CUDNN_DATA_DOUBLE
 
+{.experimental.}
+proc `=destroy`(o: cudnnTensorDescriptor_t) =
+  check cudnnDestroyTensorDescriptor o
+
+proc `=destroy`(o: cudnnFilterDescriptor_t) =
+  check cudnnDestroyFilterDescriptor o
+
+proc `=destroy`(o: cudnnConvolutionDescriptor_t) =
+  check cudnnDestroyConvolutionDescriptor o
+
 # #####################################################################
 # Tensor descriptor
 

--- a/src/nn_primitives/backend/cudnn.nim
+++ b/src/nn_primitives/backend/cudnn.nim
@@ -15,9 +15,12 @@
 # Nvidia CuDNN backend configuration
 # Note: Having CUDA installed does not mean CuDNN is installed
 
-import nimcuda/[nimcuda, cudnn]
+import  nimcuda/[nimcuda, cudnn],
+        ../../tensor/tensor
+export  nimcuda, cudnn
 
-export nimcuda, cudnn
+# #####################################################################
+# Initialization release
 
 
 var defaultHandle_cudnn*: cudnnHandle_t
@@ -32,3 +35,33 @@ proc cudnnRelease() {.noconv.} =
 
 addQuitProc(cudnnRelease)
 
+
+# #####################################################################
+# Types and destructors
+
+template asCudnnType*[T: SomeReal](typ: typedesc[T]): cudnnDataType_t =
+  when T is float32:
+    CUDNN_DATA_FLOAT
+  elif T is float64:
+    CUDNN_DATA_DOUBLE
+
+# #####################################################################
+# Tensor descriptor
+
+proc newCudnn4DTensorDesc*[T: SomeReal](t: CudaTensor[T]): cudnnTensorDescriptor_t {.inline, noinit.}=
+  # TODO: destroy descriptor automatically
+  # TODO: generalize with the NDTensor Desc
+  check cudnnCreateTensorDescriptor addr result
+
+  check cudnnSetTensor4dDescriptorEx(
+    result,
+    T.asCudnnType,
+    t.shape[0].cint, # n
+    t.shape[1].cint, # c
+    t.shape[2].cint, # h
+    t.shape[3].cint, # w
+    t.strides[0].cint, # n
+    t.strides[1].cint, # c
+    t.strides[2].cint, # h
+    t.strides[3].cint, # w
+  )

--- a/src/nn_primitives/backend/cudnn_conv_interface.nim
+++ b/src/nn_primitives/backend/cudnn_conv_interface.nim
@@ -91,7 +91,7 @@ proc newCudnnConvKernelDesc*[T: SomeReal](
     addr filters[0]
   )
 
-proc convOutDims*(input, kernel: CudaTensor, padding, convStrides, dilation: SizeHW): MetadataArray {.inline, noInit.}=
+proc convOutDims*(input, kernel: CudaTensor, padding, strides, dilation: SizeHW): MetadataArray {.inline, noInit.}=
 
   ## Each dimension of the (nbDims-2)-D images of the output tensor is computed as followed:
   ##   outputDim = 1 + ( inputDim + 2*pad - (((filterDim-1)*upscaleA)+1) )/ convolutionStride;
@@ -108,8 +108,8 @@ proc convOutDims*(input, kernel: CudaTensor, padding, convStrides, dilation: Siz
     kW = kernel.shape[3]
     dH = dilation[0]
     dW = dilation[1]
-    sH = convStrides[0]
-    sW = convStrides[1]
+    sH = strides[0]
+    sW = strides[1]
 
   result.len = 4
   result[0] = input.shape[0]

--- a/src/nn_primitives/backend/cudnn_interface.nim
+++ b/src/nn_primitives/backend/cudnn_interface.nim
@@ -168,7 +168,7 @@ proc conv_algo_workspace*[T: SomeReal](
 
 
 
-type Conv_bwd_filter_AlgoSpace*[T] = object
+type Conv_bwd_kernel_AlgoSpace*[T] = object
   algo*: cudnnConvolutionBwdFilterAlgo_t # TODO: create a destructor
   workspace*: ref[ptr T]
   sizeInBytes*: csize
@@ -178,10 +178,10 @@ proc conv_bwd_kernel_algo_workspace*[T: SomeReal](
   gradOutputTensorDesc: cudnnTensorDescriptor_t, # gradOuput is the gradient of the output. Result will be the gradient of the input
   gradKernelDesc: cudnnFilterDescriptor_t,
   convDesc: cudnnConvolutionDescriptor_t
-): Conv_bwd_filter_AlgoSpace[T] =
+): Conv_bwd_kernel_AlgoSpace[T] =
 
   when defined(debug):
-    echo "\nCudnn conv2d - get backward filter algorithm"
+    echo "\nCudnn conv2d - get backward kernel algorithm"
 
   check cudnnGetConvolutionBackwardFilterAlgorithm(
     defaultHandle_cudnn,
@@ -195,7 +195,7 @@ proc conv_bwd_kernel_algo_workspace*[T: SomeReal](
   )
 
   when defined(debug):
-    echo "Cudnn conv2d - backward filter algorithm selected: " & $result.algo
+    echo "Cudnn conv2d - backward kernel algorithm selected: " & $result.algo
 
   check cudnnGetConvolutionBackwardFilterWorkspaceSize(
     defaultHandle_cudnn,
@@ -208,7 +208,7 @@ proc conv_bwd_kernel_algo_workspace*[T: SomeReal](
   )
 
   when defined(debug):
-    echo "Cudnn conv2d - backward filter workspace size: " & $result.sizeInBytes & " bytes"
+    echo "Cudnn conv2d - backward kernel workspace size: " & $result.sizeInBytes & " bytes"
 
   if result.sizeInBytes != 0:
     new(result.workspace, deallocCuda)

--- a/src/nn_primitives/backend/cudnn_interface.nim
+++ b/src/nn_primitives/backend/cudnn_interface.nim
@@ -105,7 +105,7 @@ proc convOutDims*(input, kernel: CudaTensor, padding, convStrides, dilation: Siz
 
   result.len = 4
   result[0] = input.shape[0]
-  result[1] = kernel.shape[0 ]
+  result[1] = kernel.shape[0]
   result[2] = 1 + (iH + 2*pH - (((kH-1) * dH) + 1) div sH)
   result[3] = 1 + (iW + 2*pW - (((kW-1) * dW) + 1) div sW)
 
@@ -146,7 +146,7 @@ proc conv_algo_workspace*[T: SomeReal](
   )
 
   when defined(debug):
-    echo "\nCudnn conv2d - forward algorithm selected: " & $result.algo
+    echo "Cudnn conv2d - forward algorithm selected: " & $result.algo
 
   check cudnnGetConvolutionForwardWorkspaceSize(
     defaultHandle_cudnn,
@@ -159,7 +159,7 @@ proc conv_algo_workspace*[T: SomeReal](
   )
 
   when defined(debug):
-    echo "\nCudnn conv2D - workspace size: " & $result.sizeInBytes & " bytes"
+    echo "Cudnn conv2D - workspace size: " & $result.sizeInBytes & " bytes"
 
   if result.sizeInBytes != 0:
     new(result.workspace, deallocCuda)
@@ -195,7 +195,7 @@ proc conv_bwd_kernel_algo_workspace*[T: SomeReal](
   )
 
   when defined(debug):
-    echo "\nCudnn conv2d - backward filter algorithm selected: " & $result.algo
+    echo "Cudnn conv2d - backward filter algorithm selected: " & $result.algo
 
   check cudnnGetConvolutionBackwardFilterWorkspaceSize(
     defaultHandle_cudnn,
@@ -208,7 +208,7 @@ proc conv_bwd_kernel_algo_workspace*[T: SomeReal](
   )
 
   when defined(debug):
-    echo "\nCudnn conv2d - backward filter workspace size: " & $result.sizeInBytes & " bytes"
+    echo "Cudnn conv2d - backward filter workspace size: " & $result.sizeInBytes & " bytes"
 
   if result.sizeInBytes != 0:
     new(result.workspace, deallocCuda)
@@ -239,12 +239,12 @@ proc conv_bwd_data_algo_workspace*[T: SomeReal](
     convDesc,
     gradInputTensorDesc,
     CUDNN_CONVOLUTION_BWD_DATA_PREFER_FASTEST,
-    50000,
+    0,
     addr result.algo
   )
 
   when defined(debug):
-    echo "\nCudnn conv2d - backward data algorithm selected: " & $result.algo
+    echo "Cudnn conv2d - backward data algorithm selected: " & $result.algo
 
   check cudnnGetConvolutionBackwardDataWorkspaceSize(
     defaultHandle_cudnn,
@@ -257,7 +257,7 @@ proc conv_bwd_data_algo_workspace*[T: SomeReal](
   )
 
   when defined(debug):
-    echo "\nCudnn conv2d - backward data workspace size: " & $result.sizeInBytes & " bytes"
+    echo "Cudnn conv2d - backward data workspace size: " & $result.sizeInBytes & " bytes"
 
   if result.sizeInBytes != 0:
     new(result.workspace, deallocCuda)

--- a/src/nn_primitives/nnp_conv2d_cudnn.nim
+++ b/src/nn_primitives/nnp_conv2d_cudnn.nim
@@ -20,25 +20,25 @@ import  ./backend/cudnn,
 
 import nimcuda/[cuda_runtime_api, nimcuda]
 
-proc conv2d*[T: SomeReal](input, convKernel, bias: CudaTensor[T],
+proc conv2d*[T: SomeReal](input, kernel, bias: CudaTensor[T],
                 padding: SizeHW = [0,0],
                 convStrides, dilation: SizeHW = [1,1]): CudaTensor[T] {.noInit.}=
   ## Input:
   ##     - ``input`` 4D Tensor batch of images of the size [N,C_in,H_in,W_in]
-  ##     - ``convKernel`` 4D Tensor convolving kernel filters of the size [C_out,C_in,kH,kW]
+  ##     - ``kernel`` 4D Tensor convolving kernel filters of the size [C_out,C_in,kH,kW]
   ##     - ``bias`` 3D Tensor bias of the size [C_out,1,1]
 
   # TODO bias as an Optional type
 
   const convDims: cint = 2
   const rank: cint = 4
-  let srcTensorDesc = newCudnn4DTensorDesc input # TODO: finalizer to destroy descriptor with GC
-  let convKernelDesc = newCudnnConvKernelDesc(convKernel) # TODO: finalizer to destroy descriptor with GC
+  let srcTensorDesc = newCudnn4DTensorDesc input # TODO: destructor
+  let kernelDesc = newCudnnConvKernelDesc(kernel) # TODO: destructor
 
   # Conversion to cint + object living long enough so we can use pointers to it for CuDNN
   let convConfig = initConv2DConfig(padding, convStrides, dilation)
 
-  var convDesc: cudnnConvolutionDescriptor_t # TODO: finalizer to destroy descriptor with GC
+  var convDesc: cudnnConvolutionDescriptor_t # TODO: destructor
   check cudnnCreateConvolutionDescriptor(addr convDesc)
 
   check cudnnSetConvolutionNdDescriptor(
@@ -52,12 +52,12 @@ proc conv2d*[T: SomeReal](input, convKernel, bias: CudaTensor[T],
   )
 
   # Setting up the result
-  let result_shape = convOutDims(input, convKernel, padding, convStrides, dilation)
+  let result_shape = convOutDims(input, kernel, padding, convStrides, dilation)
   result = newCudaTensor[T](result_shape, rowMajor)
   let dstTensorDesc = newCudnn4DTensorDesc result
 
   # Getting the convolution algorithm, shared memory workspace and its size.
-  let algo_workspace = conv_algo_workspace[T](srcTensorDesc, convKernelDesc, convDesc, dstTensorDesc)
+  let algo_workspace = conv_algo_workspace[T](srcTensorDesc, kernelDesc, convDesc, dstTensorDesc)
 
   # Scaling factors
   var alpha: T = 1
@@ -68,8 +68,8 @@ proc conv2d*[T: SomeReal](input, convKernel, bias: CudaTensor[T],
     addr alpha,
     srcTensorDesc,
     input.data.data[],
-    convKernelDesc,
-    convKernel.data.data[],
+    kernelDesc,
+    kernel.data.data[],
     convDesc,
     algo_workspace.algo,
     algo_workspace.workspace[],
@@ -80,3 +80,125 @@ proc conv2d*[T: SomeReal](input, convKernel, bias: CudaTensor[T],
   )
 
   result .+= bias.unsafeUnsqueeze(0)
+
+proc conv2d_backward*[T](input, kernel, bias: CudaTensor[T],
+                         padding: SizeHW = [0,0],
+                         convStrides, dilation: SizeHW = [1,1],
+                         grad_output: CudaTensor[T],
+                         grad_input, grad_kernel, grad_bias: var CudaTensor[T]) =
+  ## Computes gradients of a 2D convolution. Intended to be used after
+  ## ``conv2d`` to calculate gradients in backward pass.
+  ##
+  ## Input:
+  ##     - ``input`` 4D Tensor batch of images of the size [N,C_in,H_in,W_in]
+  ##     - ``kernel`` 4D Tensor convolving kernel weights of the size [C_out,C_in,kH,kW]
+  ##     - ``bias`` 3D Tensor bias of the size [C_out,1,1] or an empty tensor for no bias
+  ##     - ``padding`` SizeHW tuple with height and width of the padding
+  ##     - ``convStrides`` SizeHW tuple with height and width of the convolution strides
+  ##     - ``dilation`` SizeHW tuple with a rescaling factor of the convolution
+  ##     - ``grad_output`` 4D tensor gradient of the next layer of the size [N,C_out,H_out,W_out]
+  ##     - ``grad_input`` tensor where the gradient w.r.t input will be written
+  ##     - ``grad_kernel`` tensor where the gradient w.r.t convolution kernel will be written
+  ##     - ``grad_bias`` tensor where the gradient w.r.t bias will be written
+  ##
+  ## Note:
+  ##   ``grad_input``, ``grad_kernel`` and ``grad_bias`` will be overwritten. They must have the same shape
+  ##    as the corresponding ``input``, ``kernel`` and ``bias``
+
+
+  const convDims: cint = 2
+  const rank: cint = 4
+
+
+
+  let # TODO: Automatic destructor
+    srcTensorDesc = newCudnn4DTensorDesc input
+    kernelDesc = newCudnnConvKernelDesc(kernel)
+    gradKernelDesc = newCudnnConvKernelDesc(grad_kernel)
+    gradInputTensorDesc =  newCudnn4DTensorDesc grad_input
+    gradOutputTensorDesc =  newCudnn4DTensorDesc grad_output
+
+  # Conversion to cint + object living long enough so we can use pointers to it for CuDNN
+  let convConfig = initConv2DConfig(padding, convStrides, dilation)
+
+  var convDesc: cudnnConvolutionDescriptor_t # TODO: destructor
+  check cudnnCreateConvolutionDescriptor(addr convDesc)
+
+  check cudnnSetConvolutionNdDescriptor(
+    convDesc,
+    convDims,
+    convConfig.getPtr(pad),
+    convConfig.getPtr(strides),
+    convConfig.getPtr(dilation),
+    CUDNN_CROSS_CORRELATION,
+    T.asCudnnType
+  )
+
+  # Scaling factors
+  var alpha: T = 1
+  var beta: T = 0
+
+  # Input: getting the backward conv algorithm, shared memory workspace and its size.
+  let gradInput_algo_workspace = conv_bwd_data_algo_workspace[T](
+                                srcTensorDesc,
+                                gradOutputTensorDesc,
+                                kernelDesc, # Note the kernel
+                                convDesc,
+                                gradInputTensorDesc
+                                )
+
+  # Input gradient
+  check cudnnConvolutionBackwardData(
+    defaultHandle_cudnn,
+    addr alpha,
+    kernelDesc,
+    kernel.data.data[],
+    gradOutputTensorDesc,
+    grad_output.data.data[],
+    convDesc,
+    gradInput_algo_workspace.algo,
+    gradInput_algo_workspace.workspace[],
+    gradInput_algo_workspace.sizeInBytes,
+    addr beta,
+    gradInputTensorDesc,
+    grad_input.data.data[]
+  )
+
+  # Kernel: getting the backward conv algorithm, shared memory workspace and its size.
+  let kernel_algo_workspace = conv_bwd_kernel_algo_workspace[T](
+                                srcTensorDesc,
+                                gradOutputTensorDesc,
+                                gradKernelDesc, # Note the gradKernel
+                                convDesc
+                                )
+
+
+  # Kernel gradient
+  check cudnnConvolutionBackwardFilter(
+    defaultHandle_cudnn,
+    addr alpha,
+    srcTensorDesc,
+    input.data.data[],
+    gradOutputTensorDesc,
+    grad_output.data.data[],
+    convDesc,
+    kernel_algo_workspace.algo,
+    kernel_algo_workspace.workspace[],
+    kernel_algo_workspace.sizeInBytes,
+    addr beta,
+    gradKernelDesc,
+    grad_kernel.data.data[]
+  )
+
+  # Bias gradient
+  if bias.rank > 0:
+    let gradBiasTensorDesc = newCudnn4DTensorDesc grad_bias.unsafeUnsqueeze(0)
+    check cudnnConvolutionBackwardBias(
+      defaultHandle_cudnn,
+      addr alpha,
+      gradOutputTensorDesc,
+      grad_output.data.data[],
+      addr beta,
+      gradBiasTensorDesc,
+      grad_bias.data.data[]
+    )

--- a/src/tensor/init_cpu.nim
+++ b/src/tensor/init_cpu.nim
@@ -111,7 +111,6 @@ proc toTensor*(s:string): auto {.noSideEffect.} =
   ## This proc handles string specifically as otherwise they are interpreted as a sequence of char
   toTensorCpu(s)
 
-# TODO add tests for randomTensor
 proc zeros*[T: SomeNumber](shape: varargs[int]): Tensor[T] {.noInit,noSideEffect, inline.} =
   ## Creates a new Tensor filled with 0
   ##
@@ -163,8 +162,8 @@ proc ones*[T: SomeNumber](shape: MetadataArray): Tensor[T] {.noInit,noSideEffect
   tensorCpu(shape, result)
   result.data = newSeqWith(result.size, 1.T)
 
-proc ones_like*[T: SomeNumber](t: AnyTensor[T]): auto {.noInit,noSideEffect, inline.} =
-  ## Creates a new Tensor filled with 0 with the same shape as the input
+proc ones_like*[T: SomeNumber](t: Tensor[T]): Tensor[T] {.noInit,noSideEffect, inline.} =
+  ## Creates a new Tensor filled with 1 with the same shape as the input
   ## and filled with 1
   ## Input:
   ##      - Tensor

--- a/src/tensor/init_cuda.nim
+++ b/src/tensor/init_cuda.nim
@@ -16,7 +16,9 @@ import  ../private/sequninit,
         ./private/p_init_cuda,
         ./backend/cuda,
         ./backend/cuda_global_state,
+        ./backend/metadataArray,
         ./data_structure,
+        ./init_cpu,
         nimcuda/[cuda_runtime_api, driver_types]
 
 proc unsafeView*[T](t: CudaTensor[T]): CudaTensor[T] {.inline,noSideEffect.}=
@@ -115,7 +117,29 @@ proc cpu*[T:SomeReal](t: CudaTensor[T]): Tensor[T] {.noSideEffect, noInit.}=
 
   let size = csize(t.data.len * sizeof(T))
 
-  check cudaMemCpy(result.get_data_ptr,
-                   t.get_data_ptr,
-                   size,
-                   cudaMemcpyDeviceToHost)
+  check cudaMemCpy( result.get_data_ptr,
+                    t.get_data_ptr,
+                    size,
+                    cudaMemcpyDeviceToHost)
+
+
+
+proc zeros_like*[T: SomeReal](t: CudaTensor[T]): CudaTensor[T] {.noInit, inline.} =
+  ## Creates a new CudaTensor filled with 0 with the same shape as the input
+  ## Input:
+  ##      - Shape of the CudaTensor
+  ##      - Type of its elements
+  ## Result:
+  ##      - A zero-ed CudaTensor of the same shape
+
+  # TODO use cudaMemset
+  result = zeros[T](t.shape).cuda
+
+proc ones_like*[T: SomeReal](t: CudaTensor[T]): CudaTensor[T] {.noInit, inline.} =
+  ## Creates a new CudaTensor filled with 1 with the same shape as the input
+  ## and filled with 1
+  ## Input:
+  ##      - A CudaTensor
+  ## Result:
+  ##      - A one-ed CudaTensor of the same shape
+  result = ones[T](t.shape).cuda


### PR DESCRIPTION
Bug fix in convolution forward (Number of channels in the output was not from the kernel [C_out, C_int, H, W]

+ WIP on Conv2D Backward

Currently both kernel backward and data backward fails at the GetAlgorithm stage with `CUDNN_STATUS_NOT_SUPPORTED` (Error code 9) which is undocumented :/ on the following snippet

```Nim
import ../../src/arraymancer
import unittest, future

let
  input = randomTensor([1,1,4,4], 1.0f).cuda
  kernel = randomTensor([1,1,3,3], 1.0f).cuda
  bias = randomTensor([1,1,1], 1.0f).cuda
  padding = [1,1]
  stride = [1,1]
  dilation = [1, 1]

let output = conv2d(input, kernel, bias, padding, stride)

let # Check gradient with float64 and cpu convolution
  dinput = input.cpu.astype(float)
  dkernel = kernel.cpu.astype(float)
  dbias = bias.cpu.astype(float)
  dpad = (1, 1) # TODO unify cudnn sizeHW and cpu size2D
  dstride = (1, 1)

let
  target_grad_input = dinput.numerical_gradient(
    x => conv2d(x, dkernel, dbias, dpad, dstride).sum())
  target_grad_weight = dkernel.numerical_gradient(
    w => dinput.conv2d(w, dbias, dpad, dstride).sum())
  target_grad_bias = dbias.numerical_gradient(
    b => dinput.conv2d(dkernel, b, dpad, dstride).sum())

var
  grad_input = zeros_like input
  grad_kernel = zeros_like kernel
  grad_bias = zeros_like bias

let grad_output = ones_like(output)
echo grad_output

conv2d_backward(input, kernel, bias, padding, stride, dilation,
                grad_output, grad_input, grad_kernel, grad_bias)
```

Forward convolution works fine