### PR TITLE
Template substitution will trigger proc parameters multiple times

### DIFF
--- a/src/autograd/ag_accessors.nim
+++ b/src/autograd/ag_accessors.nim
@@ -16,14 +16,23 @@ import ../tensor/tensor,
        ./ag_data_structure
 
 template `[]`*[TT](v: Variable[TT], args: varargs[untyped]): Variable[TT] =
+  ## Slice the tensor contained by the dynamic graph Variable
+  ## Input:
+  ##   - a Variable
+  ## Output:
+  ##   - a sliced Variable
+
+  # Ensure that v is only called once even if it's a function with side-effects
+  let z = v
+
   # TODO: backprop support
-  var result: type(v)
+  var result: type(z)
   new result
 
-  result.context = v.context
-  result.value = v.value[args]
-  result.grad = v.grad[args]
-  result.requires_grad = v.requires_grad
+  result.context = z.context
+  result.value = z.value[args]
+  result.grad = z.grad[args]
+  result.requires_grad = z.requires_grad
 
   result
 

--- a/src/private/functional.nim
+++ b/src/private/functional.nim
@@ -15,54 +15,6 @@
 # Functional programming and iterator tooling
 import sequtils
 
-template scanr*[T](s: seq[T], operation: untyped): untyped =
-  ## Template to scan a sequence from right to left, returning the accumulation and intermediate values.
-  ## This is a foldr with intermediate steps returned
-
-  ## @[2, 2, 3, 4].scanr(a * b) = @[48, 24, 12, 4]
-  let len = s.len
-
-  assert len > 0, "Can't scan empty sequences"
-  var result = newSeq[T](len)
-
-  result[result.high] = s[s.high]
-  for i in countdown(len - 1, 1):
-    let
-      a {.inject.} = s[i-1]
-      b {.inject.} = result[i]
-    result[i-1] = operation
-  result
-
-template scanl*[T](s: seq[T], operation: untyped): untyped =
-  ## Template to scan a sequence from left to right, returning the accumulation and intermediate values.
-  ## This is a foldl with intermediate steps returned
-
-  ## @[2, 2, 3, 4].scanl(a * b) = @[2, 4, 12, 48]
-  let len = s.len
-
-  assert len > 0, "Can't scan empty sequences"
-  var result = newSeq[T](len)
-
-  result[0] = s[0]
-  for i in 1..s.high:
-    let
-      a {.inject.} = s[i]
-      b {.inject.} = result[i-1]
-    result[i] = operation
-  result
-
-iterator zip*[T1, T2](a: openarray[T1], b: openarray[T2]): (T1,T2) {.noSideEffect.} =
-  ## Transform two lists in a list of tuples.
-  ## Length of result will be the length of the smallest list, items from the longest will be discarded.
-  let len = min(a.len, b.len)
-
-  for i in 0..<len:
-    yield (a[i], b[i])
-
-template product*[T: SomeNumber](s: seq[T]): T =
-  ## Get the product of all numbers in a sequence or array
-  s.foldl(a*b)
-
 proc concatMap*[T](s: seq[T], f: proc(ss: T):string): string  {.noSideEffect.}=
   ## Map a function to a sequence of T and concatenate the result as string
   return s.foldl(a & f(b), "")

--- a/src/tensor/data_structure.nim
+++ b/src/tensor/data_structure.nim
@@ -120,7 +120,7 @@ proc `data=`*[T](t: var Tensor[T], s: seq[T]) {.inline, noSideEffect.}=
 # Tensor Metadata
 # ################
 
-template rank*(t: AnyTensor): int =
+proc rank*(t: AnyTensor): int {.noSideEffect, inline.}=
   ## Input:
   ##     - A tensor
   ## Returns:

--- a/src/tensor/optim_ops_fusion.nim
+++ b/src/tensor/optim_ops_fusion.nim
@@ -77,7 +77,7 @@ template rewriteTensor_MultiplyAdd_inplace*{C += `*`(A,B)}[T](
 #################################################
 ## initialization
 
-template toTensorReshapeT(oa: typed, shape: varargs[int]): untyped = 
+template toTensorReshapeImpl(oa: typed, shape: varargs[int]): untyped =
   let data = toSeq(flatIter(oa))
   let seq_shape = shape.toMetadataArray
 
@@ -94,14 +94,14 @@ proc toTensorReshape(oa: string, shape: varargs[int]): auto {.noInit,noSideEffec
   ##
   ## Deal specifically with strings/seq[char]
 
-  toTensorReshapeT(oa, shape)
+  toTensorReshapeImpl(oa, shape)
 
 proc toTensorReshape(oa: openarray, shape: varargs[int], dummy_bugfix: static[int] = 0): auto {.noInit,noSideEffect.}=
   ## Fuse toTensor and reshape in one operation
   ##
   # Dummy_bugfix param is necessary due to: https://github.com/nim-lang/Nim/issues/6343
   # TODO: remove 'dummy_bugfix'
-  toTensorReshapeT(oa, shape)
+  toTensorReshapeImpl(oa, shape)
 
 template rewriteToTensorReshape*{reshape(toTensor(oa, dummy_bugfix), shape)}(
   oa: openarray,

--- a/src/tensor/private/p_init_cpu.nim
+++ b/src/tensor/private/p_init_cpu.nim
@@ -19,15 +19,15 @@ import  ../../private/nested_containers,
         nimblas,
         sequtils
 
-template tensorCpu*[T](out_shape: varargs[int], t: Tensor[T], layout: OrderType = rowMajor): untyped =
-  t.shape.copyFrom(out_shape)
-  shape_to_strides(t.shape, layout, t.strides)
-  t.offset = 0
+proc tensorCpu*[T](out_shape: varargs[int], result: var Tensor[T], layout: OrderType = rowMajor) {.inline, noSideEffect.} =
+  result.shape.copyFrom(out_shape)
+  shape_to_strides(result.shape, layout, result.strides)
+  result.offset = 0
 
-template tensorCpu*[T](out_shape: MetadataArray, t: Tensor[T], layout: OrderType = rowMajor): untyped =
-  t.shape.copyFrom(out_shape)
-  shape_to_strides(t.shape, layout, t.strides)
-  t.offset = 0
+proc tensorCpu*[T](out_shape: MetadataArray, result: var Tensor[T], layout: OrderType = rowMajor) {.inline, noSideEffect.} =
+  result.shape.copyFrom(out_shape)
+  shape_to_strides(result.shape, layout, result.strides)
+  result.offset = 0
 
 template toTensorCpu*(s: typed): untyped =
   let shape = s.shape

--- a/src/tensor/private/p_shapeshifting.nim
+++ b/src/tensor/private/p_shapeshifting.nim
@@ -20,7 +20,7 @@ import  ../../private/sequninit,
         ./p_checks,
         nimblas
 
-proc contiguousImpl*[T](t: Tensor[T], layout: OrderType, result: var Tensor[T]) {.noSideEffect.}=
+proc contiguousImpl*[T](t: Tensor[T], layout: OrderType, result: var Tensor[T]) =
   if layout == rowMajor:
     result = t.map_inline(x)
   else: # colMajor
@@ -29,7 +29,7 @@ proc contiguousImpl*[T](t: Tensor[T], layout: OrderType, result: var Tensor[T]) 
     apply2_inline(result, t):
       y
 
-proc reshape_with_copy*[T](t: Tensor[T], new_shape: varargs[int]|MetadataArray, result: var Tensor[T]) {.noSideEffect.}=
+proc reshape_with_copy*[T](t: Tensor[T], new_shape: varargs[int]|MetadataArray, result: var Tensor[T]) =
   result = newTensorUninit[T](new_shape)
   result.apply2_inline(t,y)
 
@@ -38,7 +38,7 @@ proc reshape_no_copy*(t: AnyTensor, new_shape: varargs[int]|MetadataArray, resul
   shape_to_strides(result.shape, rowMajor, result.strides)
   result.offset = t.offset
 
-proc reshapeImpl*(t: AnyTensor, new_shape: varargs[int]|MetadataArray, result: var AnyTensor) {.noSideEffect.}=
+proc reshapeImpl*(t: AnyTensor, new_shape: varargs[int]|MetadataArray, result: var AnyTensor) =
   when compileOption("boundChecks"):
     when new_shape is MetadataArray:
       check_reshape(t, new_shape)

--- a/src/tensor/private/p_shapeshifting.nim
+++ b/src/tensor/private/p_shapeshifting.nim
@@ -15,11 +15,12 @@
 import  ../../private/sequninit,
         ../backend/metadataArray,
         ../data_structure, ../higher_order_applymap,
+        ../init_cpu,
         ./p_init_cpu,
         ./p_checks,
         nimblas
 
-template contiguousImpl*[T](t: Tensor[T], layout: OrderType, result: var Tensor[T]): untyped=
+proc contiguousImpl*[T](t: Tensor[T], layout: OrderType, result: var Tensor[T]) {.noSideEffect.}=
   if layout == rowMajor:
     result = t.map_inline(x)
   else: # colMajor
@@ -28,16 +29,16 @@ template contiguousImpl*[T](t: Tensor[T], layout: OrderType, result: var Tensor[
     apply2_inline(result, t):
       y
 
-template reshape_with_copy*[T](t: Tensor[T], new_shape: varargs[int]|MetadataArray, result: var Tensor[T]) =
+proc reshape_with_copy*[T](t: Tensor[T], new_shape: varargs[int]|MetadataArray, result: var Tensor[T]) {.noSideEffect.}=
   result = newTensorUninit[T](new_shape)
   result.apply2_inline(t,y)
 
-template reshape_no_copy*(t: AnyTensor, new_shape: varargs[int]|MetadataArray, result: var AnyTensor) =
+proc reshape_no_copy*(t: AnyTensor, new_shape: varargs[int]|MetadataArray, result: var AnyTensor) {.noSideEffect.}=
   result.shape.copyFrom(new_shape)
   shape_to_strides(result.shape, rowMajor, result.strides)
   result.offset = t.offset
 
-template reshapeImpl*(t: AnyTensor, new_shape: varargs[int]|MetadataArray, result: var AnyTensor) =
+proc reshapeImpl*(t: AnyTensor, new_shape: varargs[int]|MetadataArray, result: var AnyTensor) {.noSideEffect.}=
   when compileOption("boundChecks"):
     when new_shape is MetadataArray:
       check_reshape(t, new_shape)
@@ -51,7 +52,7 @@ template reshapeImpl*(t: AnyTensor, new_shape: varargs[int]|MetadataArray, resul
 
   reshape_with_copy(t, new_shape, result)
 
-template broadcastImpl*(t: var AnyTensor, shape: varargs[int]|MetadataArray) =
+proc broadcastImpl*(t: var AnyTensor, shape: varargs[int]|MetadataArray) {.noSideEffect.}=
   when compileOption("boundChecks"):
     assert t.rank == shape.len
 
@@ -63,7 +64,7 @@ template broadcastImpl*(t: var AnyTensor, shape: varargs[int]|MetadataArray) =
     elif t.shape[i] != shape[i]:
       raise newException(ValueError, "The broadcasted size of the tensor must match existing size for non-singleton dimension")
 
-template broadcast2Impl*[T](a, b: AnyTensor[T], result: var tuple[a, b: AnyTensor[T]]) =
+proc broadcast2Impl*[T](a, b: AnyTensor[T], result: var tuple[a, b: AnyTensor[T]]) {.noSideEffect.}=
   let rank = max(a.rank, b.rank)
 
   var shapeA, stridesA, shapeB, stridesB = initMetadataArray(rank) # initialized with 0
@@ -111,7 +112,7 @@ proc exch_dim*[T](t: Tensor[T], dim1, dim2: int): Tensor[T] {.noInit,noSideEffec
   swap(result.strides[dim1], result.strides[dim2])
   swap(result.shape[dim1], result.shape[dim2])
 
-template permuteImpl*[T](result: var Tensor[T], dims: varargs[int]): untyped =
+proc permuteImpl*[T](result: var Tensor[T], dims: varargs[int]) {.noSideEffect.} =
   var perm = dims.toMetadataArray
   for i, p in perm:
     if p != i and p != -1:
@@ -124,7 +125,7 @@ template permuteImpl*[T](result: var Tensor[T], dims: varargs[int]): untyped =
       perm[j] = -1
 
 
-template squeezeImpl*(t: var AnyTensor): untyped =
+proc squeezeImpl*(t: var AnyTensor) {.noSideEffect.} =
   var idx_real_dim = 0
 
   for i in 0..<t.rank:
@@ -137,7 +138,7 @@ template squeezeImpl*(t: var AnyTensor): untyped =
   t.shape = t.shape[0..<idx_real_dim]
   t.strides = t.strides[0..<idx_real_dim]
 
-template squeezeImpl*(t: var AnyTensor, axis: int): untyped =
+proc squeezeImpl*(t: var AnyTensor, axis: int) {.noSideEffect.} =
   when compileOption("boundChecks"):
     check_squeezeAxis(t, axis)
 
@@ -145,7 +146,7 @@ template squeezeImpl*(t: var AnyTensor, axis: int): untyped =
     t.shape.delete(axis)
     t.strides.delete(axis)
 
-template unsqueezeImpl*(t: var AnyTensor, axis: int): untyped =
+proc unsqueezeImpl*(t: var AnyTensor, axis: int) {.noSideEffect.} =
   when compileOption("boundChecks"):
     check_unsqueezeAxis(t, axis)
 

--- a/src/tensor/shapeshifting.nim
+++ b/src/tensor/shapeshifting.nim
@@ -117,7 +117,7 @@ proc broadcast*[T: SomeNumber](val: T, shape: varargs[int]): Tensor[T] {.noInit,
   result.shape.copyFrom(shape)
   # result.strides # Unneeded, autoinitialized with 0
   result.offset = 0
-  result.data = newSeqWith(1, val)
+  result.data = @[val]
 
 proc broadcast*[T: SomeNumber](val: T, shape: MetadataArray): Tensor[T] {.noInit,noSideEffect.} =
   ## Broadcast a number
@@ -137,7 +137,7 @@ proc broadcast*[T: SomeNumber](val: T, shape: MetadataArray): Tensor[T] {.noInit
   result.shape.copyFrom(shape)
   # result.strides # Unneeded, autoinitialized with 0
   result.offset = 0
-  result.data = newSeqWith(1, val)
+  result.data = @[val]
 
 template bc*(t: (Tensor|SomeNumber), shape: varargs[int]): untyped =
   ## Alias for ``broadcast``
@@ -183,7 +183,7 @@ proc permute*(t: Tensor, dims: varargs[int]): Tensor {.noInit,noSideEffect.}=
   result = t
   permuteImpl(result, dims)
 
-proc concat*[T](t_list: varargs[Tensor[T]], axis: int): Tensor[T]  {.noInit,noSideEffect.}=
+proc concat*[T](t_list: varargs[Tensor[T]], axis: int): Tensor[T]  {.noInit.}=
   ## Concatenate tensors
   ## Input:
   ##   - Tensors

--- a/tests/end_to_end/examples.nim
+++ b/tests/end_to_end/examples.nim
@@ -1,0 +1,51 @@
+# Copyright (c) 2017-2018 the Arraymancer contributors
+# Licensed under the Apache License, version 2.0, ([LICENSE-APACHE](LICENSE) or http://www.apache.org/licenses/LICENSE-2.0)
+# This file may not be copied, modified, or distributed except according to those terms.
+
+import ../../src/arraymancer
+import unittest, random
+
+suite "End-to-End: Examples compile and run":
+  test "Example 1: XOR Perceptron":
+    let ctx = newContext Tensor[float32]
+
+    let bsz = 32
+    let x_train_bool = randomTensor([bsz * 10, 2], 2).astype(bool)
+    let y_bool = x_train_bool[_,0] xor x_train_bool[_,1]
+
+    let x_train = ctx.variable(x_train_bool.astype(float32))
+    let y = y_bool.astype(float32)
+
+    let layer_3neurons = ctx.variable(
+                          randomTensor(3, 2, 2.0f) .- 1.0f,
+                          requires_grad = true
+                          )
+
+    let classifier_layer = ctx.variable(
+                      randomTensor(1, 3, 2.0f) .- 1.0f,
+                      requires_grad = true
+                      )
+
+    let optim = newSGD[float32](
+      layer_3neurons, classifier_layer, 0.01f # 0.01 is the learning rate
+    )
+
+    for epoch in 0..1:
+      for batch_id in 0..<10:
+
+        let offset = batch_id * 32
+        let x = x_train[offset ..< offset + 32, _]
+        let target = y[offset ..< offset + 32, _]
+
+        let n1 = relu linear(x, layer_3neurons)
+        let n2 = linear(n1, classifier_layer)
+        let loss = sigmoid_cross_entropy(n2, target)
+
+        # echo "Epoch is:" & $epoch
+        # echo "Batch id:" & $batch_id
+        # echo "Loss is:" & $loss.value.data[0]
+
+        loss.backprop()
+
+        optim.update()
+

--- a/tests/tests_cpu.nim
+++ b/tests/tests_cpu.nim
@@ -34,4 +34,5 @@ import ../src/arraymancer,
         ./autograd/test_gate_blas,
         ./ml/test_metrics
 
-import ./stability_tests/test_stability_openmp
+import  ./stability_tests/test_stability_openmp,
+        ./end_to_end/examples


### PR DESCRIPTION
Due to how template substitution work, if an input is a proc, the proc will be called twice.

At best the compiler will detect that and replace that with a single call, at medium it will be slower or result in bigger binaries, at worst we may trigger side-effects twice or var parameter modification twice.

See #192 