### PR TITLE
fixed slicing in ex02

### DIFF
--- a/examples/ex02_handwritten_digits_recognition.nim
+++ b/examples/ex02_handwritten_digits_recognition.nim
@@ -120,10 +120,10 @@ for epoch in 0 ..< 5:
     var score = 0.0
     var loss = 0.0
     for i in 0 ..< 10:
-      let y_pred = X_test[i ..< i+1000, _].model.value.softmax.argmax(axis = 1).indices.squeeze
-      score += accuracy_score(y_test[i ..< i+1000, _], y_pred)
+      let y_pred = X_test[i*1000 ..< (i+1)*1000, _].model.value.softmax.argmax(axis = 1).indices.squeeze
+      score += accuracy_score(y_test[i*1000 ..< (i+1)*1000], y_pred)
 
-      loss += X_test[i ..< i+1000, _].model.sparse_softmax_cross_entropy(y_test[i ..< i+1000, _]).value.data[0]
+      loss += X_test[i*1000 ..< (i+1)*1000, _].model.sparse_softmax_cross_entropy(y_test[i*1000 ..< (i+1)*1000]).value.data[0]
     score /= 10
     loss /= 10
     echo "Accuracy: " & $(score * 100) & "%"


### PR DESCRIPTION
Partial fix for #197

I think the slicing in the accuracy check was also not quite as intended: Before, the loop `i in 0 ..< 10` would compute the accuracy on `0..<1000`, `1..<1001`, `2..<1002`, i.e., the test samples have a huge overlap. I changed the slicing to use disjoint blocks.

I'm wondering if the expression `i*1000 ..< (i+1)*1000` could be reused, because it has to be repeated 4 times. Is there a way to construct a stand-alone `SteppedSlice`? Simply writing `let test_slice = i*1000 ..< (i+1)*1000` will pick `..<` from system, so that doesn't work. Would be nice to have a special stand-alone constructor for Arraymancer slices like:

```nimrod
let test_slice = slice(i*1000 ..< (i+1)*1000) # macro similar to []
```