### PR TITLE
fix import of `tensor` in `nnp_numerical_gradient`

### DIFF
--- a/src/nn_primitives/nnp_numerical_gradient.nim
+++ b/src/nn_primitives/nnp_numerical_gradient.nim
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ../../src/tensor/tensor
+import ../tensor/tensor
 
 proc numerical_gradient*[T](input: T, f: (proc(x: T): T), h: T = 1e-5.T): T {.inline.} =
   ## Compute numerical gradient for any function w.r.t. to an input value,


### PR DESCRIPTION
Changes the import of `tensor` in `nnp_numerical_gradient` to be of the same kind as in the other files in the same folder.

Without this fix, I receive a 
```
~/.nimble/pkgs/arraymancer-0.3.90/nn_primitives/nnp_numerical_gradient.nim(15, 24) Error: cannot open '../../src/tensor/tensor'
```
if I import arraymancer in any file.