### PR TITLE
Autograd no cyclic strong ref

### DIFF
--- a/examples/ex02_handwritten_digits_recognition.nim
+++ b/examples/ex02_handwritten_digits_recognition.nim
@@ -1,4 +1,4 @@
-import ../src/arraymancer
+import ../src/arraymancer, random
 
 # This is an early minimum viable example of handwritten digits recognition.
 # It uses convolutional neural networks to achieve high accuracy.
@@ -10,6 +10,9 @@ import ../src/arraymancer
 # In the future, model, weights and optimizer definition will be streamlined.
 # Also, currently this only works on Nim 0.17.2
 # until I debug the new Nim allocator introduced in November 2017 in devel branch.
+
+# Make the results reproducible by initializing a random seed
+randomize(1337)
 
 let
   ctx = newContext Tensor[float32] # Autograd/neural network graph

--- a/src/autograd/ag_accessors.nim
+++ b/src/autograd/ag_accessors.nim
@@ -20,7 +20,6 @@ template `[]`*[TT](v: Variable[TT], args: varargs[untyped]): Variable[TT] =
   new result
 
   result.tape = v.tape
-  result.ancestor = v.ancestor
   result.value = v.value[args]
   result.grad = v.grad[args]
 

--- a/src/autograd/ag_accessors.nim
+++ b/src/autograd/ag_accessors.nim
@@ -19,7 +19,7 @@ template `[]`*[TT](v: Variable[TT], args: varargs[untyped]): Variable[TT] =
   var result: type(v)
   new result
 
-  result.tape = v.tape
+  result.context = v.context
   result.value = v.value[args]
   result.grad = v.grad[args]
 

--- a/src/autograd/ag_data_structure.nim
+++ b/src/autograd/ag_data_structure.nim
@@ -35,7 +35,7 @@ type
   Variable*[TT] = ref VariableObj[TT]
     ## A variable is a wrapper for Tensors that tracks operations applied to it.
     ## It consists of:
-    ##    - A record of operations ``context``
+    ##    - A weak reference to a record of operations ``context``
     ##    - The tensor being tracked ``value``
     ##    - The gradient of the tensor ``grad``
     ##
@@ -116,22 +116,22 @@ proc weakRef*[TT](ctx: Context[TT]): ContextPtr[TT] {.inline.} =
   ## to avoid strong cyclic references.
   cast[ContextPtr[TT]](ctx)
 
-proc len[TT](ctx: ContextPtr[TT]): int {.inline.}=
+proc len[TT](ctx: ContextPtr[TT]): int {.noSideEffect, inline.}=
   ## Returns the number of operations applied in the context
   ctx.nodes.len()
 
-proc push*[TT](ctx: ContextPtr[TT], node: Node[TT]) {.inline.}= #TODO: how not to export that
+proc push*[TT](ctx: ContextPtr[TT], node: Node[TT]) {.noSideEffect, inline.}=
   ## Append a new operation to the context
   ctx.nodes.add(node)
 
-proc peek[TT](ctx: ContextPtr[TT]): Node[TT] {.inline.}=
+proc peek[TT](ctx: ContextPtr[TT]): Node[TT] {.noSideEffect, inline.}=
   ctx.nodes[ctx.len - 1]
 
-proc pop[TT](ctx: ContextPtr[TT]): Node[TT] {.inline.}=
+proc pop[TT](ctx: ContextPtr[TT]): Node[TT] {.noSideEffect, inline.}=
   ctx.nodes.pop
 
 proc check_ctx*(a, b: Variable) {.noSideEffect, inline.} =
-  if unlikely(a.context != b.context): # Compare pointer address directly
+  if unlikely(a.context != b.context):
     raise newException(ValueError, "You cannot combine variable from different contexts")
 
 proc backprop*[TT](v: Variable[TT]) =

--- a/src/autograd/ag_data_structure.nim
+++ b/src/autograd/ag_data_structure.nim
@@ -74,7 +74,7 @@ type
     parents*: Parents[TT]
     payload*: Variable[TT]
 
