### PR TITLE
fix random tensor

### DIFF
--- a/benchmarks/implementation/softmax_cross_entropy_bench_batch_first.nim
+++ b/benchmarks/implementation/softmax_cross_entropy_bench_batch_first.nim
@@ -260,7 +260,7 @@ let batch_size = 200
 let nb_classes = 100000
 
 # Create a sparse label tensor of shape: [batch_size]
-let sparse_labels = randomTensor(batch_size, nb_classes - 1)
+let sparse_labels = randomTensor(batch_size, nb_classes)
 
 # Create the corresponding dense label tensor of shape [batch_size, nb_classes]
 var labels = zeros[float64](batch_size, nb_classes)

--- a/benchmarks/implementation/softmax_cross_entropy_bench_batch_last.nim
+++ b/benchmarks/implementation/softmax_cross_entropy_bench_batch_last.nim
@@ -260,7 +260,7 @@ let batch_size = 200
 let nb_classes = 100000
 
 # Create a sparse label tensor of shape: [batch_size]
-let sparse_labels = randomTensor(batch_size, nb_classes-1)
+let sparse_labels = randomTensor(batch_size, nb_classes)
 
 # Create the corresponding dense label tensor of shape [nb_classes, batch_size]
 var labels = zeros[float64](nb_classes, batch_size)

--- a/src/tensor/init_cpu.nim
+++ b/src/tensor/init_cpu.nim
@@ -180,19 +180,19 @@ proc randomTensor*[T:SomeReal](shape: varargs[int], max: T): Tensor[T] {.noInit.
   ##      - a tensor backend
   ## Result:
   ##      - A tensor of the input shape filled with random value between 0 and max input value
-  randomTensorCpu(result, shape, max-1)
+  randomTensorCpu(result, shape, max)
 
 proc randomTensor*(shape: varargs[int], max: int): Tensor[int] {.noInit.} =
-  ## Creates a new int Tensor filled with values between 0 and max-1.
+  ## Creates a new int Tensor filled with values between 0 and max.
   ##
   ## Random seed can be set by importing ``random`` and ``randomize(seed)``
   ## Input:
   ##      - a shape
-  ##      - the max value possible (integer, exclusive)
+  ##      - the max value possible (integer, inclusive)
   ##      - a tensor backend
   ## Result:
   ##      - A tensor of the input shape filled with random value between 0 and max input value (excluded)
-  randomTensorCpu(result, shape, max-1)
+  randomTensorCpu(result, shape, max)
 
 proc randomTensor*[T](shape: varargs[int], slice: Slice[T]): Tensor[T] {.noInit.} =
   ## Creates a new int Tensor filled with values in the Slice range.


### PR DESCRIPTION
I fixed the issue yesterday by making the `randomTensor` keep its old behavior (sticking to the docstring). I have now changed it back to the breaking behavior and adjusted the docstring. There are more occurrences of `randomTensor` throughout the codebase, but in some cases it is not clear to me which convention is correct (probably it does not matter in some cases).