### PR TITLE
Add a transform boolean parameter to pca; update unit test.

### DIFF
--- a/src/ml/dimensionality_reduction/pca.nim
+++ b/src/ml/dimensionality_reduction/pca.nim
@@ -6,7 +6,7 @@ import
   ../../tensor/tensor, ../../linear_algebra/linear_algebra
 
 
-proc pca*[T: SomeReal](x: Tensor[T], nb_components = 2, transform: bool = true): tuple[results: Tensor[T], components: Tensor[T]] =
+proc pca*[T: SomeReal](x: Tensor[T], nb_components = 2): tuple[results: Tensor[T], components: Tensor[T]] {.noInit.} =
   ## Principal Component Analysis (PCA)
   ## Inputs:
   ##   - A matrix of shape [Nb of observations, Nb of features]
@@ -26,13 +26,10 @@ proc pca*[T: SomeReal](x: Tensor[T], nb_components = 2, transform: bool = true):
   let (_, eigvecs) = cov_matrix.symeig(true, ^nb_components .. ^1) # Note: eigvals/vecs are returned in ascending order
 
   # [Nb_obs, Nb_feats] * [Nb_feats, Nb_components], don't forget to reorder component in descending order
-  var
-    descending_eigvecs = eigvecs[_, ^1..0|-1]
-    pca_results = mean_centered * descending_eigvecs
+  result.components = eigvecs[_, ^1..0|-1]
+  result.results= mean_centered * result.components
 
-  return (pca_results, descending_eigvecs)
-
-proc pca*[T: SomeReal](x: Tensor[T], principal_axes: Tensor[T]): Tensor[T] =
+proc pca*[T: SomeReal](x: Tensor[T], principal_axes: Tensor[T]): Tensor[T] {.noInit.} =
   ## Principal Component Analysis (PCA) projection
   ## Inputs:
   ##    - A matrix of shape [Nb of observations, Nb of components]

--- a/src/ml/dimensionality_reduction/pca.nim
+++ b/src/ml/dimensionality_reduction/pca.nim
@@ -6,11 +6,14 @@ import
   ../../tensor/tensor, ../../linear_algebra/linear_algebra
 
 
-proc pca*[T: SomeReal](x: Tensor[T], nb_components = 2): Tensor[T] =
+proc pca*[T: SomeReal](x: Tensor[T], nb_components = 2, transform: bool = true): Tensor[T] =
   ## Principal Component Analysis (PCA)
   ## Inputs:
   ##   - A matrix of shape [Nb of observations, Nb of features]
   ##   - The number of components to keep (default 2D for 2D projection)
+  ##   - transform: whether or not to output the tensor or components:
+  ##     If transform: output the dimensionality reduced tensor
+  ##     Else output the first n principal components feature plane
   ##
   ## Returns:
   ##   - A matrix of shape [Nb of observations, Nb of components]
@@ -26,3 +29,19 @@ proc pca*[T: SomeReal](x: Tensor[T], nb_components = 2): Tensor[T] =
 
   # [Nb_obs, Nb_feats] * [Nb_feats, Nb_components], don't forget to reorder component in descending order
   result = mean_centered * eigvecs[_, ^1..0|-1]
+
+  if transform:
+    return result
+  else:
+    return eigvecs
+
+proc pca*[T: SomeReal](x: Tensor[T], principal_axes: Tensor[T]): Tensor[T] =
+  ## Principal Component Analysis (PCA) projection
+  ## Inputs:
+  ##    - A matrix of shape [Nb of observations, Nb of features]
+  ##    - A matrix of shape [Nb of observations, Nb of principal axes] to project on
+  ##
+  ## Returns:
+  ##    - A matrix of shape [Nb of observations, Nb of components]
+  let mean_centered = x .- x.mean(axis=0)
+  result = mean_centered * principal_axes[_, ^1..0|-1]