-  Parents*[TT] = array[MAX_NB_GRADS, VariablePtr[TT]]
+  Parents[TT] = array[MAX_NB_GRADS, VariablePtr[TT]]
   SmallDiffs*[TT] = array[MAX_NB_GRADS, TT]
 
 # Somehow if you declare forward before backward, you get invalid declaration order

--- a/src/autograd/gates_basic.nim
+++ b/src/autograd/gates_basic.nim
@@ -40,7 +40,7 @@ proc `+`*[TT](a, b: Variable[TT]): Variable[TT] =
   # Gate
   var gate: AddGate[TT]
   new gate
-  gate.arity = 2
+  gate.nb_grads = 2
   gate.ab_shape = a.value.shape # Shape equality will be checked in the forward proc
 
   # Node
@@ -55,6 +55,6 @@ proc `+`*[TT](a, b: Variable[TT]): Variable[TT] =
 
   # Resulting var
   result = gate.forward(a, b)
-  node.child = result
+  node.payload = result
 
 

--- a/src/autograd/gates_basic.nim
+++ b/src/autograd/gates_basic.nim
@@ -48,8 +48,8 @@ proc `+`*[TT](a, b: Variable[TT]): Variable[TT] =
   new node
 
   node.gate = gate
-  node.parents[0] = a
-  node.parents[1] = b
+  node.parents[0] = a.weakRef
+  node.parents[1] = b.weakRef
 
   a.tape.push(node)
 

--- a/src/autograd/gates_basic.nim
+++ b/src/autograd/gates_basic.nim
@@ -55,7 +55,6 @@ proc `+`*[TT](a, b: Variable[TT]): Variable[TT] =
 
   # Resulting var
   result = gate.forward(a, b)
-  result.ancestor = node
   node.child = result
 
 

--- a/src/autograd/gates_basic.nim
+++ b/src/autograd/gates_basic.nim
@@ -25,7 +25,7 @@ type AddGate* {.final.} [TT] = ref object of Gate[TT]
 method forward*[TT](self: AddGate[TT], a, b: Variable[TT]): Variable[TT] {.inline, locks:0.}=
   new result
 
-  result.tape = a.tape
+  result.context = a.context
   result.value = a.value + b.value
   result.grad = zeros[getSubType(TT)](result.value.shape)
 
@@ -51,7 +51,7 @@ proc `+`*[TT](a, b: Variable[TT]): Variable[TT] =
   node.parents[0] = a.weakRef
   node.parents[1] = b.weakRef
 
-  a.tape.push(node)
+  a.context.push(node)
 
   # Resulting var
   result = gate.forward(a, b)

--- a/src/autograd/gates_blas.nim
+++ b/src/autograd/gates_blas.nim
@@ -55,5 +55,4 @@ proc `*`*[TT](a, b: Variable[TT]): Variable[TT] =
 
   # Resulting var
   result = gate.forward(a, b)
-  result.ancestor = node
   node.child = result

--- a/src/autograd/gates_blas.nim
+++ b/src/autograd/gates_blas.nim
@@ -39,7 +39,7 @@ proc `*`*[TT](a, b: Variable[TT]): Variable[TT] =
   # Gate
   var gate: MatMulGate[TT]
   new gate
-  gate.arity = 2
+  gate.nb_grads = 2
   gate.a = a # TODO use ref to avoid copy
   gate.b = b
 
@@ -55,4 +55,4 @@ proc `*`*[TT](a, b: Variable[TT]): Variable[TT] =
 
   # Resulting var
   result = gate.forward(a, b)
-  node.child = result
+  node.payload = result

--- a/src/autograd/gates_blas.nim
+++ b/src/autograd/gates_blas.nim
@@ -24,7 +24,7 @@ type MatMulGate* {.final.} [TT] = ref object of Gate[TT]
 method forward*[TT](self: MatMulGate[TT], a, b: Variable[TT]): Variable[TT] {.inline, locks:0.}=
   new result
 
