### PR TITLE
Add hdf5 support

### DIFF
--- a/src/io/io.nim
+++ b/src/io/io.nim
@@ -2,6 +2,6 @@
 # Distributed under the Apache v2 License (license terms are at http://www.apache.org/licenses/LICENSE-2.0).
 # This file may not be copied, modified, or distributed except according to those terms.
 
-import ./io_csv, ./io_npy, ./io_image
+import ./io_csv, ./io_npy, ./io_image, ./io_hdf5
 
-export io_csv, io_npy, io_image
+export io_csv, io_npy, io_image, io_hdf5

--- a/src/io/io.nim
+++ b/src/io/io.nim
@@ -2,6 +2,16 @@
 # Distributed under the Apache v2 License (license terms are at http://www.apache.org/licenses/LICENSE-2.0).
 # This file may not be copied, modified, or distributed except according to those terms.
 
-import ./io_csv, ./io_npy, ./io_image, ./io_hdf5
+template canImport(x: untyped): bool =
+  compiles:
+    import x
 
-export io_csv, io_npy, io_image, io_hdf5
+import ./io_csv, ./io_npy, ./io_image
+
+export io_csv, io_npy, io_image
+
+when canImport(nimhdf5):
+  # only provide the hdf5 interface, if the hdf5 library is
+  # installed to avoid making `nimhdf5` a dependency
+  import ./io_hdf5
+  export io_hdf5

--- a/src/io/io_hdf5.nim
+++ b/src/io/io_hdf5.nim
@@ -1,0 +1,92 @@
+# Copyright (c) 2018 Mamy André-Ratsimbazafy and the Arraymancer contributors
+# Distributed under the Apache v2 License (license terms are at http://www.apache.org/licenses/LICENSE-2.0).
+# This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  ../tensor/tensor,
+  strutils, strformat, ospaths,
+  nimhdf5
+
+# constant which we use to keep track of how many tensors are stored
+# in a given H5 file without having to visit the whole H5 file.
+# We create an attribute on the root group with this name and increment
+# for each tensor.
+const NumTensorStored = "numTensorsStored"
+
+proc read_hdf5*[T: SomeNumber](hdf5Path: string): Tensor[T] {.noInit.} =
+  ## Reads a .h5 file (written by arraymancer) and returns a tensor of the
+  ## specified type.
+  ## If the tensor is stored in a different type in the file, it will be
+  ## converted.
+  ##
+  ## Input:
+  ##   - The path to a HDF5 file as a string
+  ## Output:
+  ##   - A tensor
+  discard
+
+proc write_hdf5*[T: SomeNumber](t: Tensor[T],
+                                hdf5Path: string,
+                                name = "",
+                                group = "") =
+  ## Exports a tensor to a hdf5 file
+  ## To keep this a simple convenience proc, the tensor is stored
+  ## in the root group of the hdf5 file under a generic name.
+  ## If the `name` argument is given, the tensor is stored under this
+  ## name instead. If the `group` argument is given the tensor is
+  ## stored in that group instead of the root group.
+  ## Note: if no `name` is given, we need to visit the whole file
+  ## to check for existing tensors. This will introduce a small
+  ## overhead!
+  ## TODO: introduce a "num tensors stored" like attribute in the
+  ## h5 file, which we write. Instead of visiting the whole file
+  ## just access that single attribute.
+  ##
+  ## Input:
+  ##   - The tensor to write
+  ##   - The path to a HDF5 file as a string (will be created)
+  ##   - An optional name for the dataset of the tensor in the file
+  ##     Useful to store multiple tensors in a single HDF5 file
+  ##   - An optional name for a `group` to store the tensor in
+
+  # create hdf5 file
+  var
+    h5f = H5File(hdf5Path, "rw")
+    grpName = ""
+    dsetName = ""
+  if group.len > 0:
+    grpName = group
+  if name.len > 0:
+    dsetName = name
+  else:
+    # create a generic name based on tensor rank and number of
+    # tensors stored in file
+    # get num tensors in file (int32 should be plenty I guess...)
+    var numTensors = 0'u32
+    if NumTensorStored in h5f.attrs:
+      numTensors = h5f.attrs[NumTensorStored, uint32]
+    dsetName = &"Tensor_{t.rank}_{numTensors}"
+
+  var dset = h5f.create_dataset(grpName / dsetName,
+                                @(t.shape),
+                                dtype = T)
+  # write tensor data
+  # TODO: for efficiency we'd want to hand the whole tensor and in
+  # nimhdf5 access its data as the raw data ptr. Modify tensor
+  # functions in nimhdf5!
+  dset.unsafeWrite(t.get_data_ptr, t.size)
+
+  # now write attributes of tensor
+  dset.attrs["rank"] = t.rank
+  dset.attrs["shape"] = @(t.shape)
+  dset.attrs["size"] = t.size
+  # workaround since we can't write bool attributes
+  dset.attrs["is_C_contiguous"] = if t.is_C_contiguous: "true" else: "false"
+
+  # close file
+  let err = h5f.close()
+  if err != 0:
+    # TODO: raise? echo?
+    echo "WARNING: could not properly close H5 file. Error code: ", err
+    #raise newException(HDF5LibraryError,  "WARNING: could not properly close " &
+    #  "H5 file. Error code: ", err)

