### PR TITLE
Backpropagation: support unlimited parent tensors

### DIFF
--- a/benchmarks/ex02_mnist.nim
+++ b/benchmarks/ex02_mnist.nim
@@ -1,0 +1,61 @@
+import ../src/arraymancer, random
+
+# Make the results reproducible by initializing a random seed
+randomize(42)
+
+let
+  ctx = newContext Tensor[float32] # Autograd/neural network graph
+  n = 32                           # Batch size
+
+let
+  mnist = load_mnist(cache = true)
+  x_train = mnist.train_images.astype(float32) / 255'f32
+  X_train = ctx.variable x_train.unsqueeze(1)
+  y_train = mnist.train_labels.astype(int)
+
+  x_test = mnist.test_images.astype(float32) / 255'f32
+  X_test = ctx.variable x_test.unsqueeze(1)
+  y_test = mnist.test_labels.astype(int)
+
+# Configuration of the neural network
+network ctx, DemoNet:
+  layers:
+    x:          Input([1, 28, 28])
+    cv1:        Conv2D(x.out_shape, 20, 5, 5)
+    mp1:        MaxPool2D(cv1.out_shape, (2,2), (0,0), (2,2))
+    cv2:        Conv2D(mp1.out_shape, 50, 5, 5)
+    mp2:        MaxPool2D(cv2.out_shape, (2,2), (0,0), (2,2))
+    fl:         Flatten(mp2.out_shape)
+    hidden:     Linear(fl.out_shape, 500)
+    classifier: Linear(500, 10)
+  forward x:
+    x.cv1.relu.mp1.cv2.relu.mp2.fl.hidden.relu.classifier
+
+let model = ctx.init(DemoNet)
+
+# Stochastic Gradient Descent (API will change)
+let optim = model.optimizerSGD(learning_rate = 0.01'f32)
+
+# Learning loop
+for epoch in 0 ..< 2:
+  for batch_id in 0 ..< X_train.value.shape[0] div n: # some at the end may be missing
+    let offset = batch_id * n
+    let x = X_train[offset ..< offset + n, _]
+    let target = y_train[offset ..< offset + n]
+
+    let clf = model.forward(x)
+    let loss = clf.sparse_softmax_cross_entropy(target)
+
+    loss.backprop()
+    optim.update()
+
+  ctx.no_grad_mode:
+    var score = 0.0
+    var loss = 0.0
+    for i in 0 ..< 10:
+      let y_pred = model.forward(X_test[i*1000 ..< (i+1)*1000, _]).value.softmax.argmax(axis = 1).squeeze
+      score += accuracy_score(y_test[i*1000 ..< (i+1)*1000], y_pred)
+
+      loss += model.forward(X_test[i*1000 ..< (i+1)*1000, _]).sparse_softmax_cross_entropy(y_test[i*1000 ..< (i+1)*1000]).value.data[0]
+    score /= 10
+    loss /= 10

--- a/examples/ex02_handwritten_digits_recognition.nim
+++ b/examples/ex02_handwritten_digits_recognition.nim
@@ -15,7 +15,7 @@ let
   n = 32                           # Batch size
 
 let
-  mnist = load_mnist()
+  mnist = load_mnist(cache = true)
   # Training data is 60k 28x28 greyscale images from 0-255,
   # neural net prefers input rescaled to [0, 1] or [-1, 1]
   x_train = mnist.train_images.astype(float32) / 255'f32

--- a/src/autograd/gates_reduce.nim
+++ b/src/autograd/gates_reduce.nim
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import  ../private/[ast_utils, functional],
+import  ../private/[ast_utils, sequninit],
         ../tensor/tensor,
         ./ag_data_structure,
         sequtils
@@ -27,8 +27,9 @@ proc forward[TT](self: MeanGate[TT], a: Variable[TT]): Variable[TT] {.inline.}=
   result.context = a.context
   result.value = [a.value.mean].toTensor
 
-method backward*[TT](self: MeanGate[TT], payload: Payload[TT]): SmallDiffs[TT] {.noInit, inline, locks:0.}=
+method backward*[TT](self: MeanGate[TT], payload: Payload[TT]): SmallDiffs[TT] {.noInit, inline.}=
   let gradient = payload.variable.grad
+  result = newSeqUninit[TT](1)
   result[0] = gradient / getSubType(TT)(self.cached_input_shape.product) # Conversion to subtype T, oh Higher kinded-types ...
 
   let z_shape = newSeqWith(self.cached_input_shape.len, 1) # We create a shape of 1 dimension that we will expand with broadcast
@@ -38,13 +39,13 @@ proc mean*[TT](a: Variable[TT]): Variable[TT] =
   # Gate
   var gate: MeanGate[TT]
   new gate
-  gate.nb_grads = 1
 
   # Node
   var node: Node[TT]
   new node
 
   node.gate = gate
+  node.parents = newSeqUninit[VariablePtr[TT]](1)
   node.parents[0] = a.weakRef
 
   a.context.push(node)
@@ -70,8 +71,9 @@ proc forward[TT](self: SumGate[TT], a: Variable[TT]): Variable[TT] {.inline.}=
   result.context = a.context
   result.value = [a.value.sum].toTensor
 
-method backward*[TT](self: SumGate[TT], payload: Payload[TT]): SmallDiffs[TT] {.noInit, inline, locks:0.}=
+method backward*[TT](self: SumGate[TT], payload: Payload[TT]): SmallDiffs[TT] {.noInit, inline.}=
   let gradient = payload.variable.grad
+  result = newSeqUninit[TT](1)
 
   let z_shape = newSeqWith(self.cached_input_shape.len, 1) # We create a shape of 1 dimension that we will expand with broadcast
   result[0] = gradient.reshape(z_shape).broadcast(self.cached_input_shape)
@@ -80,13 +82,13 @@ proc sum*[TT](a: Variable[TT]): Variable[TT] =
   # Gate
   var gate: SumGate[TT]
   new gate
-  gate.nb_grads = 1
 
   # Node
   var node: Node[TT]
   new node
 
   node.gate = gate
+  node.parents = newSeqUninit[VariablePtr[TT]](1)
   node.parents[0] = a.weakRef
 
   a.context.push(node)


### PR DESCRIPTION
Partially address #293 
This is key for using the stack ops


Baseline benchmark - https://github.com/mratsim/Arraymancer/commit/70dfd2ecdce5bbc996524aa0400f2f6b2a343aea

Note only GEMM calls (including convolution) are parallel as they use BLAS.

![2018-09-30_16-20-22](https://user-images.githubusercontent.com/22738317/46258554-21d8db80-c4cd-11e8-9885-b8952fb3a320.png)


