### PR TITLE
More tweaking of Euler benchmarks

### DIFF
--- a/benchmarks/euler_nativearray.nim
+++ b/benchmarks/euler_nativearray.nim
@@ -34,8 +34,9 @@ proc main() =
 
   for t in 0 ..< timeSteps:
     Ts[t][0] = startingTemp - oscillations * sin(2.0 * PI * t.float / timeSteps)
-    for s in 1 ..< spaceSteps:
-      Ts[t][s] = startingTemp
+
+  for s in 1 ..< spaceSteps:
+    Ts[0][s] = startingTemp
 
   Ts.eulerSolve()
   echo Ts[45_000][10]
@@ -50,7 +51,9 @@ let elapsed = stop - start
 echo &"Native array Euler solve - time taken: {elapsed} seconds"
 
 
-
 # Measurement on i7-970 (Hexa core 3.2GHz)
-# Native array Euler solve - time taken: 2.732873 seconds
-# 2.87s, 3816.5Mb
+# 42.0060796609176
+# 34.83783780774945
+# 29.89741051712985
+# Native array Euler solve - time taken: 1.59722 seconds
+# 1.61s, 3816.6Mb

--- a/benchmarks/euler_nativearray.nim
+++ b/benchmarks/euler_nativearray.nim
@@ -1,12 +1,13 @@
 import math, times, strformat
 
 const
-  dz = 0.01
-  z = 100
+  dz = 0.1
+  z = 1000
   spaceSteps = int(z / dz)
-  timeSteps = 50000
-  dt = 0.12 / timeSteps
-  alpha = 2.0
+  timeSteps = 50_000
+  totalTime = 1_000_000
+  dt = totalTime / timeSteps
+  alpha = 2e-4
   startingTemp = 30.0
   oscillations = 20.0
   a_dz2 = alpha / dz^2
@@ -37,6 +38,9 @@ proc main() =
       Ts[t][s] = startingTemp
 
   Ts.eulerSolve()
+  echo Ts[45_000][10]
+  echo Ts[45_000][100]
+  echo Ts[45_000][500]
 
 let start = cpuTime()
 main()
@@ -44,6 +48,7 @@ let stop = cpuTime()
 
 let elapsed = stop - start
 echo &"Native array Euler solve - time taken: {elapsed} seconds"
+
 
 
 # Measurement on i7-970 (Hexa core 3.2GHz)

--- a/benchmarks/euler_numpy.py
+++ b/benchmarks/euler_numpy.py
@@ -3,13 +3,13 @@ import time
 import numpy as np
 
 
-dz = 0.01
-z = 100
+dz = 0.1
+z = 1000
 space_steps = int(z / dz)
-
-time_steps = 50000
-dt = 0.12 / time_steps
-alpha = 2
+time_steps = 50_000
+total_time = 1_000_000
+dt = total_time / time_steps
+alpha = 2e-4
 starting_temp = 30
 oscillations = 20
 a_dz2 = alpha / dz**2
@@ -23,20 +23,21 @@ def euler_solve(Ts):
     for t in range(time_steps-1):
         Ts[t+1, 1:-1] = Ts[t, 1:-1] + dt * f(Ts[t])
         Ts[t+1, -1] = Ts[t+1, -2]
-    return Ts
+
 
 start = time.time()
-
-ts = np.linspace(0, 0.12, time_steps)
 
 start_iterspeed = time.time()
 Ts = starting_temp * np.ones((time_steps, space_steps), dtype=np.float64)
 stop_iterspeed = time.time()
 
-Ts[:, 0] = starting_temp - oscillations * np.sin(2 * np.pi * ts / 12)
+ts = np.linspace(0, time_steps, time_steps)
+Ts[:, 0] = starting_temp - oscillations * np.sin(2 * np.pi * ts)
 
-euler = euler_solve(Ts)
-
+euler_solve(Ts)
+print(Ts[45_000, 10])
+print(Ts[45_000, 100])
+print(Ts[45_000, 500])
 stop = time.time()
 
 print(sys.version)

--- a/benchmarks/euler_numpy.py
+++ b/benchmarks/euler_numpy.py
@@ -56,3 +56,13 @@ print("Numpy Euler solve - time taken: {} seconds".format(stop - start))
 # Numpy iteration speed - time taken: 2.673659086227417 seconds
 # Numpy Euler solve - time taken: 6.034733057022095 seconds
 # 6.49s, 3836.5Mb
+
+
+# Measurement on i7-970 (Hexa core 3.2GHz)
+# Python 3.6
+# 42.0046266041
+# 34.8379557903
+# 29.8974105039
+# Numpy iteration speed - time taken: 1.1823573112487793 seconds
+# Numpy Euler solve - time taken: 4.745648145675659 seconds
+# 4.96s, 3842.0Mb