-  result.tape = a.tape
+  result.context = a.context
   result.value = a.value * b.value
   result.grad = zeros[getSubType(TT)](result.value.shape)
 
@@ -51,7 +51,7 @@ proc `*`*[TT](a, b: Variable[TT]): Variable[TT] =
   node.parents[0] = a.weakRef
   node.parents[1] = b.weakRef
 
-  a.tape.push(node)
+  a.context.push(node)
 
   # Resulting var
   result = gate.forward(a, b)

--- a/src/autograd/gates_blas.nim
+++ b/src/autograd/gates_blas.nim
@@ -48,8 +48,8 @@ proc `*`*[TT](a, b: Variable[TT]): Variable[TT] =
   new node
 
   node.gate = gate
-  node.parents[0] = a
-  node.parents[1] = b
+  node.parents[0] = a.weakRef
+  node.parents[1] = b.weakRef
 
   a.tape.push(node)
 

--- a/src/autograd/gates_reduce.nim
+++ b/src/autograd/gates_reduce.nim
@@ -51,7 +51,7 @@ proc mean*[TT](a: Variable[TT]): Variable[TT] =
   new node
 
   node.gate = gate
-  node.parents[0] = a
+  node.parents[0] = a.weakRef
 
   a.tape.push(node)
 

--- a/src/autograd/gates_reduce.nim
+++ b/src/autograd/gates_reduce.nim
@@ -24,7 +24,7 @@ type MeanGate* {.final.} [TT] = ref object of Gate[TT]
 method forward*[TT](self: MeanGate[TT], a: Variable[TT]): Variable[TT] {.inline, locks:0.}=
   new result
 
-  result.tape = a.tape
+  result.context = a.context
   result.value = [a.value.mean].toTensor
 
   result.grad = zeros[getSubType(TT)](1)
@@ -53,7 +53,7 @@ proc mean*[TT](a: Variable[TT]): Variable[TT] =
   node.gate = gate
   node.parents[0] = a.weakRef
 
-  a.tape.push(node)
+  a.context.push(node)
 
   # Resulting var
   result = gate.forward(a)

--- a/src/autograd/gates_reduce.nim
+++ b/src/autograd/gates_reduce.nim
@@ -43,7 +43,7 @@ proc mean*[TT](a: Variable[TT]): Variable[TT] =
   # Gate
   var gate: MeanGate[TT]
   new gate
-  gate.arity = 1
+  gate.nb_grads = 1
   gate.a_shape = a.value.shape # TODO use ref to avoid copy
 
   # Node
@@ -57,4 +57,4 @@ proc mean*[TT](a: Variable[TT]): Variable[TT] =
 
   # Resulting var
   result = gate.forward(a)
-  node.child = result
+  node.payload = result

--- a/src/autograd/gates_reduce.nim
+++ b/src/autograd/gates_reduce.nim
@@ -57,5 +57,4 @@ proc mean*[TT](a: Variable[TT]): Variable[TT] =
 
   # Resulting var
   result = gate.forward(a)
-  result.ancestor = node
   node.child = result

--- a/src/nn/activation/relu.nim
+++ b/src/nn/activation/relu.nim
@@ -49,7 +49,6 @@ proc relu*[TT](a: Variable[TT]): Variable[TT] =
 
   # Resulting var
   result = gate.forward(a)
-  result.ancestor = node
   node.child = result
 
   # Caching for backprop

--- a/src/nn/activation/relu.nim
+++ b/src/nn/activation/relu.nim
@@ -43,7 +43,7 @@ proc relu*[TT](a: Variable[TT]): Variable[TT] =
   new node
 
   node.gate = gate
-  node.parents[0] = a
+  node.parents[0] = a.weakRef
 
   a.tape.push(node)
 

