### PR TITLE
Autograd - Add backpropagation to shapeshifting operation

### DIFF
--- a/src/autograd/ag_data_structure.nim
+++ b/src/autograd/ag_data_structure.nim
@@ -176,39 +176,11 @@ proc backprop*[TT](v: Variable[TT]) =
       if parent_i.requires_grad:
         parent_i.grad += diffs[i]
 
-template `[]`*[TT](v: Variable[TT], args: varargs[untyped]): Variable[TT] =
-  ## Slice the tensor contained by the dynamic graph Variable
-  ## Input:
-  ##   - a Variable
-  ## Output:
-  ##   - a sliced Variable
-
-  # TODO - investigate https://github.com/mratsim/Arraymancer/issues/241
-  # As https://github.com/mratsim/Arraymancer/commit/e609e998d663710281dbe161249a0139befa818c
-  # which fixed https://github.com/mratsim/Arraymancer/issues/185 had to be rollbacked
-
-  # Ensure that v is only called once even if it's a function with side-effects
-  let z = v
-
-  # TODO: backprop support
-  var result: type(z)
-  new result
-
-  result.context = z.context
-  result.value = z.value[args]
-  result.grad = z.grad[args]
-  result.requires_grad = z.requires_grad
-
-  result
-
-  # TODO: tests for slicing correspondence
-
 proc weakRef*[TT](v: Variable[TT]): VariablePtr[TT] {.inline.} =
   ## Get a weak/untraced reference to a Variable
   ## This is intended for library writers and Neural Network graphs
   ## to avoid strong cyclic references.
   cast[VariablePtr[TT]](v)
-
 
 proc weakRef*[TT](ctx: Context[TT]): ContextPtr[TT] {.inline.} =
   ## Get a weak/untraced reference to a Variable

--- a/src/autograd/autograd.nim
+++ b/src/autograd/autograd.nim
@@ -16,10 +16,12 @@ import  ./ag_data_structure,
         ./gates_basic,
         ./gates_blas,
         ./gates_reduce,
-        ./gates_shapeshifting
+        ./gates_shapeshifting_views,
+        ./gates_shapeshifting_concat_split
 
 export  ag_data_structure,
         gates_basic,
         gates_blas,
         gates_reduce,
-        gates_shapeshifting
+        gates_shapeshifting_views,
+        gates_shapeshifting_concat_split

--- a/src/autograd/gates_basic.nim
+++ b/src/autograd/gates_basic.nim
@@ -21,13 +21,14 @@ import  ../private/ast_utils,
 
 type AddGate* {.final.} [TT] = ref object of Gate[TT]
 
-method forward*[TT](self: AddGate[TT], a, b: Variable[TT]): Variable[TT] {.inline, locks:0.}=
+proc forward[TT](self: AddGate[TT], a, b: Variable[TT]): Variable[TT] {.inline.}=
   new result
 
   result.context = a.context
   result.value = a.value + b.value
 
-method backward*[TT](self: AddGate[TT], gradient: TT): SmallDiffs[TT] {.noInit, inline, locks:0.}=
+method backward*[TT](self: AddGate[TT], payload: Payload[TT]): SmallDiffs[TT] {.noInit, inline, locks:0.}=
+  let gradient = payload.variable.grad
   result[0] = gradient
   result[1] = gradient
 
@@ -52,7 +53,7 @@ proc `+`*[TT](a, b: Variable[TT]): Variable[TT] =
 
   # Resulting var
   result = gate.forward(a, b)
-  node.payload = result
+  node.payload = Payload[TT](kind: pkVar, variable: result)
 
   # Caching for backprop
   if a.is_grad_needed or b.is_grad_needed:
@@ -61,13 +62,14 @@ proc `+`*[TT](a, b: Variable[TT]): Variable[TT] =
 
 type SubGate* {.final.} [TT] = ref object of Gate[TT]
 
-method forward*[TT](self: SubGate[TT], a, b: Variable[TT]): Variable[TT] {.inline, locks:0.}=
+proc forward[TT](self: SubGate[TT], a, b: Variable[TT]): Variable[TT] {.inline.}=
   new result
 
   result.context = a.context
   result.value = a.value - b.value
 
-method backward*[TT](self: SubGate[TT], gradient: TT): SmallDiffs[TT] {.noInit, inline, locks:0.}=
+method backward*[TT](self: SubGate[TT], payload: Payload[TT]): SmallDiffs[TT] {.noInit, inline, locks:0.}=
+  let gradient = payload.variable.grad
   result[0] = gradient
   result[1] = -gradient
 
