### PR TITLE
replace all `SomeReal` by `SomeFloat`

### DIFF
--- a/benchmarks/implementation/logsumexp.nim
+++ b/benchmarks/implementation/logsumexp.nim
@@ -16,7 +16,7 @@ import times, ../../src/arraymancer, math, sequtils
 # - Streaming: from http://www.nowozin.net/sebastian/blog/streaming-log-sum-exp-computation.html
 # which is similar to Welford algorithm for streaming mean and variance in statistics
 
-proc logsumexp[T: SomeReal](t: Tensor[T]): T =
+proc logsumexp[T: SomeFloat](t: Tensor[T]): T =
   # Advantage:
   #  - OpenMP parallel
   #  - No branching in a tight loop
@@ -51,7 +51,7 @@ proc streaming_max_sumexp*[T](t: Tensor[T]): tuple[max:T, sumexp: T] {.noSideEff
       result.sumexp += 1
       result.max = x
 
-proc logsumexp_stream*[T: SomeReal](t: Tensor[T]): T =
+proc logsumexp_stream*[T: SomeFloat](t: Tensor[T]): T =
   # Advantage:
   #  - Only one loop over the data
   #  - Can be done "on-the-fly"

--- a/benchmarks/implementation/softmax_cross_entropy_bench_batch_first.nim
+++ b/benchmarks/implementation/softmax_cross_entropy_bench_batch_first.nim
@@ -70,12 +70,12 @@ proc classic_max_sumexp[T](t: Tensor[T], axis: int): Tensor[tuple[max:T, sumexp:
     result = result.unsqueeze(0)
 
 
-proc streaming_logsumexp[T: SomeReal](t: Tensor[T]): T =
+proc streaming_logsumexp[T: SomeFloat](t: Tensor[T]): T =
   # 1 pass but branching
   let (max, sumexp) = t.streaming_max_sumexp
   result = max + ln(sumexp)
 
-proc classic_logsumexp[T: SomeReal](t: Tensor[T]): T =
+proc classic_logsumexp[T: SomeFloat](t: Tensor[T]): T =
   # 2 pass but no branching
   let max = t.max # first loop over data
 
@@ -91,7 +91,7 @@ proc classic_logsumexp[T: SomeReal](t: Tensor[T]): T =
 
   result = max + ln(result)
 
-proc classic_logsumexp_v2[T: SomeReal](t: Tensor[T]): T =
+proc classic_logsumexp_v2[T: SomeFloat](t: Tensor[T]): T =
   # 2 pass no branching
   let (max, sumexp) = t.classic_max_sumexp
   result = max + ln(sumexp)

--- a/benchmarks/implementation/softmax_cross_entropy_bench_batch_last.nim
+++ b/benchmarks/implementation/softmax_cross_entropy_bench_batch_last.nim
@@ -70,12 +70,12 @@ proc classic_max_sumexp[T](t: Tensor[T], axis: int): Tensor[tuple[max:T, sumexp:
     result = result.unsqueeze(0)
 
 
-proc streaming_logsumexp[T: SomeReal](t: Tensor[T]): T =
+proc streaming_logsumexp[T: SomeFloat](t: Tensor[T]): T =
   # 1 pass but branching
   let (max, sumexp) = t.streaming_max_sumexp
   result = max + ln(sumexp)
 
-proc classic_logsumexp[T: SomeReal](t: Tensor[T]): T =
+proc classic_logsumexp[T: SomeFloat](t: Tensor[T]): T =
   # 2 pass but no branching
   let max = t.max # first loop over data
 
@@ -91,7 +91,7 @@ proc classic_logsumexp[T: SomeReal](t: Tensor[T]): T =
 
   result = max + ln(result)
 
-proc classic_logsumexp_v2[T: SomeReal](t: Tensor[T]): T =
+proc classic_logsumexp_v2[T: SomeFloat](t: Tensor[T]): T =
   # 2 pass no branching
   let (max, sumexp) = t.classic_max_sumexp
   result = max + ln(sumexp)

--- a/benchmarks/implementation/stable_sigmoid_bench.nim
+++ b/benchmarks/implementation/stable_sigmoid_bench.nim
@@ -6,18 +6,18 @@ import times, ../../src/arraymancer, math
 # We create a random tensor with randomly positive and negative value
 let a = randomTensor(1000, 1000, 100.0f) .- 50.0f
 
-proc sigmoid1[T: SomeReal](t: Tensor[T]): Tensor[T] {.noInit.}=
+proc sigmoid1[T: SomeFloat](t: Tensor[T]): Tensor[T] {.noInit.}=
   # Instable for large negative
   result = t.map_inline():
     1.T / (1.T + exp(-x))
 
-proc sigmoid2[T: SomeReal](t: Tensor[T]): Tensor[T] {.noInit.}=
+proc sigmoid2[T: SomeFloat](t: Tensor[T]): Tensor[T] {.noInit.}=
   # Instable for large positive
   result = t.map_inline():
     let tmp = exp(x)
     tmp / (1.T + tmp)
 
-proc sigmoid3[T: SomeReal](t: Tensor[T]): Tensor[T] {.noInit.}=
+proc sigmoid3[T: SomeFloat](t: Tensor[T]): Tensor[T] {.noInit.}=
   # Stable but branching in a loop
   result = t.map_inline():
     if x >= 0:
@@ -26,12 +26,12 @@ proc sigmoid3[T: SomeReal](t: Tensor[T]): Tensor[T] {.noInit.}=
       let z = exp(x)
       z / (1 + z)
 
-proc sigmoid4*[T: SomeReal](t: Tensor[T]): Tensor[T] {.noInit.}=
+proc sigmoid4*[T: SomeFloat](t: Tensor[T]): Tensor[T] {.noInit.}=
   # Stable but expensive tanh
   result = t.map_inline():
     0.5.T * (tanh(0.5.T * x) + 1.T)
 
-proc sigmoid5*[T: SomeReal](t: Tensor[T]): Tensor[T] {.noInit.}=
+proc sigmoid5*[T: SomeFloat](t: Tensor[T]): Tensor[T] {.noInit.}=
   # Stable and probably fastest
   result = t.map_inline():
     let clip_x = max(-500, -x)

--- a/docs/uth.speed.rst
+++ b/docs/uth.speed.rst
@@ -40,7 +40,7 @@ and ``.+``. (To avoid name conflict we change the logistic sigmoid name)
 
     import arraymancer
 
-    proc customSigmoid[T: SomeReal](t: Tensor[T]): Tensor[T] =
+    proc customSigmoid[T: SomeFloat](t: Tensor[T]): Tensor[T] =
       result = 1 ./ (1 .+ exp(-t))
 
 Well, unfortunately, the only thing we gain here is parallelism but we
@@ -51,7 +51,7 @@ the loop fusion template ``map_inline``:
 
     import arraymancer
 
-    proc customSigmoid2[T: SomeReal](t: Tensor[T]): Tensor[T] =
+    proc customSigmoid2[T: SomeFloat](t: Tensor[T]): Tensor[T] =
       result = map_inline(t):
         1 / (1 + exp(-x))
 

--- a/src/io/io_csv.nim
+++ b/src/io/io_csv.nim
@@ -38,7 +38,7 @@ proc read_csv*[T: SomeNumber|bool|string](
     parser = proc(x:string): T = x.parseInt.T
   elif T is SomeUnsignedInt:
     parser = proc(x:string): T = x.parseUInt.T
-  elif T is SomeReal:
+  elif T is SomeFloat:
     parser = proc(x:string): T = x.parseFloat.T
   elif T is bool:
     parser = parseBool

--- a/src/io/io_npy.nim
+++ b/src/io/io_npy.nim
@@ -127,7 +127,7 @@ proc write_npy*[T: SomeNumber](t: Tensor[T], npyPath: string) =
     endian = when system.cpuEndian == littleEndian: '<' else: '>'
     npy_type: char =  when T is SomeUnsignedInt: 'u'
                       elif T is SomeSignedInt: 'i'
-                      elif T is SomeReal: 'f'
+                      elif T is SomeFloat: 'f'
                       else: "Unreachable"
     npy_size = char T.sizeof + ord('0')
     dtype = endian & npy_type & $npy_size

--- a/src/linear_algebra/decomposition.nim
+++ b/src/linear_algebra/decomposition.nim
@@ -34,7 +34,7 @@ proc syevr(jobz: cstring; range: cstring; uplo: cstring; n: ptr cint; a: ptr cdo
           liwork, info)
 
 
-proc symeigImpl[T: SomeReal](a: Tensor[T], eigenvectors: bool,
+proc symeigImpl[T: SomeFloat](a: Tensor[T], eigenvectors: bool,
   low_idx: int, high_idx: int, result: var tuple[eigenval, eigenvec: Tensor[T]]) =
 
   assert a.shape[0] == a.shape[1], "Input should be a symmetric matrix"
@@ -124,7 +124,7 @@ proc symeigImpl[T: SomeReal](a: Tensor[T], eigenvectors: bool,
 template `^^`(s, i: untyped): untyped =
   (when i is BackwardsIndex: s.shape[0] - int(i) else: int(i))
 
-proc symeig*[T: SomeReal](a: Tensor[T], eigenvectors = false): tuple[eigenval, eigenvec: Tensor[T]] {.inline.}=
+proc symeig*[T: SomeFloat](a: Tensor[T], eigenvectors = false): tuple[eigenval, eigenvec: Tensor[T]] {.inline.}=
   ## Compute the eigenvalues and eigen vectors of a symmetric matrix
   ## Input:
   ##   - A symmetric matrix of shape [n x n]
@@ -140,7 +140,7 @@ proc symeig*[T: SomeReal](a: Tensor[T], eigenvectors = false): tuple[eigenval, e
 
   symeigImpl(a, eigenvectors, 0, a.shape[0] - 1, result)
 
-proc symeig*[T: SomeReal](a: Tensor[T], eigenvectors = false,
+proc symeig*[T: SomeFloat](a: Tensor[T], eigenvectors = false,
   slice: HSlice[int or BackwardsIndex, int or BackwardsIndex]): tuple[eigenval, eigenvec: Tensor[T]] {.inline.}=
   ## Compute the eigenvalues and eigen vectors of a symmetric matrix
   ## Input:

--- a/src/linear_algebra/least_squares.nim
+++ b/src/linear_algebra/least_squares.nim
@@ -34,7 +34,7 @@ proc gelsd(m: ptr cint; n: ptr cint; nrhs: ptr cint; a: ptr cdouble; lda: ptr ci
   )
 
 
-proc least_squares_solver*[T: SOmeReal](a, b: Tensor[T]):
+proc least_squares_solver*[T: SomeFloat](a, b: Tensor[T]):
   tuple[
     least_square_sol: Tensor[T],
     residuals:  Tensor[T],

--- a/src/ml/clustering/kmeans.nim
+++ b/src/ml/clustering/kmeans.nim
@@ -6,7 +6,7 @@ import math, random, tables
 import
   ../../tensor/tensor, ../../linear_algebra/linear_algebra
 
-proc euclidean_distance[T: SomeReal](u: Tensor[T], v: Tensor[T], squared: bool = false): T {.noInit.} =
+proc euclidean_distance[T: SomeFloat](u: Tensor[T], v: Tensor[T], squared: bool = false): T {.noInit.} =
   ## Calculates the euclidean distance
   ## Inputs:
   ##  - u: a tensor of shape (nb samples, nb features)
@@ -24,7 +24,7 @@ proc euclidean_distance[T: SomeReal](u: Tensor[T], v: Tensor[T], squared: bool =
   if not squared:
     result = sqrt(result)
 
-proc cumsum[T: SomeReal](p: Tensor[T]): Tensor[T] {.noInit.} =
+proc cumsum[T: SomeFloat](p: Tensor[T]): Tensor[T] {.noInit.} =
   ## Calculates the cumulative sum of a vector.
   ## Inputs:
   ##  - p: a rank-1 tensor to cumulatively sum
@@ -42,14 +42,14 @@ proc cumsum[T: SomeReal](p: Tensor[T]): Tensor[T] {.noInit.} =
   for i in 1..<n_rows:
     result[i] += result[i-1]
 
-proc init_random[T: SomeReal](x: Tensor[T], n_clusters: int): Tensor[T] {.noInit.} =
+proc init_random[T: SomeFloat](x: Tensor[T], n_clusters: int): Tensor[T] {.noInit.} =
   ## Helper method to randomly assign the initial centroids
   result = newTensor[T](n_clusters, x.shape[1])
   for i in 0..<n_clusters:
     let random_point = rand(x.shape[0])
     result[i, _] = x[random_point, _]
 
-proc get_closest_centroid[T: SomeReal](x: Tensor[T], centroids: Tensor[T], cid: int): int =
+proc get_closest_centroid[T: SomeFloat](x: Tensor[T], centroids: Tensor[T], cid: int): int =
   ## Helper method to get the closest centroid
   var closest_dist = Inf
   for closest in 0..<cid:
@@ -58,7 +58,7 @@ proc get_closest_centroid[T: SomeReal](x: Tensor[T], centroids: Tensor[T], cid: 
       closest_dist = dist
       result = closest
 
-proc get_candidates[T: SomeReal](n: int, distances: Tensor[T]): Tensor[int] {.noInit.} =
+proc get_candidates[T: SomeFloat](n: int, distances: Tensor[T]): Tensor[int] {.noInit.} =
   ## Sample candidates with probability weighted by the distances
   let probs = cumsum(distances ./ distances.sum)
   result = newTensor[int](n)
@@ -69,14 +69,14 @@ proc get_candidates[T: SomeReal](n: int, distances: Tensor[T]): Tensor[int] {.no
           result[t] = i
           break sampling
 
-proc get_distances[T: SomeReal](point: int, x: Tensor[T], squared: bool = false): Tensor[T] {.noInit.} =
+proc get_distances[T: SomeFloat](point: int, x: Tensor[T], squared: bool = false): Tensor[T] {.noInit.} =
   ## Helper method to get distances from one point to all other points in a matrix.
   let n_rows = x.shape[0]
   result = newTensor[T](n_rows)
   for i in 0..<n_rows:
     result[i] = euclidean_distance(x[point, _], x[i, _], squared)
 
-proc init_plus_plus[T: SomeReal](x: Tensor[T], n_clusters: int): Tensor[T] {.noInit.} =
+proc init_plus_plus[T: SomeFloat](x: Tensor[T], n_clusters: int): Tensor[T] {.noInit.} =
   ## Helper method to use the KMeans++ heuristic for initial centroids
   ##  - x: a tensor of input data with rank of 2
   ##  - n_clusters: the number of centroids to initialize
@@ -123,7 +123,7 @@ proc init_plus_plus[T: SomeReal](x: Tensor[T], n_clusters: int): Tensor[T] {.noI
     # Assign best candidate for current centroid
     result[cid, _] = x[best_candidate_id, _]
 
-proc assign_labels[T: SomeReal](x: Tensor[T], n_clusters = 10, tol: float = 0.0001, max_iters = 300, random = false):
+proc assign_labels[T: SomeFloat](x: Tensor[T], n_clusters = 10, tol: float = 0.0001, max_iters = 300, random = false):
   tuple[labels: Tensor[int], centroids: Tensor[T], inertia: T] {.noInit.} =
   ## K-Means Clustering label assignment
   ##  - x: A matrix of shape [Nb of observations, Nb of features]
@@ -205,7 +205,7 @@ proc assign_labels[T: SomeReal](x: Tensor[T], n_clusters = 10, tol: float = 0.00
 
   return (labels: labels, centroids: centroids, inertia: inertia)
 
-proc kmeans*[T: SomeReal](x: Tensor[T], n_clusters = 10, tol: float = 0.0001, n_init = 10, max_iters = 300, seed = 1000, random = false):
+proc kmeans*[T: SomeFloat](x: Tensor[T], n_clusters = 10, tol: float = 0.0001, n_init = 10, max_iters = 300, seed = 1000, random = false):
   tuple[labels: Tensor[int], centroids: Tensor[T], inertia: T] {.noInit.} =
   ## K-Means Clustering
   ## Inputs:
@@ -241,7 +241,7 @@ proc kmeans*[T: SomeReal](x: Tensor[T], n_clusters = 10, tol: float = 0.0001, n_
   let i = inertias.find(inertias.min)
   return (labels[i], centroids[i], inertias[i])
 
-proc kmeans*[T: SomeReal](x: Tensor[T], centroids: Tensor[T]): Tensor[int] {.noInit.} =
+proc kmeans*[T: SomeFloat](x: Tensor[T], centroids: Tensor[T]): Tensor[int] {.noInit.} =
   ## K-Means Clustering
   ## Inputs:
   ##  - x: A matrix of shape [Nb of observations, Nb of features]

--- a/src/ml/dimensionality_reduction/pca.nim
+++ b/src/ml/dimensionality_reduction/pca.nim
@@ -6,7 +6,7 @@ import
   ../../tensor/tensor, ../../linear_algebra/linear_algebra
 
 
-proc pca*[T: SomeReal](x: Tensor[T], nb_components = 2): tuple[results: Tensor[T], components: Tensor[T]] {.noInit.} =
+proc pca*[T: SomeFloat](x: Tensor[T], nb_components = 2): tuple[results: Tensor[T], components: Tensor[T]] {.noInit.} =
   ## Principal Component Analysis (PCA)
   ## Inputs:
   ##   - A matrix of shape [Nb of observations, Nb of features]
@@ -29,7 +29,7 @@ proc pca*[T: SomeReal](x: Tensor[T], nb_components = 2): tuple[results: Tensor[T
   result.components = eigvecs[_, ^1..0|-1]
   result.results= mean_centered * result.components
 
-proc pca*[T: SomeReal](x: Tensor[T], principal_axes: Tensor[T]): Tensor[T] {.noInit.} =
+proc pca*[T: SomeFloat](x: Tensor[T], principal_axes: Tensor[T]): Tensor[T] {.noInit.} =
   ## Principal Component Analysis (PCA) projection
   ## Inputs:
   ##    - A matrix of shape [Nb of observations, Nb of components]

--- a/src/nn/optimizers/optimizers.nim
+++ b/src/nn/optimizers/optimizers.nim
@@ -40,10 +40,10 @@ proc update*(self: Sgd) =
       x - self.lr * y
     v.grad = v.value.zeros_like
 
-func optimizerSGD*[M](model: M, learning_rate: SomeReal): Sgd[Tensor[SomeReal]] =
+func optimizerSGD*[M](model: M, learning_rate: SomeFloat): Sgd[Tensor[SomeFloat]] =
   ## Create a SGD optimizer that will update the model weight
 
-  # TODO: rename to optimize[M](model: M, OptimizerKind: typedesc[SGD], learning_rate: SomeReal): ...
+  # TODO: rename to optimize[M](model: M, OptimizerKind: typedesc[SGD], learning_rate: SomeFloat): ...
   # Pending https://github.com/nim-lang/Nim/issues/7734 and https://github.com/nim-lang/Nim/issues/7733
 
   result.params = @[]

--- a/src/nn_primitives/backend/cudnn.nim
+++ b/src/nn_primitives/backend/cudnn.nim
@@ -36,7 +36,7 @@ let cudnnHandle0* = initCudnnHandle()
 # #####################################################################
 # Types and destructors
 
-template asCudnnType*[T: SomeReal](typ: typedesc[T]): cudnnDataType_t =
+template asCudnnType*[T: SomeFloat](typ: typedesc[T]): cudnnDataType_t =
   when T is float32:
     CUDNN_DATA_FLOAT
   elif T is float64:
@@ -56,7 +56,7 @@ template asCudnnType*[T: SomeReal](typ: typedesc[T]): cudnnDataType_t =
 # #####################################################################
 # Tensor descriptor
 
-proc newCudnn4DTensorDesc*[T: SomeReal](t: CudaTensor[T]): cudnnTensorDescriptor_t {.inline, noinit.}=
+proc newCudnn4DTensorDesc*[T: SomeFloat](t: CudaTensor[T]): cudnnTensorDescriptor_t {.inline, noinit.}=
   # TODO: destroy descriptor automatically
   # TODO: generalize with the NDTensor Desc
   check cudnnCreateTensorDescriptor addr result

--- a/src/nn_primitives/backend/cudnn_conv_interface.nim
+++ b/src/nn_primitives/backend/cudnn_conv_interface.nim
@@ -35,7 +35,7 @@ type
 
 type Algo = cudnnConvolutionFwdAlgo_t or cudnnConvolutionBwdFilterAlgo_t or cudnnConvolutionBwdDataAlgo_t
 
-type ConvAlgoSpace*[T: SomeReal, Algo] = object
+type ConvAlgoSpace*[T: SomeFloat, Algo] = object
   algo*: Algo
   workspace*: ref[ptr T]
   sizeInBytes*: csize
@@ -66,14 +66,14 @@ proc newConvDesc( convolution_dimension: range[2..3],
     T.asCudnnType
   )
 
-proc newConv2dDesc*[T: SomeReal](padding, strides, dilation: SizeHW): cudnnConvolutionDescriptor_t {.noInit, inline.}=
+proc newConv2dDesc*[T: SomeFloat](padding, strides, dilation: SizeHW): cudnnConvolutionDescriptor_t {.noInit, inline.}=
   let convConfig = initConv2DConfig(padding, strides, dilation)
   result = newConvDesc(2, convConfig, CUDNN_CROSS_CORRELATION, T)
 
 # #####################################################################
 # Convolution kernel descriptor
 
-proc newCudnnConvKernelDesc*[T: SomeReal](
+proc newCudnnConvKernelDesc*[T: SomeFloat](
   convKernel: CudaTensor[T]): cudnnFilterDescriptor_t {.inline, noInit.}=
   # TODO: destroy descriptor automatically
   check cudnnCreateFilterDescriptor addr result
@@ -131,7 +131,7 @@ proc convOutDims*(input, kernel: CudaTensor, padding, strides, dilation: SizeHW)
 # ###############################################################
 # Forward convolution: Algorithm and Worksize space
 
-proc conv_algo_workspace*[T: SomeReal](
+proc conv_algo_workspace*[T: SomeFloat](
   srcTensorDesc: cudnnTensorDescriptor_t,
   kernelDesc: cudnnFilterDescriptor_t,
   convDesc: cudnnConvolutionDescriptor_t,
@@ -176,7 +176,7 @@ proc conv_algo_workspace*[T: SomeReal](
 # ###############################################################
 # Backward convolution - Kernel: Algorithm and Worksize space
 
-proc conv_bwd_kernel_algo_workspace*[T: SomeReal](
+proc conv_bwd_kernel_algo_workspace*[T: SomeFloat](
   srcTensorDesc: cudnnTensorDescriptor_t,
   gradOutputTensorDesc: cudnnTensorDescriptor_t, # gradOuput is the gradient of the output. Result will be the gradient of the input
   gradKernelDesc: cudnnFilterDescriptor_t,
@@ -221,7 +221,7 @@ proc conv_bwd_kernel_algo_workspace*[T: SomeReal](
 # ###############################################################
 # Backward convolution - Data: Algorithm and Worksize space
 
-proc conv_bwd_data_algo_workspace*[T: SomeReal](
+proc conv_bwd_data_algo_workspace*[T: SomeFloat](
   srcTensorDesc: cudnnTensorDescriptor_t,
   gradOutputTensorDesc: cudnnTensorDescriptor_t, # gradOuput is the gradient of the output. Result will be the gradient of the input
   kernelDesc: cudnnFilterDescriptor_t,

--- a/src/nn_primitives/nnp_activation.nim
+++ b/src/nn_primitives/nnp_activation.nim
@@ -23,7 +23,7 @@ import  ../tensor/tensor,
 # ##################################################################################################
 # Forward
 
-proc sigmoid*[T: SomeReal](t: Tensor[T]): Tensor[T] {.noInit.}=
+proc sigmoid*[T: SomeFloat](t: Tensor[T]): Tensor[T] {.noInit.}=
   ## Logistic sigmoid activation function, :math:`f(x) = 1 / (1 + \exp(-x))`
   ## Note: Canonical sigmoid is not stable for large negative value
   ## Please use sigmoid_cross_entropy for the final layer for better stability and performance
@@ -36,13 +36,13 @@ proc sigmoid*[T: SomeReal](t: Tensor[T]): Tensor[T] {.noInit.}=
 proc relu*[T](t: Tensor[T]): Tensor[T] {.noInit.}=
   t.map_inline max(0.T,x)
 
-proc tanh*[T: SomeReal](t: Tensor[T]): Tensor[T] {.noInit.}=
+proc tanh*[T: SomeFloat](t: Tensor[T]): Tensor[T] {.noInit.}=
   t.map_inline tanh(x)
 
 # ##################################################################################################
 # In-place forward
 
-proc msigmoid*[T: SomeReal](t: var Tensor[T]) =
+proc msigmoid*[T: SomeFloat](t: var Tensor[T]) =
   ## Logistic sigmoid activation function, :math:`f(x) = 1 / (1 + \exp(-x))`
   ## Note: Canonical sigmoid is not stable for large negative value
 
@@ -53,7 +53,7 @@ proc msigmoid*[T: SomeReal](t: var Tensor[T]) =
 proc mrelu*[T](t: var Tensor[T]) =
   t.apply_inline max(0.T, x)
 
-proc mtanh*[T: SomeReal](t: var Tensor[T]) =
+proc mtanh*[T: SomeFloat](t: var Tensor[T]) =
   t.apply_inline tanh(x)
 
 # ##################################################################################################

--- a/src/nn_primitives/nnp_conv2d_cudnn.nim
+++ b/src/nn_primitives/nnp_conv2d_cudnn.nim
@@ -17,7 +17,7 @@ import  ./backend/cudnn,
         ../tensor/tensor,
         ../tensor/private/p_init_cuda # TODO: it might be worth it to export newCudaTensor
 
-proc conv2d*[T: SomeReal](input, kernel, bias: CudaTensor[T],
+proc conv2d*[T: SomeFloat](input, kernel, bias: CudaTensor[T],
                 padding: SizeHW = [0,0],
                 strides, dilation: SizeHW = [1,1]): CudaTensor[T] {.noInit.}=
   ## Input:

--- a/src/nn_primitives/private/p_activation.nim
+++ b/src/nn_primitives/private/p_activation.nim
@@ -14,5 +14,5 @@
 
 import math
 
-proc sigmoid*[T: SomeReal](x: T): T {.inline, noSideEffect.} =
+proc sigmoid*[T: SomeFloat](x: T): T {.inline, noSideEffect.} =
   1 / (1 + exp(-x))

--- a/src/nn_primitives/private/p_logsumexp.nim
+++ b/src/nn_primitives/private/p_logsumexp.nim
@@ -58,7 +58,7 @@ proc stable_softmax*[T](x, max, sumexp: T): T {.noSideEffect, inline.}=
   # Numerically stable streaming softmax helper
   result = exp(x - max) / sumexp
 
-proc logsumexp*[T: SomeReal](t: Tensor[T]): T =
+proc logsumexp*[T: SomeFloat](t: Tensor[T]): T =
   # Advantage:
   #  - Only one loop over the data
   #  - Can be done "on-the-fly"
@@ -78,7 +78,7 @@ proc logsumexp*[T: SomeReal](t: Tensor[T]): T =
   result = max + ln(sumexp)
 
 
-# proc logsumexp_classic[T: SomeReal](t: Tensor[T]): T =
+# proc logsumexp_classic[T: SomeFloat](t: Tensor[T]): T =
 #   # Advantage:
 #   #  - OpenMP parallel
 #   #  - No branching in a tight loop

--- a/src/nn_primitives/recurrent/nnp_gru.nim
+++ b/src/nn_primitives/recurrent/nnp_gru.nim
@@ -37,7 +37,7 @@ import
 # Also see here for counterarg: https://software.intel.com/en-us/forums/intel-moderncode-for-parallel-architectures/topic/635075
 # Intel CPUs prefetcher can maintain 32 streams
 
-proc gru_cell_inference*[T: SomeReal](
+proc gru_cell_inference*[T: SomeFloat](
   input, hidden,
   W3, U3,
   bW3, bU3: Tensor[T],
@@ -84,7 +84,7 @@ proc gru_cell_inference*[T: SomeReal](
   next_hidden = map3_inline(W3x[_, sz], n, hidden):
     (1 - x) * y + x * z
 
-proc gru_cell_forward*[T: SomeReal](
+proc gru_cell_forward*[T: SomeFloat](
   input, hidden,
   W3, U3,
   bW3, bU3: Tensor[T],
@@ -136,7 +136,7 @@ proc gru_cell_forward*[T: SomeReal](
   next_hidden = map3_inline(z, n, hidden):
     (1 - x) * y + x * z
 
-proc gru_cell_backward*[T: SomeReal](
+proc gru_cell_backward*[T: SomeFloat](
   dx, dh, dW3, dU3,          # input and weights gradients
   dbW3, dbU3: var Tensor[T], # bias gradient
   dnext: Tensor[T],          # gradient flowing back from the next hidden state

--- a/src/stats/stats.nim
+++ b/src/stats/stats.nim
@@ -4,7 +4,7 @@
 
 import ../tensor/tensor
 
-proc covariance_matrix*[T: SomeReal](x, y: Tensor[T]): Tensor[T] =
+proc covariance_matrix*[T: SomeFloat](x, y: Tensor[T]): Tensor[T] =
 
   ## Input:
   ##   - 2 tensors of shape [Nb observations, features]

--- a/src/tensor/aggregate.nim
+++ b/src/tensor/aggregate.nim
@@ -56,11 +56,11 @@ proc mean*[T: SomeInteger](t: Tensor[T], axis: int): Tensor[T] {.noInit,inline.}
   ## Warning ⚠: Since input is integer, output will also be integer (using integer division)
   t.sum(axis) div t.shape[axis].T
 
-proc mean*[T: SomeReal](t: Tensor[T]): T {.inline.}=
+proc mean*[T: SomeFloat](t: Tensor[T]): T {.inline.}=
   ## Compute the mean of all elements
   t.sum / t.size.T
 
-proc mean*[T: SomeReal](t: Tensor[T], axis: int): Tensor[T] {.noInit,inline.}=
+proc mean*[T: SomeFloat](t: Tensor[T], axis: int): Tensor[T] {.noInit,inline.}=
   ## Compute the mean along an axis
   t.sum(axis) / t.shape[axis].T
 
@@ -86,7 +86,7 @@ proc max*[T](t: Tensor[T], axis: int): Tensor[T] {.noInit.} =
     for ex, ey in mzip(x,y):
       ex = max(ex,ey)
 
-proc variance*[T: SomeReal](t: Tensor[T]): T =
+proc variance*[T: SomeFloat](t: Tensor[T]): T =
   ## Compute the sample variance of all elements
   ## The normalization is by (n-1), also known as Bessel's correction,
   ## which partially correct the bias of estimating a population variance from a sample of this population.
@@ -102,7 +102,7 @@ proc variance*[T: SomeReal](t: Tensor[T]): T =
     x += y
   result /= (t.size-1).T
 
-proc variance*[T: SomeReal](t: Tensor[T], axis: int): Tensor[T] {.noInit.} =
+proc variance*[T: SomeFloat](t: Tensor[T], axis: int): Tensor[T] {.noInit.} =
   ## Compute the variance of all elements
   ## The normalization is by the (n-1), like in the formal definition
   let mean = t.mean(axis)
@@ -118,12 +118,12 @@ proc variance*[T: SomeReal](t: Tensor[T], axis: int): Tensor[T] {.noInit.} =
     x += y
   result /= (t.shape[axis]-1).T
 
-proc std*[T: SomeReal](t: Tensor[T]): T {.inline.} =
+proc std*[T: SomeFloat](t: Tensor[T]): T {.inline.} =
   ## Compute the standard deviation of all elements
   ## The normalization is by the (n-1), like in the formal definition
   sqrt(t.variance())
 
-proc std*[T: SomeReal](t: Tensor[T], axis: int): Tensor[T] {.noInit,inline.} =
+proc std*[T: SomeFloat](t: Tensor[T], axis: int): Tensor[T] {.noInit,inline.} =
   ## Compute the standard deviation of all elements
   ## The normalization is by the (n-1), like in the formal definition
   sqrt(t.variance(axis))

--- a/src/tensor/backend/cublas.nim
+++ b/src/tensor/backend/cublas.nim
@@ -26,7 +26,7 @@ export cuda, cublas_v2, cublas_api
 # L1 BLAS
 
 # Vector copy
-proc cublas_copy*[T: SomeReal](
+proc cublas_copy*[T: SomeFloat](
   n: int; x: ptr T; incx: int;
   y: ptr T; incy: int) {.inline.}=
 
@@ -38,7 +38,7 @@ proc cublas_copy*[T: SomeReal](
     check cublasDcopy(cublasHandle0, n.cint, x, incx.cint, y, incy.cint)
 
 # Vector dot product
-proc cublas_dot*[T: SomeReal](
+proc cublas_dot*[T: SomeFloat](
   n: int;
   x: ptr T; incx: int;
   y: ptr T; incy: int;
@@ -52,7 +52,7 @@ proc cublas_dot*[T: SomeReal](
     check cublasDdot(cublasHandle0, n.cint, x, incx.cint, y, incy.cint, output)
 
 # Vector addition
-proc cublas_axpy*[T: SomeReal](
+proc cublas_axpy*[T: SomeFloat](
   n: int;
   alpha: T;
   x: ptr T; incx: int;
@@ -70,7 +70,7 @@ proc cublas_axpy*[T: SomeReal](
     check cublasDaxpy(cublasHandle0, n.cint, addr al, x, incx.cint, y, incy.cint)
 
 # Scalar multiplication
-proc cublas_scal*[T: SomeReal](
+proc cublas_scal*[T: SomeFloat](
   n: int; alpha: T;
   x: ptr T; incx: int) {.inline.}=
 
@@ -85,7 +85,7 @@ proc cublas_scal*[T: SomeReal](
 
 # BLAS extension (L1-like)
 # Matrix addition (non-standard BLAS)
-proc cublas_geam*[T: SomeReal](
+proc cublas_geam*[T: SomeFloat](
   transa, transb: cublasOperation_t;
   m, n: int;
   alpha: T; A: ptr T; lda: int;
@@ -112,7 +112,7 @@ proc cublas_geam*[T: SomeReal](
                       C, ldc.cint)
 
 # L2 BLAS
-proc cublas_gemv*[T: SomeReal](
+proc cublas_gemv*[T: SomeFloat](
   trans: cublasOperation_t, m, n: int,
   alpha: T, A: ptr T, lda: int,
   x: ptr T, incx: int,
@@ -139,7 +139,7 @@ proc cublas_gemv*[T: SomeReal](
                       addr be, y, incy.cint)
 
 # L3 BLAS
-proc cublas_gemm*[T: SomeReal](
+proc cublas_gemm*[T: SomeFloat](
   transa, transb: cublasOperation_t,
   m, n, k: int,
   alpha: T, A: ptr T, lda: int,
@@ -169,7 +169,7 @@ proc cublas_gemm*[T: SomeReal](
                       B, ldb.cint,
                       addr be, C, ldc.cint)
 
-proc cublas_gemmStridedBatched*[T: SomeReal](
+proc cublas_gemmStridedBatched*[T: SomeFloat](
   transa, transb: cublasOperation_t;
   m, n, k: int;
   alpha: T; A: ptr T; lda: int; strideA: int;

--- a/src/tensor/backend/cuda.nim
+++ b/src/tensor/backend/cuda.nim
@@ -34,7 +34,7 @@ proc deallocCuda*[T](p: ref[ptr T]) {.noSideEffect.}=
 # ##############################################################
 # # Base CudaStorage type
 
-proc newCudaStorage*[T: SomeReal](length: int): CudaStorage[T] {.noSideEffect.}=
+proc newCudaStorage*[T: SomeFloat](length: int): CudaStorage[T] {.noSideEffect.}=
   result.Flen = length
   new(result.Fref_tracking, deallocCuda)
   result.Fdata = cast[ptr UncheckedArray[T]](cudaMalloc[T](result.Flen))
@@ -72,7 +72,7 @@ type
   CudaLayoutArray = ref[ptr cint]
 
 
-  CudaTensorLayout [T: SomeReal] = object
+  CudaTensorLayout [T: SomeFloat] = object
     ## Mimicks CudaTensor
     ## This will be stored on GPU in the end
     ## Goal is to avoids clumbering proc with cudaMemcpyshape, strides, offset, data, rank, len
@@ -87,7 +87,7 @@ type
     data*: ptr T              # Data on Cuda device
     len*: cint                # Number of elements allocated in memory
 
-proc layoutOnDevice*[T:SomeReal](t: CudaTensor[T]): CudaTensorLayout[T] {.noSideEffect.}=
+proc layoutOnDevice*[T:SomeFloat](t: CudaTensor[T]): CudaTensorLayout[T] {.noSideEffect.}=
   ## Store a CudaTensor shape, strides, etc information on the GPU
   #
   # TODO: instead of storing pointers to shape/stride/etc that are passed to each kernel

--- a/src/tensor/backend/opencl_backend.nim
+++ b/src/tensor/backend/opencl_backend.nim
@@ -46,7 +46,7 @@ proc deallocCl*[T](p: ref[ptr UncheckedArray[T]]) {.noSideEffect.}=
 # ##############################################################
 # # Base ClStorage type
 
-proc newClStorage*[T: SomeReal](length: int): ClStorage[T] =
+proc newClStorage*[T: SomeFloat](length: int): ClStorage[T] =
   result.Flen = length
   new(result.Fref_tracking, deallocCl)
   result.Fdata = clMalloc[T](result.Flen)
@@ -61,7 +61,7 @@ type
     # TODO: finalizer
     # or replace by a distinct type with a destructor
 
-  ClTensorLayout [T: SomeReal] = object
+  ClTensorLayout [T: SomeFloat] = object
     ## Mimicks CudaTensor
     ## Metadata stored on GPU or Accelerators
 
@@ -72,7 +72,7 @@ type
     data*: ptr T              # Data on OpenCL device
     len*: cint                # Number of elements allocated in memory
 
-proc layoutOnDevice*[T:SomeReal](t: ClTensor[T]): ClTensorLayout[T] =
+proc layoutOnDevice*[T:SomeFloat](t: ClTensor[T]): ClTensorLayout[T] =
   ## Store a ClTensor shape, strides, etc information on the GPU
   #
   # TODO: instead of storing pointers to shape/stride/etc that are passed to each kernel

--- a/src/tensor/data_structure.nim
+++ b/src/tensor/data_structure.nim
@@ -47,7 +47,7 @@ type
     offset*: int
     storage*: CpuStorage[T]
 
-  CudaStorage*[T: SomeReal] = object
+  CudaStorage*[T: SomeFloat] = object
     ## Opaque seq-like structure for storage on the Cuda backend.
     ##
     ## Nim garbage collector will automatically ask cuda to clear GPU memory if data becomes unused.
@@ -57,7 +57,7 @@ type
     Fdata*: ptr UncheckedArray[T]
     Fref_tracking*: ref[ptr UncheckedArray[T]] # We keep ref tracking for the GC in a separate field to avoid double indirection.
 
-  CudaTensor*[T: SomeReal] = object
+  CudaTensor*[T: SomeFloat] = object
     ## Tensor data structure stored on Nvidia GPU (Cuda)
     ##   - ``shape``: Dimensions of the CudaTensor
     ##   - ``strides``: Numbers of items to skip to get the next item along a dimension.
@@ -73,13 +73,13 @@ type
     offset*: int
     storage*: CudaStorage[T]
 
-  ClStorage*[T: SomeReal] = object
+  ClStorage*[T: SomeFloat] = object
     ## Opaque seq-like structure for storage on the OpenCL backend.
     Flen*: int
     Fdata*: ptr UncheckedArray[T]
     Fref_tracking*: ref[ptr UncheckedArray[T]] # We keep ref tracking for the GC in a separate field to avoid double indirection.
 
-  ClTensor*[T: SomeReal] = object
+  ClTensor*[T: SomeFloat] = object
     ## Tensor data structure stored on OpenCL (CPU, GPU, FPGAs or other accelerators)
     ##   - ``shape``: Dimensions of the CudaTensor
     ##   - ``strides``: Numbers of items to skip to get the next item along a dimension.

--- a/src/tensor/init_cpu.nim
+++ b/src/tensor/init_cpu.nim
@@ -170,7 +170,7 @@ template randomTensorCpu[T](t: Tensor[T], shape: varargs[int], max_or_range: typ
   tensorCpu(shape, t)
   result.storage.Fdata = newSeqWith(t.size, T(rand(max_or_range))) # Due to automatic converter (float32 -> float64), we must force T #68
 
-proc randomTensor*[T:SomeReal](shape: varargs[int], max: T): Tensor[T] {.noInit.} =
+proc randomTensor*[T:SomeFloat](shape: varargs[int], max: T): Tensor[T] {.noInit.} =
   ## Creates a new float Tensor filled with values between 0 and max.
   ##
   ## Random seed can be set by importing ``random`` and ``randomize(seed)``
@@ -221,7 +221,7 @@ proc randomNormal(mean = 0.0, std = 1.0): float =
     valid = false
     return rho*sin(2.0*PI*x)*std+mean
 
-proc randomNormalTensor*[T:SomeReal](shape: varargs[int], mean:T = 0, std:T = 1): Tensor[T] {.noInit.} =
+proc randomNormalTensor*[T:SomeFloat](shape: varargs[int], mean:T = 0, std:T = 1): Tensor[T] {.noInit.} =
   ## Creates a new Tensor filled with values in the normal distribution
   ##
   ## Random seed can be set by importing ``random`` and ``randomize(seed)``

--- a/src/tensor/init_cuda.nim
+++ b/src/tensor/init_cuda.nim
@@ -19,7 +19,7 @@ import  ../private/sequninit,
         ./data_structure,
         ./init_cpu
 
-proc cuda*[T:SomeReal](t: Tensor[T]): CudaTensor[T] {.noInit.}=
+proc cuda*[T:SomeFloat](t: Tensor[T]): CudaTensor[T] {.noInit.}=
   ## Convert a tensor on Cpu to a tensor on a Cuda device.
   # Note: due to modifying the cudaStream0 global var for async copy
   # proc cannot be tagged noSideEffect
@@ -39,7 +39,7 @@ proc cuda*[T:SomeReal](t: Tensor[T]): CudaTensor[T] {.noInit.}=
                         cudaMemcpyHostToDevice,
                         cudaStream0) # cudaStream0 is a cudaStream_t global var
 
-proc cpu*[T:SomeReal](t: CudaTensor[T]): Tensor[T] {.noSideEffect, noInit.}=
+proc cpu*[T:SomeFloat](t: CudaTensor[T]): Tensor[T] {.noSideEffect, noInit.}=
   ## Convert a tensor on a Cuda device to a tensor on Cpu.
   # We use blocking copy in this case to make sure
   # all data is available for future computation
@@ -58,7 +58,7 @@ proc cpu*[T:SomeReal](t: CudaTensor[T]): Tensor[T] {.noSideEffect, noInit.}=
 
 
 
-proc zeros_like*[T: SomeReal](t: CudaTensor[T]): CudaTensor[T] {.noInit, inline.} =
+proc zeros_like*[T: SomeFloat](t: CudaTensor[T]): CudaTensor[T] {.noInit, inline.} =
   ## Creates a new CudaTensor filled with 0 with the same shape as the input
   ## Input:
   ##      - Shape of the CudaTensor
@@ -69,7 +69,7 @@ proc zeros_like*[T: SomeReal](t: CudaTensor[T]): CudaTensor[T] {.noInit, inline.
   # TODO use cudaMemset
   result = zeros[T](t.shape).cuda
 
-proc ones_like*[T: SomeReal](t: CudaTensor[T]): CudaTensor[T] {.noInit, inline.} =
+proc ones_like*[T: SomeFloat](t: CudaTensor[T]): CudaTensor[T] {.noInit, inline.} =
   ## Creates a new CudaTensor filled with 1 with the same shape as the input
   ## and filled with 1
   ## Input:

--- a/src/tensor/init_opencl.nim
+++ b/src/tensor/init_opencl.nim
@@ -18,7 +18,7 @@ import  ../private/sequninit,
         ./data_structure,
         ./init_cpu
 
-proc opencl*[T:SomeReal](t: Tensor[T]): ClTensor[T] {.noInit.}=
+proc opencl*[T:SomeFloat](t: Tensor[T]): ClTensor[T] {.noInit.}=
   ## Convert a tensor on Cpu to a tensor on an OpenCL device.
 
   result = newClTensor[T](t.shape)
@@ -39,7 +39,7 @@ proc opencl*[T:SomeReal](t: Tensor[T]): ClTensor[T] {.noInit.}=
     0, nil, nil
   )
 
-proc cpu*[T:SomeReal](t: ClTensor[T]): Tensor[T] {.noInit.}=
+proc cpu*[T:SomeFloat](t: ClTensor[T]): Tensor[T] {.noInit.}=
   ## Convert a tensor on an OpenCL device to a tensor on Cpu.
   # We use blocking copy in this case to make sure
   # all data is available for future computation
@@ -64,7 +64,7 @@ proc cpu*[T:SomeReal](t: ClTensor[T]): Tensor[T] {.noInit.}=
     0, nil, nil
   )
 
-proc zeros_like*[T: SomeReal](t: ClTensor[T]): ClTensor[T] {.noInit, inline.} =
+proc zeros_like*[T: SomeFloat](t: ClTensor[T]): ClTensor[T] {.noInit, inline.} =
   ## Creates a new ClTensor filled with 0 with the same shape as the input
   ## Input:
   ##      - Shape of the CudaTensor
@@ -75,7 +75,7 @@ proc zeros_like*[T: SomeReal](t: ClTensor[T]): ClTensor[T] {.noInit, inline.} =
   # TODO use clEnqueueFillBuffer (OpenCL 1.2 only)
   result = zeros[T](t.shape).opencl
 
-proc ones_like*[T: SomeReal](t: ClTensor[T]): ClTensor[T] {.noInit, inline.} =
+proc ones_like*[T: SomeFloat](t: ClTensor[T]): ClTensor[T] {.noInit, inline.} =
   ## Creates a new ClTensor filled with 1 with the same shape as the input
   ## and filled with 1
   ## Input:

--- a/src/tensor/math_functions.nim
+++ b/src/tensor/math_functions.nim
@@ -31,7 +31,7 @@ proc elwise_div*[T: Someinteger](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Element-wise division
   map2_inline(a, b, x div y)
 
-proc elwise_div*[T: SomeReal](a, b: Tensor[T]): Tensor[T] {.noInit.} =
+proc elwise_div*[T: SomeFloat](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Element-wise division
   map2_inline(a, b, x / y)
 
@@ -39,23 +39,23 @@ proc melwise_div*[T: Someinteger](a: var Tensor[T], b: Tensor[T]) =
   ## Element-wise division (in-place)
   a.apply2_inline(b, x div y)
 
-proc melwise_div*[T: SomeReal](a: var Tensor[T], b: Tensor[T]) =
+proc melwise_div*[T: SomeFloat](a: var Tensor[T], b: Tensor[T]) =
   ## Element-wise division (in-place)
   a.apply2_inline(b, x / y)
 
-proc reciprocal*[T: SomeReal](t: Tensor[T]): Tensor[T] {.noInit.} =
+proc reciprocal*[T: SomeFloat](t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Return a tensor with the reciprocal 1/x of all elements
   t.map_inline(1.T/x)
 
-proc mreciprocal*[T: SomeReal](t: var Tensor[T]) =
+proc mreciprocal*[T: SomeFloat](t: var Tensor[T]) =
   ## Apply the reciprocal 1/x in-place to all elements of the Tensor
   t.apply_inline(1.T/x)
 
-proc negate*[T: SomeSignedInt|SomeReal](t: Tensor[T]): Tensor[T] {.noInit.} =
+proc negate*[T: SomeSignedInt|SomeFloat](t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Return a tensor with all elements negated (10 -> -10)
   t.map_inline(-x)
 
-proc mnegate*[T: SomeSignedInt|SomeReal](t: var Tensor[T]) =
+proc mnegate*[T: SomeSignedInt|SomeFloat](t: var Tensor[T]) =
   ## Negate in-place all elements of the tensor (10 -> -10)
   t.apply_inline(-x)
 

--- a/src/tensor/operators_blas_l1.nim
+++ b/src/tensor/operators_blas_l1.nim
@@ -23,7 +23,7 @@ import  ./private/p_checks,
   # FIXME: Can't use built-in proc `+` in map: https://github.com/nim-lang/Nim/issues/5702
   # map2(a, `+`, b)
 
-proc dot*[T: SomeReal](a, b: Tensor[T]): T {.noSideEffect.} =
+proc dot*[T: SomeFloat](a, b: Tensor[T]): T {.noSideEffect.} =
   ## Vector to Vector dot (scalar) product
   when compileOption("boundChecks"): check_dot_prod(a,b)
   return dot(a.shape[0], a.get_offset_ptr, a.strides[0], b.get_offset_ptr, b.strides[0])
@@ -69,7 +69,7 @@ proc `*`*[T: SomeNumber](t: Tensor[T], a: T): Tensor[T] {.noInit.} =
   ## Element-wise multiplication by a scalar
   a * t
 
-proc `/`*[T: SomeReal](t: Tensor[T], a: T): Tensor[T] {.noInit.} =
+proc `/`*[T: SomeFloat](t: Tensor[T], a: T): Tensor[T] {.noInit.} =
   ## Element-wise division by a float scalar
   t.map_inline(x / a)
 
@@ -84,7 +84,7 @@ proc `*=`*[T: SomeNumber](t: var Tensor[T], a: T) =
   ## Element-wise multiplication by a scalar (in-place)
   t.apply_inline(x * a)
 
-proc `/=`*[T: SomeReal](t: var Tensor[T], a: T) =
+proc `/=`*[T: SomeFloat](t: var Tensor[T], a: T) =
   ## Element-wise division by a scalar (in-place)
   t.apply_inline(x / a)
 

--- a/src/tensor/operators_blas_l1_cuda.nim
+++ b/src/tensor/operators_blas_l1_cuda.nim
@@ -25,7 +25,7 @@ include ./private/incl_accessors_cuda,
 # ####################################################################
 # BLAS Level 1 (Vector dot product, Addition, Scalar to Vector/Matrix)
 
-proc dot*[T: SomeReal](a, b: CudaTensor[T]): T {.inline.}=
+proc dot*[T: SomeFloat](a, b: CudaTensor[T]): T {.inline.}=
   ## Vector to Vector dot (scalar) product
   when compileOption("boundChecks"):
     check_dot_prod(a,b)
@@ -36,7 +36,7 @@ proc dot*[T: SomeReal](a, b: CudaTensor[T]): T {.inline.}=
 
 cuda_assign_glue("cuda_mAdd", "mAddOp", cuda_mAdd)
 
-proc `+=`*[T: SomeReal](a: var CudaTensor[T], b: CudaTensor[T]) =
+proc `+=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   ## CudaTensor in-place addition
 
   when compileOption("boundChecks"):
@@ -48,7 +48,7 @@ proc `+=`*[T: SomeReal](a: var CudaTensor[T], b: CudaTensor[T]) =
 
 cuda_binary_glue("cuda_Add", "AddOp", cuda_Add)
 
-proc `+`*[T: SomeReal](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.}=
+proc `+`*[T: SomeFloat](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.}=
   ## CudaTensor addition
 
   when compileOption("boundChecks"):
@@ -59,7 +59,7 @@ proc `+`*[T: SomeReal](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.}=
 
 cuda_assign_glue("cuda_mSub", "mSubOp", cuda_mSub)
 
-proc `-=`*[T: SomeReal](a: var CudaTensor[T], b: CudaTensor[T]) =
+proc `-=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   ## CudaTensor in-place substraction
 
   when compileOption("boundChecks"):
@@ -72,7 +72,7 @@ proc `-=`*[T: SomeReal](a: var CudaTensor[T], b: CudaTensor[T]) =
 
 cuda_binary_glue("cuda_Sub", "SubOp", cuda_Sub)
 
-proc `-`*[T: SomeReal](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
+proc `-`*[T: SomeFloat](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   ## CudaTensor substraction
 
   when compileOption("boundChecks"):
@@ -81,7 +81,7 @@ proc `-`*[T: SomeReal](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   result = newCudaTensor[T](a.shape)
   cuda_binary_call(cuda_Sub, result, a, b)
 
-proc `*=`*[T:SomeReal](t: var CudaTensor[T]; a: T) {.inline.}=
+proc `*=`*[T:SomeFloat](t: var CudaTensor[T]; a: T) {.inline.}=
   ## CudaTensor inplace multiplication by a scalar
 
   # We multiply all elements of the CudaTensor regardless of shape/strides
@@ -89,7 +89,7 @@ proc `*=`*[T:SomeReal](t: var CudaTensor[T]; a: T) {.inline.}=
   # Hence we use the whole allocated length and a stride of 1
   cublas_scal(t.storage.Flen, a, t.get_data_ptr, 1)
 
-proc `*`*[T:SomeReal](a: T, t: CudaTensor[T]): CudaTensor[T] {.noInit, inline.}=
+proc `*`*[T:SomeFloat](a: T, t: CudaTensor[T]): CudaTensor[T] {.noInit, inline.}=
   ## CudaTensor multiplication by a scalar
 
   # TODO replace by a custom kernel
@@ -98,19 +98,19 @@ proc `*`*[T:SomeReal](a: T, t: CudaTensor[T]): CudaTensor[T] {.noInit, inline.}=
   result = t.clone()
   result *= a
 
-proc `*`*[T:SomeReal](t: CudaTensor[T], a: T): CudaTensor[T] {.noInit, inline.}=
+proc `*`*[T:SomeFloat](t: CudaTensor[T], a: T): CudaTensor[T] {.noInit, inline.}=
   ## CudaTensor multiplication by a scalar
   a * t
 
 cuda_assignscal_glue("cuda_mscalDiv","mscalDivOp", cuda_mscalDiv)
 
-proc `/=`*[T:SomeReal](t: var CudaTensor[T]; a: T) {.inline.}=
+proc `/=`*[T:SomeFloat](t: var CudaTensor[T]; a: T) {.inline.}=
   ## CudaTensor in-place division by a scalar
   cuda_assignscal_call(cuda_mscalDiv, t, val)
 
 cuda_rscal_glue("cuda_rscalDiv","RscalDiv", cuda_rscalDiv)
 
-proc `/`*[T: SomeReal](t: CudaTensor[T], val: T): CudaTensor[T] {.noInit.} =
+proc `/`*[T: SomeFloat](t: CudaTensor[T], val: T): CudaTensor[T] {.noInit.} =
   ## CudaTensor division by a scalar
   result = newCudaTensor[T](t.shape)
   cuda_rscal_call(cuda_rscalDiv, result, t, val)

--- a/src/tensor/operators_blas_l1_opencl.nim
+++ b/src/tensor/operators_blas_l1_opencl.nim
@@ -27,7 +27,7 @@ import  ./backend/metadataArray,
 # ####################################################################
 # BLAS Level 1 (Vector dot product, Addition, Scalar to Vector/Matrix)
 
-template dotImpl(T: typedesc[SomeReal], clblast_proc: untyped): untyped =
+template dotImpl(T: typedesc[SomeFloat], clblast_proc: untyped): untyped =
   proc dot*(a, b: ClTensor[T]): T =
     ## Vector to Vector dot (scalar) product
     when compileOption("boundChecks"):

--- a/src/tensor/operators_blas_l2l3.nim
+++ b/src/tensor/operators_blas_l2l3.nim
@@ -21,7 +21,7 @@ import  ./private/p_checks,
         ./data_structure,
         ./init_cpu
 
-proc gemv*[T: SomeReal](
+proc gemv*[T: SomeFloat](
           alpha: T,
           A: Tensor[T],
           x: Tensor[T],
@@ -55,7 +55,7 @@ proc gemv*[T: SomeInteger](
 
   naive_gemv_fallback(alpha, A, x, beta, y)
 
-proc gemm*[T: SomeReal](
+proc gemm*[T: SomeFloat](
   alpha: T, A, B: Tensor[T],
   beta: T, C: var Tensor[T]) {.inline.}=
   # Matrix: C = alpha A matmul B + beta C

--- a/src/tensor/operators_blas_l2l3_cuda.nim
+++ b/src/tensor/operators_blas_l2l3_cuda.nim
@@ -17,7 +17,7 @@ import  ./backend/cublas,
         ./private/p_checks,
         ./data_structure
 
-proc cudaMV_y_eq_aAx_p_by[T: SomeReal](
+proc cudaMV_y_eq_aAx_p_by[T: SomeFloat](
   alpha: T, a, x: CudaTensor[T],
   beta: T, y: var CudaTensor[T]) =
   # Matrix-Vector: y = alpha A matvecmul x + beta y
@@ -40,7 +40,7 @@ proc cudaMV_y_eq_aAx_p_by[T: SomeReal](
       x.get_data_ptr, x.strides[0],
       beta, y.get_data_ptr, y.strides[0])
 
-proc cudaMM_C_eq_aAB_p_bC[T: SomeReal](
+proc cudaMM_C_eq_aAB_p_bC[T: SomeFloat](
   alpha: T, a, b: CudaTensor[T],
   beta: T, c: var CudaTensor[T]) =
   # Matrix: C = alpha A matmul B + beta C
@@ -71,7 +71,7 @@ proc cudaMM_C_eq_aAB_p_bC[T: SomeReal](
               b.get_data_ptr, ldb,
               beta, c.get_data_ptr, ldc)
 
-proc `*`*[T: SomeReal](a, b: CudaTensor[T]): CudaTensor[T] =
+proc `*`*[T: SomeFloat](a, b: CudaTensor[T]): CudaTensor[T] =
   ## Matrix multiplication (Matrix-Matrix and Matrix-Vector) on CUDA
 
   if a.rank == 2 and b.rank == 2:

--- a/src/tensor/operators_blas_l2l3_opencl.nim
+++ b/src/tensor/operators_blas_l2l3_opencl.nim
@@ -7,7 +7,7 @@ import  ./data_structure,
         ./private/[p_init_opencl, p_checks]
 
 
-template l1l2_blas_Impl(T: typedesc[SomeReal], clblast_gemv_proc, clblast_gemm_proc: untyped): untyped =
+template l1l2_blas_Impl(T: typedesc[SomeFloat], clblast_gemv_proc, clblast_gemm_proc: untyped): untyped =
   proc openCL_MV_y_eq_aAx_p_by(
     alpha: T, a, x: ClTensor[T],
     beta: T, y: var ClTensor[T]) =
@@ -77,7 +77,7 @@ template l1l2_blas_Impl(T: typedesc[SomeReal], clblast_gemv_proc, clblast_gemm_p
 l1l2_blas_Impl(float32, clblastSgemv, clblastSgemm)
 l1l2_blas_Impl(float64, clblastDgemv, clblastDgemm)
 
-proc `*`*[T: SomeReal](a, b: ClTensor[T]): ClTensor[T] =
+proc `*`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] =
   ## Matrix multiplication (Matrix-Matrix and Matrix-Vector) on CUDA
 
   if a.rank == 2 and b.rank == 2:

--- a/src/tensor/operators_broadcasted.nim
+++ b/src/tensor/operators_broadcasted.nim
@@ -46,7 +46,7 @@ proc `./`*[T: SomeInteger](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = map2_inline(tmp_a, tmp_b, x div y)
 
-proc `./`*[T: SomeReal](a, b: Tensor[T]): Tensor[T] {.noInit.} =
+proc `./`*[T: SomeFloat](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Tensor element-wise division for real numbers.
   ##
   ## And broadcasted element-wise division.
@@ -92,7 +92,7 @@ proc `./=`*[T: SomeInteger](a: var Tensor[T], b: Tensor[T]) =
   let tmp_b = b.broadcast(a.shape)
   apply2_inline(a, tmp_b, x div y)
 
-proc `./=`*[T: SomeReal](a: var Tensor[T], b: Tensor[T]) =
+proc `./=`*[T: SomeFloat](a: var Tensor[T], b: Tensor[T]) =
   ## Tensor broadcasted in-place float division.
   ##
   ## Only the right hand side tensor can be broadcasted.
@@ -125,7 +125,7 @@ proc `./`*[T: SomeInteger](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Broadcasted division of an integer by a tensor of integers.
   result = t.map_inline(val div x)
 
-proc `./`*[T: SomeReal](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
+proc `./`*[T: SomeFloat](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Broadcasted division of a float by a tensor of floats.
   result = t.map_inline(val / x)
 
@@ -133,11 +133,11 @@ proc `./`*[T: SomeInteger](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
   ## Broadcasted division of tensor of integers by an integer.
   result = t.map_inline(x div val)
 
-proc `./`*[T: SomeReal](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
+proc `./`*[T: SomeFloat](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
   ## Broadcasted division of a tensor of floats by a float.
   result = t.map_inline(x / val)
 
-proc `.^`*[T: SomeReal](t: Tensor[T], exponent: T): Tensor[T] {.noInit.} =
+proc `.^`*[T: SomeFloat](t: Tensor[T], exponent: T): Tensor[T] {.noInit.} =
   ## Compute element-wise exponentiation
   result = t.map_inline pow(x, exponent)
 
@@ -152,6 +152,6 @@ proc `.-=`*[T: SomeNumber](t: var Tensor[T], val: T) =
   ## Tensor in-place substraction with a broadcasted scalar.
   t.apply_inline(x - val)
 
-proc `.^=`*[T: SomeReal](t: var Tensor[T], exponent: T) =
+proc `.^=`*[T: SomeFloat](t: var Tensor[T], exponent: T) =
   ## Compute in-place element-wise exponentiation
   t.apply_inline pow(x, exponent)

--- a/src/tensor/operators_broadcasted_cuda.nim
+++ b/src/tensor/operators_broadcasted_cuda.nim
@@ -28,18 +28,18 @@ include ./private/incl_accessors_cuda,
 cuda_binary_glue("cuda_Mul", "MulOp", cuda_Mul)
 cuda_binary_glue("cuda_Div", "DivOp", cuda_Div)
 
-proc `.+`*[T: SomeReal](a, b: CudaTensor[T]): CudaTensor[T] {.noInit,inline.} =
+proc `.+`*[T: SomeFloat](a, b: CudaTensor[T]): CudaTensor[T] {.noInit,inline.} =
   ## Broadcasted addition for tensors of incompatible but broadcastable shape.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a + tmp_b
 
-proc `.-`*[T: SomeReal](a, b: CudaTensor[T]): CudaTensor[T] {.noInit,inline.} =
+proc `.-`*[T: SomeFloat](a, b: CudaTensor[T]): CudaTensor[T] {.noInit,inline.} =
   ## Broadcasted addition for tensors of incompatible but broadcastable shape.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a - tmp_b
 
 
-proc `.*`*[T: SomeReal](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
+proc `.*`*[T: SomeFloat](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   ## Element-wise multiplication (Hadamard product).
   ##
   ## And broadcasted element-wise multiplication.
@@ -49,7 +49,7 @@ proc `.*`*[T: SomeReal](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   result = newCudaTensor[T](tmp_a.shape)
   cuda_binary_call(cuda_Mul, result, tmp_a, tmp_b)
 
-proc `./`*[T: SomeReal](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
+proc `./`*[T: SomeFloat](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   ## CudaTensor substraction
 
   let (tmp_a, tmp_b) = broadcast2(a, b)
@@ -63,7 +63,7 @@ proc `./`*[T: SomeReal](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
 cuda_assign_glue("cuda_mMulOp", "mMulOp", cuda_mMulOp)
 cuda_assign_glue("cuda_mDivOp", "mDivOp", cuda_mDivOp)
 
-proc `.+=`*[T: SomeReal](a: var CudaTensor[T], b: CudaTensor[T]) =
+proc `.+=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   ## Tensor broadcasted in-place addition.
   ##
   ## Only the right hand side tensor can be broadcasted.
@@ -72,7 +72,7 @@ proc `.+=`*[T: SomeReal](a: var CudaTensor[T], b: CudaTensor[T]) =
   let tmp_b = b.broadcast(a.shape)
   a += tmp_b
 
-proc `.-=`*[T: SomeReal](a: var CudaTensor[T], b: CudaTensor[T]) =
+proc `.-=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   ## Tensor broadcasted in-place substraction.
   ##
   ## Only the right hand side tensor can be broadcasted.
@@ -81,7 +81,7 @@ proc `.-=`*[T: SomeReal](a: var CudaTensor[T], b: CudaTensor[T]) =
   let tmp_b = b.broadcast(a.shape)
   a -= tmp_b
 
-proc `.*=`*[T: SomeReal](a: var CudaTensor[T], b: CudaTensor[T]) =
+proc `.*=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   ## Tensor broadcasted in-place multiplication (Hadamard product)
   ##
   ## Only the right hand side tensor can be broadcasted
@@ -90,7 +90,7 @@ proc `.*=`*[T: SomeReal](a: var CudaTensor[T], b: CudaTensor[T]) =
   let tmp_b = b.broadcast(a.shape)
   cuda_assign_call(cuda_mMulOp, a, tmp_b)
 
-proc `./=`*[T: SomeReal](a: var CudaTensor[T], b: CudaTensor[T]) =
+proc `./=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   ## Tensor broadcasted in-place float division.
   ##
   ## Only the right hand side tensor can be broadcasted.
@@ -105,12 +105,12 @@ proc `./=`*[T: SomeReal](a: var CudaTensor[T], b: CudaTensor[T]) =
 cuda_rscal_glue("cuda_rscalSub","RscalSub", cuda_rscalSub)
 cuda_rscal_glue("cuda_rscalAdd","RscalAdd", cuda_rscalAdd)
 
-proc `.+`*[T: SomeReal](t: CudaTensor[T], val: T): CudaTensor[T] {.noInit.} =
+proc `.+`*[T: SomeFloat](t: CudaTensor[T], val: T): CudaTensor[T] {.noInit.} =
   ## Broadcasted addition for scalar + tensor.
   result = newCudaTensor[T](t.shape)
   cuda_rscal_call(cuda_rscalAdd, result, t, val)
 
-proc `.-`*[T: SomeReal](t: CudaTensor[T], val: T): CudaTensor[T] {.noInit.} =
+proc `.-`*[T: SomeFloat](t: CudaTensor[T], val: T): CudaTensor[T] {.noInit.} =
   ## Broadcasted substraction for scalar - tensor.
   result = newCudaTensor[T](t.shape)
   cuda_rscal_call(cuda_rscalSub, result, t, val)
@@ -120,17 +120,17 @@ cuda_lscal_glue("cuda_lscalSub","LscalSub", cuda_lscalSub)
 cuda_lscal_glue("cuda_lscalAdd","LscalAdd", cuda_lscalAdd)
 cuda_lscal_glue("cuda_lscalDiv","LscalDiv", cuda_lscalDiv)
 
-proc `.+`*[T: SomeReal](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit.} =
+proc `.+`*[T: SomeFloat](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   ## Broadcasted addition for tensor + scalar.
   result = newCudaTensor[T](t.shape)
   cuda_lscal_call(cuda_lscalAdd, result, val, t)
 
-proc `.-`*[T: SomeReal](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit.} =
+proc `.-`*[T: SomeFloat](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   ## Broadcasted substraction for tensor - scalar.
   result = newCudaTensor[T](t.shape)
   cuda_lscal_call(cuda_lscalSub, result, val, t)
 
-proc `./`*[T: SomeReal](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit.} =
+proc `./`*[T: SomeFloat](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   ## Broadcasted division of a float by a tensor of floats.
   result = newCudaTensor[T](t.shape)
   cuda_lscal_call(cuda_lscalDiv, result, val, t)
@@ -140,10 +140,10 @@ proc `./`*[T: SomeReal](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit.} =
 cuda_assignscal_glue("cuda_mscalSub","mscalSubOp", cuda_mscalSub)
 cuda_assignscal_glue("cuda_mscalAdd","mscalAddOp", cuda_mscalAdd)
 
-proc `.+=`*[T: SomeReal](t: var CudaTensor[T], val: T) =
+proc `.+=`*[T: SomeFloat](t: var CudaTensor[T], val: T) =
   ## Broadcasted addition for scalar + tensor.
   cuda_assignscal_call(cuda_mscalAdd, t, val)
 
-proc `.-=`*[T: SomeReal](t: var CudaTensor[T], val: T) =
+proc `.-=`*[T: SomeFloat](t: var CudaTensor[T], val: T) =
   ## Broadcasted substraction for scalar - tensor.
   cuda_assignscal_call(cuda_mscalSub, t, val)

--- a/src/tensor/operators_broadcasted_opencl.nim
+++ b/src/tensor/operators_broadcasted_opencl.nim
@@ -23,12 +23,12 @@ import  ./backend/opencl_backend,
 # #########################################################
 # # Broadcasting Tensor-Tensor
 # # And element-wise multiplication (Hadamard) and division
-proc `.+`*[T: SomeReal](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline.} =
+proc `.+`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline.} =
   ## Broadcasted addition for tensors of incompatible but broadcastable shape.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a + tmp_b
 
-proc `.-`*[T: SomeReal](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline.} =
+proc `.-`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline.} =
   ## Broadcasted addition for tensors of incompatible but broadcastable shape.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a - tmp_b
@@ -38,14 +38,14 @@ genClInfixOp(float64, "double", elwise_mul, "clAdd", "*", exported = false)
 genClInfixOp(float32, "float", elwise_div, "clSub", "/", exported = false)
 genClInfixOp(float64, "double", elwise_div, "clSub", "/", exported = false)
 
-proc `.*`*[T: SomeReal](a,b: ClTensor[T]): ClTensor[T] {.noInit.} =
+proc `.*`*[T: SomeFloat](a,b: ClTensor[T]): ClTensor[T] {.noInit.} =
   ## Element-wise multiplication (Hadamard product).
   ##
   ## And broadcasted element-wise multiplication.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = elwise_mul(tmp_a, tmp_b)
 
-proc `./`*[T: SomeReal](a,b: ClTensor[T]): ClTensor[T] {.noInit.} =
+proc `./`*[T: SomeFloat](a,b: ClTensor[T]): ClTensor[T] {.noInit.} =
   ## Element-wise multiplication (Hadamard product).
   ##
   ## And broadcasted element-wise multiplication.

--- a/src/tensor/private/p_init_cuda.nim
+++ b/src/tensor/private/p_init_cuda.nim
@@ -17,7 +17,7 @@ import  ../backend/cuda,
         ../data_structure
 
 
-template tensorCuda[T: SomeReal](
+template tensorCuda[T: SomeFloat](
   shape: typed,
   layout: OrderType = colMajor,
   result: var CudaTensor[T])=
@@ -27,7 +27,7 @@ template tensorCuda[T: SomeReal](
   result.offset = 0
   result.storage = newCudaStorage[T](result.size)
 
-proc newCudaTensor*[T: SomeReal](
+proc newCudaTensor*[T: SomeFloat](
   shape: varargs[int],
   layout: OrderType = colMajor): CudaTensor[T] {.noInit, noSideEffect.}=
   ## Internal proc
@@ -40,7 +40,7 @@ proc newCudaTensor*[T: SomeReal](
 
   tensorCuda(shape, layout, result)
 
-proc newCudaTensor*[T: SomeReal](
+proc newCudaTensor*[T: SomeFloat](
   shape: MetadataArray,
   layout: OrderType = colMajor): CudaTensor[T] {.noInit, noSideEffect.}=
 

--- a/src/tensor/private/p_init_opencl.nim
+++ b/src/tensor/private/p_init_opencl.nim
@@ -17,7 +17,7 @@ import  ../backend/opencl_backend,
         ../data_structure
 
 
-template tensorOpenCL[T: SomeReal](
+template tensorOpenCL[T: SomeFloat](
   shape: typed,
   layout: OrderType = rowMajor,
   result: var ClTensor[T])=
@@ -27,7 +27,7 @@ template tensorOpenCL[T: SomeReal](
   result.offset = 0
   result.storage = newClStorage[T](result.size)
 
-proc newClTensor*[T: SomeReal](
+proc newClTensor*[T: SomeFloat](
   shape: varargs[int],
   layout: OrderType = rowMajor): ClTensor[T] {.noInit.}=
   ## Internal proc
@@ -36,7 +36,7 @@ proc newClTensor*[T: SomeReal](
 
   tensorOpenCL(shape, layout, result)
 
-proc newClTensor*[T: SomeReal](
+proc newClTensor*[T: SomeFloat](
   shape: MetadataArray,
   layout: OrderType = rowMajor): ClTensor[T] {.noInit.}=
 

--- a/src/tensor/private/p_kernels_interface_cuda.nim
+++ b/src/tensor/private/p_kernels_interface_cuda.nim
@@ -28,7 +28,7 @@ template cuda_assign_binding(kernel_name: string, binding_name: untyped)=
   # The "*" in '*8 is needed to remove the pointer *
 
   # We create an new identifier on the fly with backticks
-  proc `binding_name`[T: SomeReal](
+  proc `binding_name`[T: SomeFloat](
     blocksPerGrid, threadsPerBlock: cint,
     rank, len: cint,
     dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
@@ -72,7 +72,7 @@ template cuda_assign_glue*(
 
   cuda_assign_binding(kernel_name, binding_name)
 
-template cuda_assign_call*[T: SomeReal](
+template cuda_assign_call*[T: SomeFloat](
   kernel_name: untyped, destination: var CudaTensor[T], source: CudaTensor[T]): untyped =
   ## Does the heavy-lifting to format the tensors for the cuda call
   #
@@ -103,7 +103,7 @@ template cuda_binary_binding(kernel_name: string, binding_name: untyped)=
   # The "*" in '*8 is needed to remove the pointer *
 
   # We create an new identifier on the fly with backticks
-  proc `binding_name`[T: SomeReal](
+  proc `binding_name`[T: SomeFloat](
     blocksPerGrid, threadsPerBlock: cint,
     rank, len: cint,
     dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
@@ -155,7 +155,7 @@ template cuda_binary_glue*(
   cuda_binary_binding(kernel_name, binding_name)
 
 
-template cuda_binary_call*[T: SomeReal](
+template cuda_binary_call*[T: SomeFloat](
   kernel_name: untyped, destination: var CudaTensor[T], a, b: CudaTensor[T]): untyped =
   ## Does the heavy-lifting to format the tensors for the cuda call
   #
@@ -190,7 +190,7 @@ template cuda_rscal_binding(kernel_name: string, binding_name: untyped)=
   # The "*" in '*8 is needed to remove the pointer *
 
   # We create an new identifier on the fly with backticks
-  proc `binding_name`[T: SomeReal](
+  proc `binding_name`[T: SomeFloat](
     blocksPerGrid, threadsPerBlock: cint,
     rank, len: cint,
     dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
@@ -238,7 +238,7 @@ template cuda_rscal_glue*(
   cuda_rscal_binding(kernel_name, binding_name)
 
 
-template cuda_rscal_call*[T: SomeReal](
+template cuda_rscal_call*[T: SomeFloat](
   kernel_name: untyped, destination: var CudaTensor[T], source: CudaTensor[T], beta: T): untyped =
   ## Does the heavy-lifting to format the tensors for the cuda call
   #
@@ -271,7 +271,7 @@ template cuda_lscal_binding(kernel_name: string, binding_name: untyped)=
   # The "*" in '*8 is needed to remove the pointer *
 
   # We create an new identifier on the fly with backticks
-  proc `binding_name`[T: SomeReal](
+  proc `binding_name`[T: SomeFloat](
     blocksPerGrid, threadsPerBlock: cint,
     rank, len: cint,
     dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
@@ -318,7 +318,7 @@ template cuda_lscal_glue*(
   cuda_lscal_binding(kernel_name, binding_name)
 
 
-template cuda_lscal_call*[T: SomeReal](
+template cuda_lscal_call*[T: SomeFloat](
   kernel_name: untyped, destination: var CudaTensor[T], alpha: T, source: CudaTensor[T]): untyped =
   ## Does the heavy-lifting to format the tensors for the cuda call
   #
@@ -349,7 +349,7 @@ template cuda_assignscal_binding(kernel_name: string, binding_name: untyped)=
   # The "*" in '*8 is needed to remove the pointer *
 
   # We create an new identifier on the fly with backticks
-  proc `binding_name`[T: SomeReal](
+  proc `binding_name`[T: SomeFloat](
     blocksPerGrid, threadsPerBlock: cint,
     rank, len: cint,
     dst_shape, dst_strides: ptr cint, dst_offset: cint, dst_data: ptr T,
@@ -389,7 +389,7 @@ template cuda_assignscal_glue*(
 
   cuda_assignscal_binding(kernel_name, binding_name)
 
-template cuda_assignscal_call*[T: SomeReal](
+template cuda_assignscal_call*[T: SomeFloat](
   kernel_name: untyped, destination: var CudaTensor[T], val: T): untyped =
   ## Does the heavy-lifting to format the tensors for the cuda call
   #

--- a/src/tensor/private/p_operator_blas_l2l3.nim
+++ b/src/tensor/private/p_operator_blas_l2l3.nim
@@ -25,7 +25,7 @@ import  ./p_checks,
 # BLAS Level 2 (Matrix-Vector)
 
 when defined(blis):
-  proc blisMV_y_eq_aAx_p_by*[T: SomeReal](
+  proc blisMV_y_eq_aAx_p_by*[T: SomeFloat](
     alpha: T, a, x: Tensor[T],
     beta: T, y: var Tensor[T]) {.inline,noSideEffect.}=
     # Matrix-Vector: y = alpha A matvecmul x + beta y
@@ -49,7 +49,7 @@ when defined(blis):
 
 # Note the fallback for non-real "naive_gemv_fallback" is called directly
 
-proc blasMV_y_eq_aAx_p_by*[T: SomeReal](
+proc blasMV_y_eq_aAx_p_by*[T: SomeFloat](
   alpha: T, a, x: Tensor[T],
   beta: T, y: var Tensor[T]) =
   # Matrix-Vector: y = alpha A matvecmul x + beta y
@@ -81,7 +81,7 @@ proc blasMV_y_eq_aAx_p_by*[T: SomeReal](
 # BLAS Level 3 (Matrix-Matrix)
 
 when defined(blis):
-  proc blisMM_C_eq_aAB_p_bC*[T: SomeReal](
+  proc blisMM_C_eq_aAB_p_bC*[T: SomeFloat](
     alpha: T, a, b: Tensor[T],
     beta: T, c: var Tensor[T]) {.inline,noSideEffect.}=
     # Matrix: C = alpha A matmul B + beta C
@@ -118,7 +118,7 @@ proc fallbackMM_C_eq_aAB_p_bC*[T: SomeInteger](
                     c.data, c.offset,
                     c.strides[0], c.strides[1])
 
-proc blasMM_C_eq_aAB_p_bC*[T: SomeReal](
+proc blasMM_C_eq_aAB_p_bC*[T: SomeFloat](
   alpha: T, a, b: Tensor[T],
   beta: T, c: var Tensor[T]) =
   # Matrix: C = alpha A matmul B + beta C

--- a/src/tensor/shapeshifting_cuda.nim
+++ b/src/tensor/shapeshifting_cuda.nim
@@ -34,7 +34,7 @@ proc transpose*(t: CudaTensor): CudaTensor {.noSideEffect.}=
 
 cuda_assign_glue("cuda_asContiguous", "CopyOp", cuda_asContiguous)
 
-proc asContiguous*[T: SomeReal](t: CudaTensor[T], layout: OrderType = colMajor, force: bool = false):
+proc asContiguous*[T: SomeFloat](t: CudaTensor[T], layout: OrderType = colMajor, force: bool = false):
   CudaTensor[T] {.noSideEffect.}=
   ## Transform a tensor with general striding to a Tensor with contiguous layout.
   ##

--- a/tests/nn_primitives/test_nnp_loss.nim
+++ b/tests/nn_primitives/test_nnp_loss.nim
@@ -16,7 +16,7 @@ import ../../src/arraymancer, unittest
 
 
 suite "[NN primitives] Loss functions":
-  proc `~=`[T: SomeReal](a, b: T): bool =
+  proc `~=`[T: SomeFloat](a, b: T): bool =
     let eps = 2e-5.T
     result = abs(a - b) <= eps
 

--- a/tests/tensor/test_broadcasting.nim
+++ b/tests/tensor/test_broadcasting.nim
@@ -205,7 +205,7 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
 
   test "Implicit broadcasting - Sigmoid 1 ./ (1 .+ exp(-x)":
     block:
-      proc sigmoid[T: SomeReal](t: Tensor[T]): Tensor[T]=
+      proc sigmoid[T: SomeFloat](t: Tensor[T]): Tensor[T]=
         1.T ./ (1.T .+ exp(-t))
 
       let a = newTensor[float32]([2,2])


### PR DESCRIPTION
Replaces all occurrences of `SomeReal` by `SomeFloat`, because for some reason `SomeReal` now throws an `undeclared identifier` error.