### PR TITLE
Replace sugar with future module

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Here is a preview of Arraymancer syntax.
 
 ### Tensor creation and slicing
 ```Nim
-import math, arraymancer, future
+import math, arraymancer, sugar
 
 const
     x = @[1, 2, 3, 4, 5]


### PR DESCRIPTION
Since future module has been deprecated, we can use sugar instead.