@@ -92,7 +94,7 @@ proc `-`*[TT](a, b: Variable[TT]): Variable[TT] =
 
   # Resulting var
   result = gate.forward(a, b)
-  node.payload = result
+  node.payload = Payload[TT](kind: pkVar, variable: result)
 
   # Caching for backprop
   if a.is_grad_needed or b.is_grad_needed:

--- a/src/autograd/gates_shapeshifting.nim
+++ b/src/autograd/gates_shapeshifting.nim
@@ -77,3 +77,52 @@ proc stack*[TT](variables: varargs[Variable[TT]], axis = 0): Variable[TT] =
   if anyIt(variables, it.is_grad_needed):
     result.grad = zeros[getSubType(TT)](result.value.shape)
     result.requires_grad = true
+
+type ChunkSplitGate*[TT] = ref object of Gate[TT]
+  axis: int
+
+proc forward_chunk[TT](self: ChunkSplitGate[TT], x: Variable[TT], nb_chunks: Positive): seq[Variable[TT]] {.inline.}=
+  result = x.data.chunk(nb_chunks, self.axis).mapIt(ctx.variable)
+
+method backward[TT](self: ChunkSplitGate[TT], payload: Payload[TT]): SmallDiffs[TT] =
+  let gradients = payload.sequence
+  var tensors = newSeq[TT](gradients.len) # TODO, inefficient to build a temp seq
+  for i, val in gradients:
+    tensors[i] = val.grad
+  result[0] = concat(tensors, self.axis)
+
+proc chunk*[TT](v: Variable[TT], nb_chunks: Positive, axis: Natural): seq[Variable[TT]] =
+  ## Splits a Variable into n chunks along the specified axis.
+  ##
+  ## In case a tensor cannot be split evenly,
+  ## with la == length_axis, n = n_chunks
+  ## it returns la mod n subtensors of size `(la div n) + 1`
+  ##            the rest of size `la div n`.
+  ##
+  ## This is consistent with numpy array_split
+
+  # Gate
+  var gate: ChunkSplitGate[TT]
+  new gate
+  gate.nb_grads = 1
+  gate.axis = axis
+
+  # Node
+  var node: Node[TT]
+  new node
+
+  node.gate = gate
+  node.parents[0] = v.weakRef
+  v.context.push node
+
+  # Resulting var
+  result = gate.forward_chunk v
+  node.payload = Payload[TT](kind: pkVar, sequence: result)
+
+  # Caching for backprop
+  if v.requires_grad:
+    gate.cache = result
+    gate.index_splits = newSeqUninitialized[int](nb_chunks)
+    for idx, variable in result:
+      variable.requires_grad = true
+      variable.grad = zeros_like variable.value

--- a/src/autograd/gates_shapeshifting_concat_split.nim
+++ b/src/autograd/gates_shapeshifting_concat_split.nim
@@ -79,7 +79,7 @@ proc stack*[TT](variables: varargs[Variable[TT]], axis = 0): Variable[TT] =
 
 # ###########################################################
 
-type ChunkSplitGate*[TT] = ref object of Gate[TT]
+type ChunkSplitGate*{.final.}[TT] = ref object of Gate[TT]
   axis: int
 
 proc forward_chunk[TT](self: ChunkSplitGate[TT], x: Variable[TT], nb_chunks: Positive): seq[Variable[TT]] {.inline.}=

--- a/src/nn/activation/relu.nim
+++ b/src/nn/activation/relu.nim
@@ -19,13 +19,14 @@ import  ../../tensor/tensor,
 type ReluActivation* {.final.} [TT] = ref object of Gate[TT]
   cache: TT
 
-method forward*[TT](self: ReluActivation[TT], a: Variable[TT]): Variable[TT] {.inline, locks:0.}=
+proc forward[TT](self: ReluActivation[TT], a: Variable[TT]): Variable[TT] {.inline.}=
   new result
 
   result.context = a.context
   result.value = relu a.value
 
-method backward*[TT](self: ReluActivation[TT], gradient: TT): SmallDiffs[TT] {.noInit, inline, locks:0.}=
+method backward*[TT](self: ReluActivation[TT], payload: Payload[TT]): SmallDiffs[TT] {.noInit, inline, locks:0.}=
+  let gradient = payload.variable.grad
   result[0] = gradient.relu_backward(self.cache)
 
 proc relu*[TT](a: Variable[TT]): Variable[TT] =
