### PR TITLE
[Docs] fix overlap of ')' into 2nd col of Tensor / CUDATensor tab

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -158,28 +158,28 @@ integers, string, boolean or any custom object.
 Here is a comparative table, not that this feature set is developing
 very rapidly.
 
-------------------------------------------------- --------- ---------------------------------------------------------------
- Action                                           Tensor    CudaTensor
-------------------------------------------------- --------- ---------------------------------------------------------------
- Accessing tensor properties                      [x]       [x]
- Tensor creation                                  [x]       by converting a cpu Tensor
- Accessing or modifying a single value            [x]       []
- Iterating on a Tensor                            [x]       []
- Slicing a Tensor                                 [x]       [x]
- Slice mutation ``a[1,_] = 10``                   [x]       []
- Comparison ``==``                                [x]       Coming soon
- Element-wise basic operations                    [x]       [x]
- Universal functions                              [x]       [x]
- Automatically broadcasted operations             [x]       Coming soon
- Matrix-Matrix and Matrix vector multiplication   [x]       [x] Note: sliced CudaTensors must explicitly be made contiguous
- Displaying a tensor                              [x]       [x]
- Higher-order functions (map, apply, reduce, fold)[x]       Apply, but only for internal use
- Transposing                                      [x]       [x]
- Converting to contiguous                         [x]       [x]
- Reshaping                                        [x]       []
- Explicit broadcast                               [x]       Coming soon
- Permuting dimensions                             [x]       Coming soon
- Concatenating along existing dimensions          [x]       []
- Squeezing singleton dimensions                   [x]       Coming soon
- Slicing + squeezing in one operation             [x]       Coming soon
-------------------------------------------------- --------- ---------------------------------------------------------------
+-------------------------------------------------- --------- ---------------------------------------------------------------
+ Action                                            Tensor    CudaTensor
+-------------------------------------------------- --------- ---------------------------------------------------------------
+ Accessing tensor properties                       [x]       [x]
+ Tensor creation                                   [x]       by converting a cpu Tensor
+ Accessing or modifying a single value             [x]       []
+ Iterating on a Tensor                             [x]       []
+ Slicing a Tensor                                  [x]       [x]
+ Slice mutation ``a[1,_] = 10``                    [x]       []
+ Comparison ``==``                                 [x]       Coming soon
+ Element-wise basic operations                     [x]       [x]
+ Universal functions                               [x]       [x]
+ Automatically broadcasted operations              [x]       Coming soon
+ Matrix-Matrix and Matrix vector multiplication    [x]       [x] Note: sliced CudaTensors must explicitly be made contiguous
+ Displaying a tensor                               [x]       [x]
+ Higher-order functions (map, apply, reduce, fold) [x]       Apply, but only for internal use
+ Transposing                                       [x]       [x]
+ Converting to contiguous                          [x]       [x]
+ Reshaping                                         [x]       []
+ Explicit broadcast                                [x]       Coming soon
+ Permuting dimensions                              [x]       Coming soon
+ Concatenating along existing dimensions           [x]       []
+ Squeezing singleton dimensions                    [x]       Coming soon
+ Slicing + squeezing in one operation              [x]       Coming soon
+-------------------------------------------------- --------- ---------------------------------------------------------------


### PR DESCRIPTION
While looking at your r/nim post about 0.3.0 (nice!), I noticed a small issue in the docs. In the table comparing the features of Tensors and CudaTensors, the closing parenthesis of one row overlaps into the 2nd column.

Just thought I'd fix that real quick.