--- a/src/io/io_hdf5.nim
+++ b/src/io/io_hdf5.nim
@@ -164,8 +164,6 @@ proc write_hdf5*[T: SomeNumber](h5f: var H5FileObj,
   dset.attrs["rank"] = tCont.rank
   dset.attrs["shape"] = @(tCont.shape)
   dset.attrs["size"] = tCont.size
-  # workaround since we can't write bool attributes
-  dset.attrs["is_C_contiguous"] = if tCont.is_C_contiguous: "true" else: "false"
 
   # write new number of tensors stored
   h5f.attrs[NumTensorStored] = numTensors + 1

--- a/src/io/io_hdf5.nim
+++ b/src/io/io_hdf5.nim
@@ -81,6 +81,11 @@ proc read_hdf5*[T: SomeNumber](hdf5Path: string,
   # get name of the correct tensor
   let (dsetName, grpName, _) = h5f.parseNameAndGroup(false, name, group, number)
 
+  # check whether dataset exists in file
+  if not h5f.isDataset(grpName / dsetName):
+    raise newException(ValueError, "Given name `" & grpName / dsetName & "` does not " &
+      "correspond to an existing tensor in the file: " & h5f.name)
+
   var h5dset = h5f[(grpName / dsetName).dset_str]
 
   # get the meta data from the attributes

--- a/src/io/io_hdf5.nim
+++ b/src/io/io_hdf5.nim
@@ -14,7 +14,7 @@ import
 # for each tensor.
 const NumTensorStored = "numTensorsStored"
 
-proc parseNameAndGroup(h5f: var H5FileObj,
+func parseNameAndGroup(h5f: var H5FileObj,
                        toWrite: static[bool],
                        name, group: Option[string],
                        number: Option[int] = none(int)):
@@ -30,10 +30,6 @@ proc parseNameAndGroup(h5f: var H5FileObj,
   ##   - (string, string): tuple of dataset name, group name
   ##     correctly parsed according to user desired name /
   ##     generic name
-
-  # TODO: clean up this proc!
-  # maybe disallow no args at all?
-  # use Option[T] for number arg
 
   if group.isSome:
     result.grpName = group.get
@@ -107,7 +103,6 @@ proc read_hdf5*[T: SomeNumber](h5f: var H5FileObj,
   tensorCpu(shape, result, layout)
   result.data = convertTo(h5dset)
 
-  # TODO: take these out...
   assert shape == h5dset.shape
   assert shape == @(result.shape)
   assert rank == result.rank
@@ -146,9 +141,6 @@ proc write_hdf5*[T: SomeNumber](h5f: var H5FileObj,
   ## Note: if no `name` is given, we need to visit the whole file
   ## to check for existing tensors. This will introduce a small
   ## overhead!
-  ## TODO: introduce a "num tensors stored" like attribute in the
-  ## h5 file, which we write. Instead of visiting the whole file
-  ## just access that single attribute.
   ##
   ## Input:
   ##   - The tensor to write

--- a/src/io/io_hdf5.nim
+++ b/src/io/io_hdf5.nim
@@ -164,6 +164,8 @@ proc write_hdf5*[T: SomeNumber](h5f: var H5FileObj,
   dset.attrs["rank"] = tCont.rank
   dset.attrs["shape"] = @(tCont.shape)
   dset.attrs["size"] = tCont.size
+  # workaround since we can't write bool attributes
+  dset.attrs["is_C_contiguous"] = if tCont.is_C_contiguous: "true" else: "false"
 
   # write new number of tensors stored
   h5f.attrs[NumTensorStored] = numTensors + 1

--- a/tests/io/test_hdf5.nim
+++ b/tests/io/test_hdf5.nim
@@ -4,15 +4,40 @@
 
 import ../../src/arraymancer
 import nimhdf5
-import unittest, os
+import unittest, os, options
+
+import sequtils
+
+
+template withFile(filename: string, actions: untyped): untyped =
+  block:
+    actions
+    removeFile(filename)
+
 
 suite "[IO] HDF5 .h5 file support":
 
   const test_write_file = "./build/test_hdf5_write.h5"
+  const tensorName = "TestTensor"
+  const groupName = "subgroup"
+  const nestedGroups = "subgroup/nested"
+  const name4D = "happy4DTensor"
 
   # Note: whatever the read type we convert it to int in the end.
   let expected_1d = [1'i64, 2, 3, 4].toTensor
+  let expected_1d_float = [1'f64, 2, 3, 4].toTensor
   let expected_2d = [[1'i64, 2, 3, 4], [5'i64, 6, 7, 8]].toTensor
+  let expected_2d_float = [[1'f64, 2, 3, 4], [5'f64, 6, 7, 8]].toTensor
+  let expected_4d = [[[[1'i64, 2, 3, 4],
+                       [5'i64, 6, 7, 8]],
+                      [[1'i64, 2, 3, 4],
+                       [5'i64, 6, 7, 8]]],
+                     [[[1'i64, 2, 3, 4],
+                       [5'i64, 6, 7, 8]],
+                      [[1'i64, 2, 3, 4],
+                       [5'i64, 6, 7, 8]]]].toTensor
+  echo expected_4d.shape
+
 
   # test the HDF5 interface via the following:
   # - write tensor to file
@@ -24,8 +49,60 @@ suite "[IO] HDF5 .h5 file support":
 
   test "[IO] Writing Arraymancer tensor to HDF5 file":
 
-    block:
+    withFile(test_write_file):
       expected_1d.write_hdf5(test_write_file)
 
-    block:
+      # read back
+      let a = read_hdf5[int64](test_write_file)
+      check a == expected_1d
+
+    withFile(test_write_file):
+      # write an integer dataset
+      expected_1d.write_hdf5(test_write_file)
+
+      # read back as float dataset
+      let a = read_hdf5[float64](test_write_file)
+      check a == expected_1d_float
+
+    withFile(test_write_file):
+      # write an integer dataset
+      expected_2d.write_hdf5(test_write_file, name = tensorName)
+
+      # read back as float dataset
+      let a = read_hdf5[float64](test_write_file, name = tensorName)
+      check a == expected_2d_float
+
+    withFile(test_write_file):
       expected_2d.write_hdf5(test_write_file)
+
+
+      # read back
+      let a = read_hdf5[int64](test_write_file)
+      check a == expected_2d
+
+    withFile(test_write_file):
+      expected_4d.write_hdf5(test_write_file, name = name4D)
+
+      # read back
+      let a = read_hdf5[int64](test_write_file, name = name4D)
+      check a == expected_4d
+
+    withFile(test_write_file):
+      # write several tensors one after another, read them back
+      echo "Now more one"
+      expected_1d.write_hdf5(test_write_file)
+      expected_1d_float.write_hdf5(test_write_file)
+      expected_2d.write_hdf5(test_write_file)
+      expected_2d_float.write_hdf5(test_write_file)
+      expected_4d.write_hdf5(test_write_file)
+
+      let a = read_hdf5[int64](test_write_file, number = 0)
+      check a == expected_1d
+      let b = read_hdf5[float64](test_write_file, number = 1)
+      check b == expected_1d_float
+      let c = read_hdf5[int64](test_write_file, number = 2)
+      check c == expected_2d
+      let d = read_hdf5[float64](test_write_file, number = 3)
+      check d == expected_2d_float
+      let e = read_hdf5[int64](test_write_file, number = 4)
+      check e == expected_4d

--- a/tests/io/test_hdf5.nim
+++ b/tests/io/test_hdf5.nim
@@ -1,0 +1,31 @@
+# Copyright (c) 2018 Mamy André-Ratsimbazafy and the Arraymancer contributors
+# Distributed under the Apache v2 License (license terms are at http://www.apache.org/licenses/LICENSE-2.0).
+# This file may not be copied, modified, or distributed except according to those terms.
+
+import ../../src/arraymancer
+import nimhdf5
+import unittest, os
+
+suite "[IO] HDF5 .h5 file support":
+
+  const test_write_file = "./build/test_hdf5_write.h5"
+
+  # Note: whatever the read type we convert it to int in the end.
+  let expected_1d = [1'i64, 2, 3, 4].toTensor
+  let expected_2d = [[1'i64, 2, 3, 4], [5'i64, 6, 7, 8]].toTensor
+
+  # test the HDF5 interface via the following:
+  # - write tensor to file
+  # - read tensor back, compare with input tensor
+  # - read tensor back as different type
+  # - write tensor to specific name and group, read back
+  # - write several tensors to one file, read them back
+  # - ?
+
+  test "[IO] Writing Arraymancer tensor to HDF5 file":
+
+    block:
+      expected_1d.write_hdf5(test_write_file)
+
+    block:
+      expected_2d.write_hdf5(test_write_file)


### PR DESCRIPTION
This PR will add support to read and write tensors to HDF5 files. It's a work in progress.

Features (to be) added for a start:
- [x] write tensor with generic name
- [x] write tensor with specific name
- [x] write tensor to specific group
- [x] read tensor
- [x] read tensor, convert to different datatype 
- [x] read tensor of given name
- [x] read tensor from location other than root group
- [x] write several tensors without closing H5 file in between calls
- [x] make use of `is_C_contiguous`
- [x] make sure tensors are contiguous before writing
- [x] write proper tests of writing -> reading back tensors 
  can probably always add more tests...

Once these are implemented potentially (in another PR):
- [ ] serialize NN model to H5
- [ ] read serialized NN model from H5
- [ ] read Keras NN models from H5 files

Regarding Keras H5 files, relevant Keras code: https://github.com/keras-team/keras/blob/master/keras/engine/saving.py