--- a/src/nn/activation/relu.nim
+++ b/src/nn/activation/relu.nim
@@ -22,7 +22,7 @@ type ReluActivation* {.final.} [TT] = ref object of Gate[TT]
 method forward*[TT](self: ReluActivation[TT], a: Variable[TT]): Variable[TT] {.inline, locks:0.}=
   new result
 
-  result.tape = a.tape
+  result.context = a.context
   result.value = relu a.value
   result.grad = zeros_like(result.value)
 
@@ -45,7 +45,7 @@ proc relu*[TT](a: Variable[TT]): Variable[TT] =
   node.gate = gate
   node.parents[0] = a.weakRef
 
-  a.tape.push(node)
+  a.context.push(node)
 
   # Resulting var
   result = gate.forward(a)

--- a/src/nn/activation/relu.nim
+++ b/src/nn/activation/relu.nim
@@ -36,7 +36,7 @@ proc relu*[TT](a: Variable[TT]): Variable[TT] =
   # Gate
   var gate: ReluActivation[TT]
   new gate
-  gate.arity = 1
+  gate.nb_grads = 1
 
   # Node
   var node: Node[TT]
@@ -49,7 +49,7 @@ proc relu*[TT](a: Variable[TT]): Variable[TT] =
 
   # Resulting var
   result = gate.forward(a)
-  node.child = result
+  node.payload = result
 
   # Caching for backprop
   gate.cache = result.value

--- a/src/nn/activation/sigmoid.nim
+++ b/src/nn/activation/sigmoid.nim
@@ -43,7 +43,7 @@ proc sigmoid*[TT](a: Variable[TT]): Variable[TT] =
   new node
 
   node.gate = gate
-  node.parents[0] = a
+  node.parents[0] = a.weakRef
 
   a.tape.push(node)
 

--- a/src/nn/activation/sigmoid.nim
+++ b/src/nn/activation/sigmoid.nim
@@ -22,7 +22,7 @@ type SigmoidActivation* {.final.} [TT] = ref object of Gate[TT]
 method forward*[TT](self: SigmoidActivation[TT], a: Variable[TT]): Variable[TT] {.inline, locks:0.}=
   new result
 
-  result.tape = a.tape
+  result.context = a.context
   result.value = sigmoid a.value
   result.grad = zeros_like(result.value)
 
@@ -45,7 +45,7 @@ proc sigmoid*[TT](a: Variable[TT]): Variable[TT] =
   node.gate = gate
   node.parents[0] = a.weakRef
 
-  a.tape.push(node)
+  a.context.push(node)
 
   # Resulting var
   result = gate.forward(a)

--- a/src/nn/activation/sigmoid.nim
+++ b/src/nn/activation/sigmoid.nim
@@ -36,7 +36,7 @@ proc sigmoid*[TT](a: Variable[TT]): Variable[TT] =
   # Gate
   var gate: SigmoidActivation[TT]
   new gate
-  gate.arity = 1
+  gate.nb_grads = 1
 
   # Node
   var node: Node[TT]
@@ -49,7 +49,7 @@ proc sigmoid*[TT](a: Variable[TT]): Variable[TT] =
 
   # Resulting var
   result = gate.forward(a)
-  node.child = result
+  node.payload = result
 
   # Caching for backprop
   gate.cache = result.value

--- a/src/nn/activation/sigmoid.nim
+++ b/src/nn/activation/sigmoid.nim
@@ -49,7 +49,6 @@ proc sigmoid*[TT](a: Variable[TT]): Variable[TT] =
 
   # Resulting var
   result = gate.forward(a)
-  result.ancestor = node
   node.child = result
 
   # Caching for backprop