--- a/benchmarks/euler_tensor.nim
+++ b/benchmarks/euler_tensor.nim
@@ -59,6 +59,8 @@ echo &"Arraymancer Euler solve - time taken: {elapsed} seconds"
 # xtime.rb - 27.86s, 3114.4Mb (multithreading counting woes?)
 
 # Measurement on i7-970 (Hexa core 3.2GHz)
-# Arraymancer Euler solve - time taken: 5.857952 seconds
-# 6.01s, 3882.8Mb
-
+# 42.0060796609176
+# 34.83783780774945
+# 29.89741051712985
+# Arraymancer Euler solve - time taken: 5.060707 seconds
+# 5.08s, 3882.8Mb

--- a/benchmarks/euler_tensor.nim
+++ b/benchmarks/euler_tensor.nim
@@ -8,12 +8,13 @@ proc getTime(): float =
     epochTime() # cpuTime count the sum of time on each CPU when multithreading.
 
 const
-  dz = 0.01
-  z = 100
+  dz = 0.1
+  z = 1000
   spaceSteps = int(z / dz)
-  timeSteps = 50000
-  dt = 0.12 / timeSteps
-  alpha = 2.0
+  timeSteps = 50_000
+  totalTime = 1_000_000
+  dt = totalTime / timeSteps
+  alpha = 2e-4
   startingTemp = 30.0
   oscillations = 20.0
   a_dz2 = alpha / dz^2
@@ -35,6 +36,10 @@ proc main() =
     Ts[j, 0] = startingTemp - oscillations * sin(2.0 * PI * j.float / timeSteps)
 
   Ts.eulerSolve()
+  echo Ts[45_000, 10]
+  echo Ts[45_000, 100]
+  echo Ts[45_000, 500]
+
 
 let start = getTime()
 main()

--- a/benchmarks/euler_tensor_optim.nim
+++ b/benchmarks/euler_tensor_optim.nim
@@ -8,12 +8,13 @@ proc getTime(): float =
     epochTime() # cpuTime count the sum of time on each CPU when multithreading.
 
 const
-  dz = 0.01
-  z = 100
+  dz = 0.1
+  z = 1000
   spaceSteps = int(z / dz)
-  timeSteps = 50000
-  dt = 0.12 / timeSteps
-  alpha = 2.0
+  timeSteps = 50_000
+  totalTime = 1_000_000
+  dt = totalTime / timeSteps
+  alpha = 2e-4
   startingTemp = 30.0
   oscillations = 20.0
   a_dz2 = alpha / dz^2
@@ -37,11 +38,13 @@ proc eulerSolve(Ts: var Tensor[float]) =
 proc main() =
   var Ts = newTensorWith[float]([timeSteps, spaceSteps], startingTemp)
 
-  var slice = Ts[_,0]
-  apply_inline(slice):
-    startingTemp - oscillations * sin(2.0 * PI * x.float / timeSteps)
+  for j in 0 ..< timeSteps:
+    Ts[j, 0] = startingTemp - oscillations * sin(2.0 * PI * j.float / timeSteps)
 
   Ts.eulerSolve()
+  echo Ts[45_000, 10]
+  echo Ts[45_000, 100]
+  echo Ts[45_000, 500]
 
 let start = getTime()
 main()

--- a/benchmarks/euler_tensor_optim.nim
+++ b/benchmarks/euler_tensor_optim.nim
@@ -62,8 +62,11 @@ echo &"Arraymancer Euler solve - time taken: {elapsed} seconds"
 # OpenMP slows things by a lot, probably due to false sharing with the non-contiguous slices.
 
 # Measurement on i7-970 (Hexa core 3.2GHz)
-# Arraymancer Euler solve - time taken: 5.857952 seconds
-# 6.01s, 3882.8Mb
+# 42.0060796609176
+# 34.83783780774945
+# 29.89741051712985
+# Arraymancer Euler solve - time taken: 5.060707 seconds
+# 5.08s, 3882.8Mb
 
 ###################################
 # Optimized version with no temporaries
@@ -71,3 +74,10 @@ echo &"Arraymancer Euler solve - time taken: {elapsed} seconds"
 # Single-threaded i5-5257U (Dual core mobile Broadwell 2.7Ghz)
 # Arraymancer Euler solve - time taken: 6.646692 seconds
 # 7.47s, 3037.2Mb
+
+# Measurement on i7-970 (Hexa core 3.2GHz)
+# 42.0060796609176
+# 34.83783780774945
+# 29.89741051712985
+# Arraymancer Euler solve - time taken: 2.085845 seconds
+# 2.10s, 3882.8Mb


### PR DESCRIPTION
* changed constants to more meaningful values
* `tensor_optim` was giving wrong output - quickfix (back to the old way of assigning the boundary condition)
* less assigning in `nativearray` version, making it even faster