@@ -48,7 +49,7 @@ proc relu*[TT](a: Variable[TT]): Variable[TT] =
 
   # Resulting var
   result = gate.forward(a)
-  node.payload = result
+  node.payload = Payload[TT](kind: pkVar, variable: result)
 
   # Caching for backprop
   if a.is_grad_needed:

--- a/src/nn/activation/sigmoid.nim
+++ b/src/nn/activation/sigmoid.nim
@@ -19,13 +19,14 @@ import  ../../autograd/autograd,
 type SigmoidActivation* {.final.} [TT] = ref object of Gate[TT]
   cache: TT
 
-method forward*[TT](self: SigmoidActivation[TT], a: Variable[TT]): Variable[TT] {.inline, locks:0.}=
+proc forward[TT](self: SigmoidActivation[TT], a: Variable[TT]): Variable[TT] {.inline.}=
   new result
 
   result.context = a.context
   result.value = sigmoid a.value
 
-method backward*[TT](self: SigmoidActivation[TT], gradient: TT): SmallDiffs[TT] {.noInit, inline, locks:0.}=
+method backward*[TT](self: SigmoidActivation[TT], payload: Payload[TT]): SmallDiffs[TT] {.noInit, inline, locks:0.}=
+  let gradient = payload.variable.grad
   result[0] = gradient.sigmoid_backward(self.cache)
 
 proc sigmoid*[TT](a: Variable[TT]): Variable[TT] =
@@ -48,7 +49,7 @@ proc sigmoid*[TT](a: Variable[TT]): Variable[TT] =
 
   # Resulting var
   result = gate.forward(a)
-  node.payload = result
+  node.payload = Payload[TT](kind: pkVar, variable: result)
 
   # Caching for backprop
   if a.is_grad_needed:

--- a/src/nn/activation/tanh.nim
+++ b/src/nn/activation/tanh.nim
@@ -19,13 +19,14 @@ import  ../../autograd/autograd,
 type TanhActivation* {.final.} [TT] = ref object of Gate[TT]
   cache: TT
 
-method forward*[TT](self: TanhActivation[TT], a: Variable[TT]): Variable[TT] {.inline, locks:0.}=
+proc forward[TT](self: TanhActivation[TT], a: Variable[TT]): Variable[TT] {.inline.}=
   new result
 
   result.context = a.context
   result.value = tanh a.value
 
-method backward*[TT](self: TanhActivation[TT], gradient: TT): SmallDiffs[TT] {.noInit, inline, locks:0.}=
+method backward*[TT](self: TanhActivation[TT], payload: Payload[TT]): SmallDiffs[TT] {.noInit, inline, locks:0.}=
+  let gradient = payload.variable.grad
   result[0] = gradient.tanh_backward(self.cache)
 
 proc tanh*[TT](a: Variable[TT]): Variable[TT] =
@@ -48,7 +49,7 @@ proc tanh*[TT](a: Variable[TT]): Variable[TT] =
 
   # Resulting var
   result = gate.forward(a)
-  node.payload = result
+  node.payload = Payload[TT](kind: pkVar, variable: result)
 
   # Caching for backprop
   if a.is_grad_needed:

--- a/src/nn/layers/linear.nim
+++ b/src/nn/layers/linear.nim
@@ -20,7 +20,7 @@ type LinearGate* {.final.} [TT] = ref object of Gate[TT]
   ## TODO: use fused AddMatMul gate: C <- alpha AB + beta C
   input, weight, bias: Variable[TT]
 
-method forward*[TT](self: LinearGate[TT], input: Variable[TT]): Variable[TT] {.inline, locks:0.}=
+proc forward[TT](self: LinearGate[TT], input: Variable[TT]): Variable[TT] {.inline.}=
   new result
 
   if self.bias.isNil:
