### PR TITLE
added rank check for slicer; should fix #197

### DIFF
--- a/src/tensor/init_cpu.nim
+++ b/src/tensor/init_cpu.nim
@@ -180,7 +180,7 @@ proc randomTensor*[T:SomeReal](shape: varargs[int], max: T): Tensor[T] {.noInit.
   ##      - a tensor backend
   ## Result:
   ##      - A tensor of the input shape filled with random value between 0 and max input value
-  randomTensorCpu(result, shape, max)
+  randomTensorCpu(result, shape, max-1)
 
 proc randomTensor*(shape: varargs[int], max: int): Tensor[int] {.noInit.} =
   ## Creates a new int Tensor filled with values between 0 and max-1.
@@ -192,7 +192,7 @@ proc randomTensor*(shape: varargs[int], max: int): Tensor[int] {.noInit.} =
   ##      - a tensor backend
   ## Result:
   ##      - A tensor of the input shape filled with random value between 0 and max input value (excluded)
-  randomTensorCpu(result, shape, max)
+  randomTensorCpu(result, shape, max-1)
 
 proc randomTensor*[T](shape: varargs[int], slice: Slice[T]): Tensor[T] {.noInit.} =
   ## Creates a new int Tensor filled with values in the Slice range.

--- a/src/tensor/private/p_accessors_macros_read.nim
+++ b/src/tensor/private/p_accessors_macros_read.nim
@@ -28,7 +28,7 @@ template slicerImpl*[T](result: AnyTensor[T]|var AnyTensor[T], slices: ArrayOfSl
     if unlikely(slices.len > result.rank):
       raise newException(
         IndexError,
-        &"Rank of slice expression ({slices.len}) is larger then the tensor rank ({result.rank})."
+        &"Rank of slice expression ({slices.len}) is larger than the tensor rank ({result.rank})."
       )
 
   for i, slice in slices:

--- a/src/tensor/private/p_accessors_macros_read.nim
+++ b/src/tensor/private/p_accessors_macros_read.nim
@@ -19,7 +19,7 @@ import  ../../private/ast_utils,
         ../data_structure, ../init_cpu, ../accessors_macros_syntax,
         ../backend/metadataArray,
         ./p_checks, ./p_accessors, ./p_accessors_macros_desugar,
-        sequtils, macros, strformat
+        sequtils, macros
 
 template slicerImpl*[T](result: AnyTensor[T]|var AnyTensor[T], slices: ArrayOfSlices): untyped =
   ## Slicing routine
@@ -28,7 +28,7 @@ template slicerImpl*[T](result: AnyTensor[T]|var AnyTensor[T], slices: ArrayOfSl
     if unlikely(slices.len > result.rank):
       raise newException(
         IndexError,
-        &"Rank of slice expression ({slices.len}) is larger than the tensor rank ({result.rank})."
+        "Rank of slice expression (" & $slices.len & ") is larger than the tensor rank (" & $result.rank & ")."
       )
 
   for i, slice in slices:

--- a/src/tensor/private/p_accessors_macros_read.nim
+++ b/src/tensor/private/p_accessors_macros_read.nim
@@ -19,10 +19,17 @@ import  ../../private/ast_utils,
         ../data_structure, ../init_cpu, ../accessors_macros_syntax,
         ../backend/metadataArray,
         ./p_checks, ./p_accessors, ./p_accessors_macros_desugar,
-        sequtils, macros
+        sequtils, macros, strformat
 
-template slicerImpl*[T](result: AnyTensor[T]|var AnyTensor[T], slices: ArrayOfSlices): untyped=
+template slicerImpl*[T](result: AnyTensor[T]|var AnyTensor[T], slices: ArrayOfSlices): untyped =
   ## Slicing routine
+
+  when compileOption("boundChecks"):
+    if unlikely(slices.len > result.rank):
+      raise newException(
+        IndexError,
+        &"Rank of slice expression ({slices.len}) is larger then the tensor rank ({result.rank})."
+      )
 
   for i, slice in slices:
     # Check if we start from the end
@@ -33,7 +40,7 @@ template slicerImpl*[T](result: AnyTensor[T]|var AnyTensor[T], slices: ArrayOfSl
             else: slice.b
 
     # Bounds checking
-    when compileOption("boundChecks"): check_steps(a,b, slice.step)
+    when compileOption("boundChecks"): check_steps(a, b, slice.step)
     ## TODO bounds-check the offset or leave the default?
     ## The default only checks when we retrieve the value
 

--- a/tests/end_to_end/examples.nim
+++ b/tests/end_to_end/examples.nim
@@ -10,7 +10,7 @@ suite "End-to-End: Examples compile and run":
     let ctx = newContext Tensor[float32]
 
     let bsz = 32
-    let x_train_bool = randomTensor([bsz * 10, 2], 2).astype(bool)
+    let x_train_bool = randomTensor([bsz * 10, 2], 1).astype(bool)
     let y_bool = x_train_bool[_,0] xor x_train_bool[_,1]
 
     let x_train = ctx.variable(x_train_bool.astype(float32))

--- a/tests/end_to_end/examples.nim
+++ b/tests/end_to_end/examples.nim
@@ -10,7 +10,7 @@ suite "End-to-End: Examples compile and run":
     let ctx = newContext Tensor[float32]
 
     let bsz = 32
-    let x_train_bool = randomTensor([bsz * 10, 1], 2).astype(bool)
+    let x_train_bool = randomTensor([bsz * 10, 2], 2).astype(bool)
     let y_bool = x_train_bool[_,0] xor x_train_bool[_,1]
 
     let x_train = ctx.variable(x_train_bool.astype(float32))


### PR DESCRIPTION
This produces an error message when the number of expressions in a slicer exceeds the tensor rank. For example: `Error: unhandled exception: Rank of slice expression (2) is larger than the tensor rank (1). [IndexError]`

Since the examples sometimes use less expressions in the slicer than the tensor rank, I assume that is allowed?