--- a/tests/ml/test_dimensionality_reduction.nim
+++ b/tests/ml/test_dimensionality_reduction.nim
@@ -46,8 +46,10 @@ suite "[ML] Dimensionality reduction":
                 [ 0.0,  1.0],
                 [-1.0, 0.0]].toTensor
 
-      let (val, components) = x.pca(2)
-      let transformed = x.pca(components)
+      let 
+        (val, components) = x.pca(2)
+        transformed = x.pca(components)
+
       check: transformed == val
 
       let expected = [[ 2.0,  0.0],

--- a/tests/ml/test_dimensionality_reduction.nim
+++ b/tests/ml/test_dimensionality_reduction.nim
@@ -20,7 +20,11 @@ suite "[ML] Dimensionality reduction":
                   [1.5, 1.6],
                   [1.1, 0.9]].toTensor
 
-      let val = data.pca(2)
+      let
+        (val, components) = data.pca(2)
+        transformed = data.pca(components)
+
+      check: transformed == val
 
       let expected = [[-0.827970186, -0.175115307],
                       [ 1.77758033,   0.142857227],
@@ -37,17 +41,14 @@ suite "[ML] Dimensionality reduction":
         check:  mean_absolute_error( val[_, col], expected[_, col]) < 1e-08 or
                 mean_absolute_error(-val[_, col], expected[_, col]) < 1e-08
 
-      # Test getting prinicpal components, then transforming
-      let principal_components = data.pca(nb_components = 2, transform = false)
-      let transformed = data.pca(principal_components)
-      check: transformed == val
-
     block: # https://www.cgg.com/technicaldocuments/cggv_0000014063.pdf
       let x =  [[ 1.0, -1.0],
                 [ 0.0,  1.0],
                 [-1.0, 0.0]].toTensor
 
-      let val = x.pca(2)
+      let (val, components) = x.pca(2)
+      let transformed = x.pca(components)
+      check: transformed == val
 
       let expected = [[ 2.0,  0.0],
                       [-1.0,  1.0],
@@ -56,8 +57,3 @@ suite "[ML] Dimensionality reduction":
       for col in 0..<2:
         check:  mean_absolute_error( val[_, col], expected[_, col]) < 1e-10 or
                 mean_absolute_error(-val[_, col], expected[_, col]) < 1e-10
-
-      # Test getting prinicpal components, then transforming
-      let principal_components = x.pca(nb_components = 2, transform = false)
-      let transformed = x.pca(principal_components)
-      check: transformed == val

--- a/tests/ml/test_dimensionality_reduction.nim
+++ b/tests/ml/test_dimensionality_reduction.nim
@@ -37,6 +37,11 @@ suite "[ML] Dimensionality reduction":
         check:  mean_absolute_error( val[_, col], expected[_, col]) < 1e-08 or
                 mean_absolute_error(-val[_, col], expected[_, col]) < 1e-08
 
+      # Test getting prinicpal components, then transforming
+      let principal_components = data.pca(nb_components = 2, transform = false)
+      let transformed = data.pca(principal_components)
+      check: transformed == val
+
     block: # https://www.cgg.com/technicaldocuments/cggv_0000014063.pdf
       let x =  [[ 1.0, -1.0],
                 [ 0.0,  1.0],
@@ -51,3 +56,8 @@ suite "[ML] Dimensionality reduction":
       for col in 0..<2:
         check:  mean_absolute_error( val[_, col], expected[_, col]) < 1e-10 or
                 mean_absolute_error(-val[_, col], expected[_, col]) < 1e-10
+
+      # Test getting prinicpal components, then transforming
+      let principal_components = x.pca(nb_components = 2, transform = false)
+      let transformed = x.pca(principal_components)
+      check: transformed == val


### PR DESCRIPTION
Add a simple boolean parameter to the pca proc, so that users can get the principal components in addition to transforming the input data.

I updated the unit tests as well.

@mratsim Originally you suggested `static[bool]` - which I can still try to add if you want? I was not sure how to call the method appropriately with that signature, in the test. 