--- a/src/nn/layers/conv2D.nim
+++ b/src/nn/layers/conv2D.nim
@@ -105,5 +105,4 @@ proc conv2d*[TT]( input, weight: Variable[TT],
 
   # Resulting var
   result = gate.forward(input)
-  result.ancestor = node
   node.child = result

--- a/src/nn/layers/conv2D.nim
+++ b/src/nn/layers/conv2D.nim
@@ -84,7 +84,7 @@ proc conv2d*[TT]( input, weight: Variable[TT],
   # Gate
   var gate: Conv2DGate[TT]
   new gate
-  gate.arity = if bias.isNil: 2 else: 3
+  gate.nb_grads = if bias.isNil: 2 else: 3
   gate.cached_input = input
   gate.weight = weight
   gate.bias = bias
@@ -105,4 +105,4 @@ proc conv2d*[TT]( input, weight: Variable[TT],
 
   # Resulting var
   result = gate.forward(input)
-  node.child = result
+  node.payload = result

--- a/src/nn/layers/conv2D.nim
+++ b/src/nn/layers/conv2D.nim
@@ -96,10 +96,10 @@ proc conv2d*[TT]( input, weight: Variable[TT],
   new node
 
   node.gate = gate
-  node.parents[0] = input
-  node.parents[1] = weight
+  node.parents[0] = input.weakRef
+  node.parents[1] = weight.weakRef
   if not bias.isNil:
-    node.parents[2] = bias
+    node.parents[2] = bias.weakRef
 
   input.tape.push(node)
 

--- a/src/nn/layers/conv2D.nim
+++ b/src/nn/layers/conv2D.nim
@@ -27,7 +27,7 @@ type Conv2DGate* {.final.} [TT] = ref object of Gate[TT]
 method forward*[TT](self: Conv2DGate[TT], a: Variable[TT]): Variable[TT] {.inline, locks:0.}=
   new result
 
-  result.tape = a.tape
+  result.context = a.context
   result.value = conv2D(self.cached_input.value,
                         self.weight.value,
                         self.bias.value, # Todo, case when there is no bias
@@ -101,7 +101,7 @@ proc conv2d*[TT]( input, weight: Variable[TT],
   if not bias.isNil:
     node.parents[2] = bias.weakRef
 
-  input.tape.push(node)
+  input.context.push(node)
 
   # Resulting var
   result = gate.forward(input)

--- a/src/nn/layers/layer.nim
+++ b/src/nn/layers/layer.nim
@@ -15,7 +15,7 @@
 import  ../../autograd/autograd
 
 type Layer*[TT] = ref object of Gate[TT]
-  ## Inherits from Gate (arity field)
+  ## Inherits from Gate (nb_grads field)
   ## Add required fields for gradient descent
   weight*: TT
   bias*: TT

--- a/src/nn/layers/linear.nim
+++ b/src/nn/layers/linear.nim
@@ -31,7 +31,7 @@ method forward*[TT](self: LinearGate[TT], input: Variable[TT]): Variable[TT] {.i
   else:
     linear(input.value, self.weight.value, self.bias.value, result.value)
 
-  result.tape = input.tape
+  result.context = input.context
   result.grad = zeros_like(result.value)
 
 method backward*[TT](self: LinearGate[TT], gradOutput: TT): SmallDiffs[TT] {.noInit, inline, locks:0.}=
@@ -105,7 +105,7 @@ proc linear*[TT](input, weight: Variable[TT], bias: Variable[TT] = nil): Variabl
   if not bias.isNil:
     node.parents[2] = bias.weakRef
 
-  input.tape.push(node)
+  input.context.push(node)
 
   # Resulting var
   result = gate.forward(input)

--- a/src/nn/layers/linear.nim
+++ b/src/nn/layers/linear.nim
@@ -109,5 +109,4 @@ proc linear*[TT](input, weight: Variable[TT], bias: Variable[TT] = nil): Variabl
 
   # Resulting var
   result = gate.forward(input)
-  result.ancestor = node
   node.child = result

--- a/src/nn/layers/linear.nim
+++ b/src/nn/layers/linear.nim
@@ -100,10 +100,10 @@ proc linear*[TT](input, weight: Variable[TT], bias: Variable[TT] = nil): Variabl
   new node
 
   node.gate = gate
-  node.parents[0] = input
-  node.parents[1] = weight
+  node.parents[0] = input.weakRef
+  node.parents[1] = weight.weakRef
   if not bias.isNil:
-    node.parents[2] = bias
+    node.parents[2] = bias.weakRef
 
   input.tape.push(node)
 

--- a/src/nn/layers/linear.nim
+++ b/src/nn/layers/linear.nim
@@ -90,7 +90,7 @@ proc linear*[TT](input, weight: Variable[TT], bias: Variable[TT] = nil): Variabl
   # Gate
   var gate: LinearGate[TT]
   new gate
-  gate.arity = if bias.isNil: 2 else: 3
+  gate.nb_grads = if bias.isNil: 2 else: 3
   gate.input = input
   gate.weight = weight
   gate.bias = bias
@@ -109,4 +109,4 @@ proc linear*[TT](input, weight: Variable[TT], bias: Variable[TT] = nil): Variabl
 
   # Resulting var
   result = gate.forward(input)
-  node.child = result
+  node.payload = result

--- a/src/nn/layers/maxpool2D.nim
+++ b/src/nn/layers/maxpool2D.nim
@@ -77,7 +77,7 @@ proc maxpool2d*[TT](input: Variable[TT],
   new node
 
   node.gate = gate
-  node.parents[0] = input
+  node.parents[0] = input.weakRef
 
   input.tape.push(node)
 

--- a/src/nn/layers/maxpool2D.nim
+++ b/src/nn/layers/maxpool2D.nim
@@ -83,5 +83,4 @@ proc maxpool2d*[TT](input: Variable[TT],
 
   # Resulting var
   result = gate.forward(input)
-  result.ancestor = node
   node.child = result

--- a/src/nn/layers/maxpool2D.nim
+++ b/src/nn/layers/maxpool2D.nim
@@ -25,7 +25,7 @@ type MaxPool2DGate* {.final.} [TT] = ref object of Gate[TT]
 method forward*[TT](self: MaxPool2DGate[TT], a: Variable[TT]): Variable[TT] {.inline, locks:0.}=
   new result
 
-  result.tape = a.tape
+  result.context = a.context
   (self.cached_max_indices, result.value) = maxpool2d(a.value,
                                                       self.kernel,
                                                       self.padding,
@@ -79,7 +79,7 @@ proc maxpool2d*[TT](input: Variable[TT],
   node.gate = gate
   node.parents[0] = input.weakRef
 
-  input.tape.push(node)
+  input.context.push(node)
 
   # Resulting var
   result = gate.forward(input)

--- a/src/nn/layers/maxpool2D.nim
+++ b/src/nn/layers/maxpool2D.nim
@@ -66,7 +66,7 @@ proc maxpool2d*[TT](input: Variable[TT],
   # Gate
   var gate: MaxPool2DGate[TT]
   new gate
-  gate.arity = 1
+  gate.nb_grads = 1
   gate.cached_input_shape = input.value.shape
   gate.kernel = kernel
   gate.padding = padding
@@ -83,4 +83,4 @@ proc maxpool2d*[TT](input: Variable[TT],
 
   # Resulting var
   result = gate.forward(input)
-  node.child = result
+  node.payload = result

--- a/src/nn/loss/cross_entropy_losses.nim
+++ b/src/nn/loss/cross_entropy_losses.nim
@@ -60,7 +60,6 @@ template gen_cross_entropy_loss(LossType, forward_proc, backward_proc: untyped) 
 
     # Resulting var
     result = gate.forward(a, target)
-    result.ancestor = node
     node.child = result
 
 gen_cross_entropy_loss SigmoidCrossEntropyLoss, sigmoid_cross_entropy, sigmoid_cross_entropy_backward
@@ -107,5 +106,4 @@ proc sparse_softmax_crossentropy*[TT](a: Variable[TT], target: Tensor[int]): Var
 
   # Resulting var
   result = gate.forward(a, target)
-  result.ancestor = node
   node.child = result

--- a/src/nn/loss/cross_entropy_losses.nim
+++ b/src/nn/loss/cross_entropy_losses.nim
@@ -30,7 +30,7 @@ template gen_cross_entropy_loss(LossType, forward_proc, backward_proc: untyped) 
     # We expect a in shape [batch_size, features]
 
     new result
-    result.tape = a.tape
+    result.context = a.context
 
     # TODO: implement a Scalar[T] concept instead of rewrapping the result into a Tensor
     result.value = [forward_proc(a.value, target)].toTensor
@@ -56,7 +56,7 @@ template gen_cross_entropy_loss(LossType, forward_proc, backward_proc: untyped) 
     node.gate = gate
     node.parents[0] = a.weakRef
 
-    a.tape.push(node)
+    a.context.push(node)
 
     # Resulting var
     result = gate.forward(a, target)
@@ -76,7 +76,7 @@ method forward*[TT](self: SparseSoftmaxCrossEntropyLoss[TT], a: Variable[TT], ta
   # We expect a in shape [batch_size, features]
 
   new result
-  result.tape = a.tape
+  result.context = a.context
 
   # TODO: implement a Scalar[T] concept instead of rewrapping the result into a Tensor
   result.value = [sparse_softmax_crossentropy(a.value, target)].toTensor
@@ -102,7 +102,7 @@ proc sparse_softmax_crossentropy*[TT](a: Variable[TT], target: Tensor[int]): Var
   node.gate = gate
   node.parents[0] = a.weakRef
 
-  a.tape.push(node)
+  a.context.push(node)
 
   # Resulting var
   result = gate.forward(a, target)

--- a/src/nn/loss/cross_entropy_losses.nim
+++ b/src/nn/loss/cross_entropy_losses.nim
@@ -23,7 +23,7 @@ template gen_cross_entropy_loss(LossType, forward_proc, backward_proc: untyped) 
 
   type `LossType`* {.inject, final.} [TT] = ref object of Loss[TT]
     cache: Variable[TT]
-    # arity, from Gate
+    # nb_grads, from Gate
     # target, from Loss
 
   method forward*[TT](self: LossType[TT], a: Variable[TT], target: TT): Variable[TT] {.inline, locks:0.}=
@@ -45,7 +45,7 @@ template gen_cross_entropy_loss(LossType, forward_proc, backward_proc: untyped) 
     # Gate
     var gate: LossType[TT]
     new gate
-    gate.arity = 1
+    gate.nb_grads = 1
     gate.cache = a
     gate.target = target
 
@@ -60,7 +60,7 @@ template gen_cross_entropy_loss(LossType, forward_proc, backward_proc: untyped) 
 
     # Resulting var
     result = gate.forward(a, target)
-    node.child = result
+    node.payload = result
 
 gen_cross_entropy_loss SigmoidCrossEntropyLoss, sigmoid_cross_entropy, sigmoid_cross_entropy_backward
 gen_cross_entropy_loss SoftmaxCrossEntropyLoss, softmax_cross_entropy, softmax_cross_entropy_backward
@@ -69,7 +69,7 @@ gen_cross_entropy_loss SoftmaxCrossEntropyLoss, softmax_cross_entropy, softmax_c
 
 type SparseSoftmaxCrossEntropyLoss* {.final.} [TT] = ref object of SparseLoss[TT]
   cache: Variable[TT]
-  # arity, from Gate
+  # nb_grads, from Gate
   # target, from Loss
 
 method forward*[TT](self: SparseSoftmaxCrossEntropyLoss[TT], a: Variable[TT], target: Tensor[int]): Variable[TT] {.inline, locks:0.}=
@@ -91,7 +91,7 @@ proc sparse_softmax_crossentropy*[TT](a: Variable[TT], target: Tensor[int]): Var
   # Gate
   var gate: SparseSoftmaxCrossEntropyLoss[TT]
   new gate
-  gate.arity = 1
+  gate.nb_grads = 1
   gate.cache = a
   gate.target = target
 
@@ -106,4 +106,4 @@ proc sparse_softmax_crossentropy*[TT](a: Variable[TT], target: Tensor[int]): Var
 
   # Resulting var
   result = gate.forward(a, target)
-  node.child = result
+  node.payload = result

--- a/src/nn/loss/cross_entropy_losses.nim
+++ b/src/nn/loss/cross_entropy_losses.nim
@@ -54,7 +54,7 @@ template gen_cross_entropy_loss(LossType, forward_proc, backward_proc: untyped) 
     new node
 
     node.gate = gate
-    node.parents[0] = a
+    node.parents[0] = a.weakRef
 
     a.tape.push(node)
 
@@ -100,7 +100,7 @@ proc sparse_softmax_crossentropy*[TT](a: Variable[TT], target: Tensor[int]): Var
   new node
 
   node.gate = gate
-  node.parents[0] = a
+  node.parents[0] = a.weakRef
 
   a.tape.push(node)
 

--- a/src/nn/shapeshifting/reshape_flatten.nim
+++ b/src/nn/shapeshifting/reshape_flatten.nim
@@ -23,7 +23,7 @@ type ReshapeGate* [TT] = ref object of Gate[TT]
 method forward*[TT](self: ReshapeGate[TT], a: Variable[TT]): Variable[TT] {.inline, locks:0.}=
   new result
 
-  result.tape = a.tape
+  result.context = a.context
   result.value = a.value.reshape(self.cached_output_shape)
   result.grad = zeros_like(result.value)
 
@@ -45,7 +45,7 @@ proc reshapeT[TT](a: Variable[TT], shape: MetadataArray): Variable[TT] =
   node.gate = gate
   node.parents[0] = a.weakRef
 
-  a.tape.push(node)
+  a.context.push(node)
 
   # Resulting var
   result = gate.forward(a)

--- a/src/nn/shapeshifting/reshape_flatten.nim
+++ b/src/nn/shapeshifting/reshape_flatten.nim
@@ -34,7 +34,7 @@ proc reshapeT[TT](a: Variable[TT], shape: MetadataArray): Variable[TT] =
   # Gate
   var gate: ReshapeGate[TT]
   new gate
-  gate.arity = 1
+  gate.nb_grads = 1
   gate.cached_input_shape = a.value.shape
   gate.cached_output_shape = shape
 
@@ -49,7 +49,7 @@ proc reshapeT[TT](a: Variable[TT], shape: MetadataArray): Variable[TT] =
 
   # Resulting var
   result = gate.forward(a)
-  node.child = result
+  node.payload = result
 
 
 proc reshape*[TT](a: Variable[TT], shape: varargs[int]): Variable[TT] =

--- a/src/nn/shapeshifting/reshape_flatten.nim
+++ b/src/nn/shapeshifting/reshape_flatten.nim
@@ -43,7 +43,7 @@ proc reshapeT[TT](a: Variable[TT], shape: MetadataArray): Variable[TT] =
   new node
 
   node.gate = gate
-  node.parents[0] = a
+  node.parents[0] = a.weakRef
 
   a.tape.push(node)
 

--- a/src/nn/shapeshifting/reshape_flatten.nim
+++ b/src/nn/shapeshifting/reshape_flatten.nim
@@ -49,7 +49,6 @@ proc reshapeT[TT](a: Variable[TT], shape: MetadataArray): Variable[TT] =
 
   # Resulting var
   result = gate.forward(a)
-  result.ancestor = node
   node.child = result
 
 


### PR DESCRIPTION
Remove cyclical references in autograd to improve garbage collection and performance.

Autograd performance is now significantly faster.

Unfortunately this does not solve https://github.com/mratsim/Arraymancer/issues/178 on the MNIST example.

Probably a way to tell the autograd not to compute gradient during inference/validation is missing.