@@ -30,10 +30,12 @@ method forward*[TT](self: LinearGate[TT], input: Variable[TT]): Variable[TT] {.i
 
   result.context = input.context
 
-method backward*[TT](self: LinearGate[TT], gradOutput: TT): SmallDiffs[TT] {.noInit, inline, locks:0.}=
+method backward*[TT](self: LinearGate[TT], payload: Payload[TT]): SmallDiffs[TT] {.noInit, inline, locks:0.}=
   # result[0] grad w.r.t. input
   # result[1] grad w.r.t. weight
   # result[2] grad w.r.t. bias
+
+  let gradOutput = payload.variable.grad
 
   if self.input.requires_grad:
     result[0] = gradOutput * self.weight.value
@@ -95,7 +97,7 @@ proc linear*[TT](input, weight: Variable[TT], bias: Variable[TT] = nil): Variabl
 
   # Resulting var
   result = gate.forward(input)
-  node.payload = result
+  node.payload = Payload[TT](kind: pkVar, variable: result)
 
   # Caching for backprop
   if input.is_grad_needed or weight.is_grad_needed or (not bias.isNil and bias.is_grad_needed):

--- a/src/nn/loss/loss.nim
+++ b/src/nn/loss/loss.nim
@@ -20,16 +20,5 @@ import  ../../tensor/tensor,
 type Loss* [TT] = ref object of Gate[TT]
   target*: TT
 
-
-method forward*[TT](self: Loss[TT], a: Variable[TT], target: TT): Variable[TT] {.base, inline.}=
-  # Forward for loss layers
-  raise newException(ValueError, "forward method is not implemented for " & $self.type.name)
-
-
 type SparseLoss* [TT] = ref object of Gate[TT]
   target*: Tensor[int]
-
-
-method forward*[TT](self: SparseLoss[TT], a: Variable[TT], target: Tensor[int]): Variable[TT] {.base, inline.}=
-  # Forward for sparse loss layers
-  raise newException(ValueError, "forward method is not implemented for " & $self.type.name)

--- a/src/nn/nn.nim
+++ b/src/nn/nn.nim
@@ -20,10 +20,8 @@ import  ./activation/sigmoid,
         ./layers/maxpool2D,
         ./loss/cross_entropy_losses,
         ./loss/mean_square_error_loss,
-        ./optimizers/optimizers,
-        ./shapeshifting/reshape_flatten
+        ./optimizers/optimizers
 
 export sigmoid, relu, tanh
 export linear, conv2D, maxpool2d, cross_entropy_losses, mean_square_error_loss
 export optimizers
-export reshape_flatten

--- a/tests/autograd/test_gate_shapeshifting.nim
+++ b/tests/autograd/test_gate_shapeshifting.nim
@@ -91,7 +91,6 @@ suite "Autograd of shapeshifting operations":
     # Then we slice each with t[0 ..< 2, _]
 
     let
-      height = rand(1..20)
       width = rand(1..20)
 
       x = randomTensor([10, width], 1.0)
@@ -132,3 +131,57 @@ suite "Autograd of shapeshifting operations":
 
     loss.backprop()
     check: mean_relative_error(vx.grad, expected) < 1e-07
+
+  test "Gradient of squeeze operation":
+
+    let
+      M = rand(1..20)
+      N = rand(1..20)
+
+      x = randomTensor([1, M, N], 1.0)
+      y = randomTensor([M, 1, N], 1.0)
+      z = randomTensor([N, M, 3], 1.0)
+
+    proc network_x(x: Tensor[float64]): float64 =
+      result = 0
+      for t in z.chunk(3, axis = 2):
+        result += sum(
+          (x.squeeze(0) + y.squeeze(1)) * t.squeeze(2)
+        )
+    proc network_y(y: Tensor[float64]): float64 =
+      result = 0
+      for t in z.chunk(3, axis = 2):
+        result += sum(
+          (x.squeeze(0) + y.squeeze(1)) * t.squeeze(2)
+        )
+    proc network_z(z: Tensor[float64]): float64 =
+      result = 0
+      for t in z.chunk(3, axis = 2):
+        result += sum(
+          (x.squeeze(0) + y.squeeze(1)) * t.squeeze(2)
+        )
+
+    let
+      expected_x = x.clone().numerical_gradient(network_x)
+      expected_y = y.clone().numerical_gradient(network_y)
+      expected_z = z.clone().numerical_gradient(network_z)
+      ctx = newContext Tensor[float64]
+      vx = ctx.variable(x, requires_grad = true)
+      vy = ctx.variable(y, requires_grad = true)
+      vz = ctx.variable(z, requires_grad = true)
+
+    # TODO: ease the following construct with variables
+    let chunked = vz.chunk(3, axis = 2)
+    var loss = sum(
+      (vx.squeeze(0) + vy.squeeze(1)) * chunked[0].squeeze(2)
+    )
+    for i in 1..2:
+      loss = loss + sum(
+        (vx.squeeze(0) + vy.squeeze(1)) * chunked[i].squeeze(2)
+      )
+
+    loss.backprop()
+    check:
+      mean_relative_error(vx.grad, expected_x) < 1e-07
+      mean_relative_error(vy.grad, expected_y) < 1e-07
+      mean_relative_error(vz.grad, expected_z) < 1e-07

--- a/tests/end_to_end/examples.nim
+++ b/tests/end_to_end/examples.nim
@@ -5,106 +5,110 @@
 import ../../src/arraymancer
 import unittest, random
 
+proc ex01() =
+  let ctx = newContext Tensor[float32]
+
+  let bsz = 32
+  let x_train_bool = randomTensor([bsz * 10, 2], 1).astype(bool)
+  let y_bool = x_train_bool[_,0] xor x_train_bool[_,1]
+
+  let x_train = ctx.variable(x_train_bool.astype(float32))
+  let y = y_bool.astype(float32)
+
+  let layer_3neurons = ctx.variable(
+                        randomTensor(3, 2, 2.0f) .- 1.0f,
+                        true
+                        )
+
+  let classifier_layer = ctx.variable(
+                    randomTensor(1, 3, 2.0f) .- 1.0f,
+                    true
+                    )
+
+  let optim = newSGD[float32](
+    layer_3neurons, classifier_layer, 0.01f # 0.01 is the learning rate
+  )
+
+  for epoch in 0..1:
+    for batch_id in 0..<10:
+
+      let offset = batch_id * 32
+      let x = x_train[offset ..< offset + 32, _]
+      let target = y[offset ..< offset + 32, _]
+
+      let n1 = relu linear(x, layer_3neurons)
+      let n2 = linear(n1, classifier_layer)
+      let loss = sigmoid_cross_entropy(n2, target)
+
+      # echo "Epoch is:" & $epoch
+      # echo "Batch id:" & $batch_id
+      # echo "Loss is:" & $loss.value.data[0]
+
+      loss.backprop()
+
+      optim.update()
+
+#########################################################################
+
+proc ex02() =
+  randomize(42)
+
+  let
+    ctx = newContext Tensor[float32]
+    n = 32
+
+  let
+    mnist = load_mnist(cache = true)
+    x_train = mnist.train_images.astype(float32) / 255'f32
+    X_train = ctx.variable x_train.unsqueeze(1)
+    y_train = mnist.train_labels.astype(int)
+    x_test = mnist.test_images.astype(float32) / 255'f32
+    X_test = ctx.variable x_test.unsqueeze(1)
+    y_test = mnist.test_labels.astype(int)
+
+  network ctx, DemoNet:
+    layers:
+      x:          Input([1, 28, 28])
+      cv1:        Conv2D(x.out_shape, 20, 5, 5)
+      mp1:        MaxPool2D(cv1.out_shape, (2,2), (0,0), (2,2))
+      cv2:        Conv2D(mp1.out_shape, 50, 5, 5)
+      mp2:        MaxPool2D(cv2.out_shape, (2,2), (0,0), (2,2))
+      fl:         Flatten(mp2.out_shape)
+      hidden:     Linear(fl.out_shape, 500)
+      classifier: Linear(500, 10)
+    forward x:
+      x.cv1.relu.mp1.cv2.relu.mp2.fl.hidden.relu.classifier
+
+  let model = ctx.init(DemoNet)
+
+  let optim = model.optimizerSGD(learning_rate = 0.01'f32)
+
+  for epoch in 0 ..< 1:
+    for batch_id in 0 ..< 1:
+      let offset = batch_id * n
+      let x = X_train[offset ..< offset + n, _]
+      let target = y_train[offset ..< offset + n]
+
+      let clf = model.forward(x)
+      let loss = clf.sparse_softmax_cross_entropy(target)
+
+      loss.backprop()
+      optim.update()
+
+    # Validation (checking the accuracy/generalization of our model on unseen data)
+    ctx.no_grad_mode:
+      var score = 0.0
+      var loss = 0.0
+      for i in 0 ..< 1:
+        let y_pred = model.forward(X_test[i*1000 ..< (i+1)*1000, _]).value.softmax.argmax(axis = 1).squeeze
+        score += accuracy_score(y_test[i*1000 ..< (i+1)*1000], y_pred)
+
+        loss += model.forward(X_test[i*1000 ..< (i+1)*1000, _]).sparse_softmax_cross_entropy(y_test[i*1000 ..< (i+1)*1000]).value.data[0]
+      score /= 10
+      loss /= 10
+
 suite "End-to-End: Examples compile and run":
   test "Example 1: XOR Perceptron":
-    let ctx = newContext Tensor[float32]
-
-    let bsz = 32
-    let x_train_bool = randomTensor([bsz * 10, 2], 1).astype(bool)
-    let y_bool = x_train_bool[_,0] xor x_train_bool[_,1]
-
-    let x_train = ctx.variable(x_train_bool.astype(float32))
-    let y = y_bool.astype(float32)
-
-    let layer_3neurons = ctx.variable(
-                          randomTensor(3, 2, 2.0f) .- 1.0f,
-                          true
-                          )
-
-    let classifier_layer = ctx.variable(
-                      randomTensor(1, 3, 2.0f) .- 1.0f,
-                      true
-                      )
-
-    let optim = newSGD[float32](
-      layer_3neurons, classifier_layer, 0.01f # 0.01 is the learning rate
-    )
-
-    for epoch in 0..1:
-      for batch_id in 0..<10:
-
-        let offset = batch_id * 32
-        let x = x_train[offset ..< offset + 32, _]
-        let target = y[offset ..< offset + 32, _]
-
-        let n1 = relu linear(x, layer_3neurons)
-        let n2 = linear(n1, classifier_layer)
-        let loss = sigmoid_cross_entropy(n2, target)
-
-        # echo "Epoch is:" & $epoch
-        # echo "Batch id:" & $batch_id
-        # echo "Loss is:" & $loss.value.data[0]
-
-        loss.backprop()
-
-        optim.update()
-
-    # test "Example 2: MNIST via Convolutional Neural Net":
-    #   proc ex02() =
-    #     randomize(42)
-
-    #     let
-    #       ctx = newContext Tensor[float32]
-    #       n = 32
-
-    #     let
-    #       mnist = load_mnist()
-    #       x_train = mnist.train_images.astype(float32) / 255'f32
-    #       X_train = ctx.variable x_train.unsqueeze(1)
-    #       y_train = mnist.train_labels.astype(int)
-    #       x_test = mnist.test_images.astype(float32) / 255'f32
-    #       X_test = ctx.variable x_test.unsqueeze(1)
-    #       y_test = mnist.test_labels.astype(int)
-
-    #     network ctx, DemoNet:
-    #       layers:
-    #         x:          Input([1, 28, 28])
-    #         cv1:        Conv2D(x.out_shape, 20, 5, 5)
-    #         mp1:        MaxPool2D(cv1.out_shape, (2,2), (0,0), (2,2))
-    #         cv2:        Conv2D(mp1.out_shape, 50, 5, 5)
-    #         mp2:        MaxPool2D(cv2.out_shape, (2,2), (0,0), (2,2))
-    #         fl:         Flatten(mp2.out_shape)
-    #         hidden:     Linear(fl.out_shape, 500)
-    #         classifier: Linear(500, 10)
-    #       forward x:
-    #         x.cv1.relu.mp1.cv2.relu.mp2.fl.hidden.relu.classifier
-
-    #     let model = ctx.init(DemoNet)
-
-    #     let optim = model.optimizerSGD(learning_rate = 0.01'f32)
-
-    #     for epoch in 0 ..< 1:
-    #       for batch_id in 0 ..< 1:
-    #         let offset = batch_id * n
-    #         let x = X_train[offset ..< offset + n, _]
-    #         let target = y_train[offset ..< offset + n]
-
-    #         let clf = model.forward(x)
-    #         let loss = clf.sparse_softmax_cross_entropy(target)
-
-    #         loss.backprop()
-    #         optim.update()
-
-    #       # Validation (checking the accuracy/generalization of our model on unseen data)
-    #       ctx.no_grad_mode:
-    #         var score = 0.0
-    #         var loss = 0.0
-    #         for i in 0 ..< 10:
-    #           let y_pred = model.forward(X_test[i*1000 ..< (i+1)*1000, _]).value.softmax.argmax(axis = 1).squeeze
-    #           score += accuracy_score(y_test[i*1000 ..< (i+1)*1000], y_pred)
-
-    #           loss += model.forward(X_test[i*1000 ..< (i+1)*1000, _]).sparse_softmax_cross_entropy(y_test[i*1000 ..< (i+1)*1000]).value.data[0]
-    #         score /= 10
-    #         loss /= 10
-
-    #   ex02()
+    ex01()
+  test "Example 2: MNIST via Convolutional Neural Net":
+    ex02()


### PR DESCRIPTION
Add backpropagation for:

  - [x] squeeze
  - [x] unsqueeze
  - [x] chunk
  - [ ] split

This requires supporting `seq[Variable[TT]]` payloads in the autograd instead of just `Variable[TT]`

Additionally this brings the following autograd improvement:

  - static dispatch during the forward pass, fix #296 