### PR TITLE
support complex tensor for cpu backend

### DIFF
--- a/src/ml/metrics/common_error_functions.nim
+++ b/src/ml/metrics/common_error_functions.nim
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import ../../tensor/tensor
+import complex except Complex64, Complex32
 
 
 # ####################################################

--- a/src/tensor/aggregate.nim
+++ b/src/tensor/aggregate.nim
@@ -20,6 +20,7 @@ import  ./backend/memory_optimization_hints,
         ./math_functions,
         ./accessors,
         math
+import complex except Complex64, Complex32
 
 # ### Standard aggregate functions
 # TODO consider using stats from Nim standard lib: https://nim-lang.org/docs/stats.html#standardDeviation,RunningStat
@@ -56,11 +57,11 @@ proc mean*[T: SomeInteger](t: Tensor[T], axis: int): Tensor[T] {.noInit,inline.}
   ## Warning ⚠: Since input is integer, output will also be integer (using integer division)
   t.sum(axis) div t.shape[axis].T
 
-proc mean*[T: SomeFloat](t: Tensor[T]): T {.inline.}=
+proc mean*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T]): T {.inline.}=
   ## Compute the mean of all elements
   t.sum / t.size.T
 
-proc mean*[T: SomeFloat](t: Tensor[T], axis: int): Tensor[T] {.noInit,inline.}=
+proc mean*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T], axis: int): Tensor[T] {.noInit,inline.}=
   ## Compute the mean along an axis
   t.sum(axis) / t.shape[axis].T
 

--- a/src/tensor/init_cpu.nim
+++ b/src/tensor/init_cpu.nim
@@ -21,6 +21,7 @@ import  ../private/[functional, nested_containers, sequninit],
         sequtils,
         random,
         math
+include ./private/p_complex
 
 proc newTensorUninit*[T](shape: varargs[int]): Tensor[T] {.noSideEffect,noInit, inline.} =
   ## Creates a new Tensor on Cpu backend
@@ -108,7 +109,7 @@ proc toTensor*(s:string): auto {.noSideEffect.} =
   ## This proc handles string specifically as otherwise they are interpreted as a sequence of char
   toTensorCpu(s)
 
-proc zeros*[T: SomeNumber](shape: varargs[int]): Tensor[T] {.noInit,noSideEffect, inline.} =
+proc zeros*[T: SomeNumber|Complex[float32]|Complex[float64]](shape: varargs[int]): Tensor[T] {.noInit,noSideEffect, inline.} =
   ## Creates a new Tensor filled with 0
   ##
   ## Input:
@@ -119,7 +120,7 @@ proc zeros*[T: SomeNumber](shape: varargs[int]): Tensor[T] {.noInit,noSideEffect
   tensorCpu(shape, result)
   result.storage.Fdata = newSeq[T](result.size)
 
-proc zeros*[T: SomeNumber](shape: MetadataArray): Tensor[T] {.noInit,noSideEffect, inline.} =
+proc zeros*[T: SomeNumber|Complex[float32]|Complex[float64]](shape: MetadataArray): Tensor[T] {.noInit,noSideEffect, inline.} =
   ## Creates a new Tensor filled with 0
   ##
   ## Input:
@@ -130,7 +131,7 @@ proc zeros*[T: SomeNumber](shape: MetadataArray): Tensor[T] {.noInit,noSideEffec
   tensorCpu(shape, result)
   result.storage.Fdata = newSeq[T](result.size)
 
-proc zeros_like*[T: SomeNumber](t: Tensor[T]): Tensor[T] {.noInit,noSideEffect, inline.} =
+proc zeros_like*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T]): Tensor[T] {.noInit,noSideEffect, inline.} =
   ## Creates a new Tensor filled with 0 with the same shape as the input
   ## Input:
   ##      - Shape of the Tensor
@@ -139,7 +140,7 @@ proc zeros_like*[T: SomeNumber](t: Tensor[T]): Tensor[T] {.noInit,noSideEffect, 
   ##      - A zero-ed Tensor of the same shape
   result = zeros[T](t.shape)
 
-proc ones*[T: SomeNumber](shape: varargs[int]): Tensor[T] {.noInit, inline, noSideEffect.} =
+proc ones*[T: SomeNumber|Complex[float32]|Complex[float64]](shape: varargs[int]): Tensor[T] {.noInit, inline, noSideEffect.} =
   ## Creates a new Tensor filled with 1
   ## Input:
   ##      - Shape of the Tensor
@@ -148,7 +149,7 @@ proc ones*[T: SomeNumber](shape: varargs[int]): Tensor[T] {.noInit, inline, noSi
   ##      - A one-ed Tensor of the same shape
   newTensorWith[T](shape, 1.T)
 
-proc ones*[T: SomeNumber](shape: MetadataArray): Tensor[T] {.noInit, inline, noSideEffect.} =
+proc ones*[T: SomeNumber|Complex[float32]|Complex[float64]](shape: MetadataArray): Tensor[T] {.noInit, inline, noSideEffect.} =
   ## Creates a new Tensor filled with 1
   ## Input:
   ##      - Shape of the Tensor
@@ -157,7 +158,7 @@ proc ones*[T: SomeNumber](shape: MetadataArray): Tensor[T] {.noInit, inline, noS
   ##      - A one-ed Tensor of the same shape
   newTensorWith[T](shape, 1.T)
 
-proc ones_like*[T: SomeNumber](t: Tensor[T]): Tensor[T] {.noInit, inline, noSideEffect.} =
+proc ones_like*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T]): Tensor[T] {.noInit, inline, noSideEffect.} =
   ## Creates a new Tensor filled with 1 with the same shape as the input
   ## and filled with 1
   ## Input:

--- a/src/tensor/math_functions.nim
+++ b/src/tensor/math_functions.nim
@@ -16,6 +16,7 @@ import  ./data_structure,
         ./init_cpu,
         ./higher_order_applymap,
         ./ufunc
+import complex except Complex64, Complex32
 
 # Non-operator math functions
 
@@ -43,11 +44,11 @@ proc melwise_div*[T: SomeFloat](a: var Tensor[T], b: Tensor[T]) =
   ## Element-wise division (in-place)
   a.apply2_inline(b, x / y)
 
-proc reciprocal*[T: SomeFloat](t: Tensor[T]): Tensor[T] {.noInit.} =
+proc reciprocal*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Return a tensor with the reciprocal 1/x of all elements
   t.map_inline(1.T/x)
 
-proc mreciprocal*[T: SomeFloat](t: var Tensor[T]) =
+proc mreciprocal*[T: SomeFloat|Complex[float32]|Complex[float64]](t: var Tensor[T]) =
   ## Apply the reciprocal 1/x in-place to all elements of the Tensor
   t.apply_inline(1.T/x)
 
@@ -64,12 +65,22 @@ proc `-`*[T: SomeNumber](t: Tensor[T]): Tensor[T] {.noInit.} =
   t.map_inline(-x)
 
 # Built-in nim function that doesn't work with makeUniversal
-proc abs*[T](t: Tensor[T]): Tensor[T] {.noInit.} =
+proc abs*[T:SomeNumber](t: Tensor[T]): Tensor[T] {.noInit.} =
+  ## Return a Tensor with absolute values of all elements
+  t.map_inline(abs(x))
+
+# complex abs -> float
+proc abs*(t: Tensor[Complex[float64]]): Tensor[float64] {.noInit.} =
+  ## Return a Tensor with absolute values of all elements
+  t.map_inline(abs(x))
+
+proc abs*(t: Tensor[Complex[float32]]): Tensor[float32] {.noInit.} =
   ## Return a Tensor with absolute values of all elements
   t.map_inline(abs(x))
 
 proc mabs*[T](t: var Tensor[T]) =
   ## Return a Tensor with absolute values of all elements
+  # FIXME: how to inplace convert Tensor[Complex] to Tensor[float]
   t.apply_inline(abs(x))
 
 proc clamp*[T](t: Tensor[T], min, max: T): Tensor[T] {.noInit.} =

--- a/src/tensor/operators_blas_l1.nim
+++ b/src/tensor/operators_blas_l1.nim
@@ -16,6 +16,7 @@ import  ./private/p_checks,
         ./data_structure,
         ./accessors, ./higher_order_applymap,
         nimblas
+import complex except Complex32, Complex64
 
 # ####################################################################
 # BLAS Level 1 (Vector dot product, Addition, Scalar to Vector/Matrix)
@@ -25,6 +26,7 @@ import  ./private/p_checks,
 
 proc dot*[T: SomeFloat](a, b: Tensor[T]): T {.noSideEffect.} =
   ## Vector to Vector dot (scalar) product
+  # TODO: blas's complex vector dot only support dotu and dotc
   when compileOption("boundChecks"): check_dot_prod(a,b)
   return dot(a.shape[0], a.get_offset_ptr, a.strides[0], b.get_offset_ptr, b.strides[0])
 
@@ -39,37 +41,37 @@ proc dot*[T: SomeInteger](a, b: Tensor[T]): T {.noSideEffect.} =
 # # Tensor-Tensor linear algebra
 # # shape checks are done in map2 proc
 
-proc `+`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] {.noInit.} =
+proc `+`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Tensor addition
   map2_inline(a, b, x + y)
 
-proc `-`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] {.noInit.} =
+proc `-`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Tensor substraction
   map2_inline(a, b, x - y)
 
 # #########################################################
 # # Tensor-Tensor in-place linear algebra
 
-proc `+=`*[T: SomeNumber](a: var Tensor[T], b: Tensor[T]) =
+proc `+=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
   ## Tensor in-place addition
   a.apply2_inline(b, x + y)
 
-proc `-=`*[T: SomeNumber](a: var Tensor[T], b: Tensor[T]) =
+proc `-=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
   ## Tensor in-place substraction
   a.apply2_inline(b, x - y)
 
 # #########################################################
 # # Tensor-scalar linear algebra
 
-proc `*`*[T: SomeNumber](a: T, t: Tensor[T]): Tensor[T] {.noInit.} =
+proc `*`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: T, t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Element-wise multiplication by a scalar
   t.map_inline(x * a)
 
-proc `*`*[T: SomeNumber](t: Tensor[T], a: T): Tensor[T] {.noInit.} =
+proc `*`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], a: T): Tensor[T] {.noInit.} =
   ## Element-wise multiplication by a scalar
   a * t
 
-proc `/`*[T: SomeFloat](t: Tensor[T], a: T): Tensor[T] {.noInit.} =
+proc `/`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T], a: T): Tensor[T] {.noInit.} =
   ## Element-wise division by a float scalar
   t.map_inline(x / a)
 
@@ -80,11 +82,11 @@ proc `div`*[T: SomeInteger](t: Tensor[T], a: T): Tensor[T] {.noInit.} =
 # #########################################################
 # # Tensor-scalar in-place linear algebra
 
-proc `*=`*[T: SomeNumber](t: var Tensor[T], a: T) =
+proc `*=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], a: T) =
   ## Element-wise multiplication by a scalar (in-place)
   t.apply_inline(x * a)
 
-proc `/=`*[T: SomeFloat](t: var Tensor[T], a: T) =
+proc `/=`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: var Tensor[T], a: T) =
   ## Element-wise division by a scalar (in-place)
   t.apply_inline(x / a)
 

--- a/src/tensor/operators_blas_l2l3.nim
+++ b/src/tensor/operators_blas_l2l3.nim
@@ -20,8 +20,9 @@ import  ./private/p_checks,
         ./fallback/naive_l2_gemv,
         ./data_structure,
         ./init_cpu
+from complex import Complex
 
-proc gemv*[T: SomeFloat](
+proc gemv*[T: SomeFloat|Complex](
           alpha: T,
           A: Tensor[T],
           x: Tensor[T],
@@ -55,7 +56,7 @@ proc gemv*[T: SomeInteger](
 
   naive_gemv_fallback(alpha, A, x, beta, y)
 
-proc gemm*[T: SomeFloat](
+proc gemm*[T: SomeFloat|Complex](
   alpha: T, A, B: Tensor[T],
   beta: T, C: var Tensor[T]) {.inline.}=
   # Matrix: C = alpha A matmul B + beta C
@@ -85,10 +86,10 @@ proc gemm*[T: SomeNumber](
   C: var Tensor[T]) {.inline.}=
   gemm(1.T, A, B, 0.T, C)
 
-proc `*`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] {.noInit.} =
+proc `*`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Matrix multiplication (Matrix-Matrix and Matrix-Vector)
   ##
-  ## Float operations use optimized BLAS like OpenBLAS, Intel MKL or BLIS.
+  ## Float and complex operations use optimized BLAS like OpenBLAS, Intel MKL or BLIS.
 
   if a.rank == 2 and b.rank == 2:
     result = newTensorUninit[T](a.shape[0], b.shape[1])

--- a/src/tensor/operators_broadcasted.nim
+++ b/src/tensor/operators_broadcasted.nim
@@ -16,22 +16,23 @@ import  ./data_structure,
         ./higher_order_applymap,
         ./shapeshifting,
         ./math
+import complex except Complex64, Complex32
 
 # #########################################################
 # # Broadcasting Tensor-Tensor
 # # And element-wise multiplication (Hadamard) and division
 
-proc `.+`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] {.noInit,inline.} =
+proc `.+`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit,inline.} =
   ## Broadcasted addition for tensors of incompatible but broadcastable shape.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a + tmp_b
 
-proc `.-`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] {.noInit,inline.} =
+proc `.-`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit,inline.} =
   ## Broadcasted addition for tensors of incompatible but broadcastable shape.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a - tmp_b
 
-proc `.*`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] {.noInit.} =
+proc `.*`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Element-wise multiplication (Hadamard product).
   ##
   ## And broadcasted element-wise multiplication.
@@ -46,7 +47,7 @@ proc `./`*[T: SomeInteger](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = map2_inline(tmp_a, tmp_b, x div y)
 
-proc `./`*[T: SomeFloat](a, b: Tensor[T]): Tensor[T] {.noInit.} =
+proc `./`*[T: SomeFloat|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Tensor element-wise division for real numbers.
   ##
   ## And broadcasted element-wise division.
@@ -56,7 +57,7 @@ proc `./`*[T: SomeFloat](a, b: Tensor[T]): Tensor[T] {.noInit.} =
 # ##############################################
 # # Broadcasting in-place Tensor-Tensor
 
-proc `.+=`*[T: SomeNumber](a: var Tensor[T], b: Tensor[T]) =
+proc `.+=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
   ## Tensor broadcasted in-place addition.
   ##
   ## Only the right hand side tensor can be broadcasted.
@@ -65,7 +66,7 @@ proc `.+=`*[T: SomeNumber](a: var Tensor[T], b: Tensor[T]) =
   let tmp_b = b.broadcast(a.shape)
   apply2_inline(a, tmp_b, x + y)
 
-proc `.-=`*[T: SomeNumber](a: var Tensor[T], b: Tensor[T]) =
+proc `.-=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
   ## Tensor broadcasted in-place substraction.
   ##
   ## Only the right hand side tensor can be broadcasted.
@@ -74,7 +75,7 @@ proc `.-=`*[T: SomeNumber](a: var Tensor[T], b: Tensor[T]) =
   let tmp_b = b.broadcast(a.shape)
   apply2_inline(a, tmp_b, x - y)
 
-proc `.*=`*[T: SomeNumber](a: var Tensor[T], b: Tensor[T]) =
+proc `.*=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
   ## Tensor broadcasted in-place multiplication (Hadamard product)
   ##
   ## Only the right hand side tensor can be broadcasted
@@ -92,7 +93,7 @@ proc `./=`*[T: SomeInteger](a: var Tensor[T], b: Tensor[T]) =
   let tmp_b = b.broadcast(a.shape)
   apply2_inline(a, tmp_b, x div y)
 
-proc `./=`*[T: SomeFloat](a: var Tensor[T], b: Tensor[T]) =
+proc `./=`*[T: SomeFloat|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
   ## Tensor broadcasted in-place float division.
   ##
   ## Only the right hand side tensor can be broadcasted.
@@ -105,19 +106,19 @@ proc `./=`*[T: SomeFloat](a: var Tensor[T], b: Tensor[T]) =
 # ##############################################
 # # Broadcasting Tensor-Scalar and Scalar-Tensor
 
-proc `.+`*[T: SomeNumber](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
+proc `.+`*[T: SomeNumber|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Broadcasted addition for tensor + scalar.
   result = t.map_inline(x + val)
 
-proc `.+`*[T: SomeNumber](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
+proc `.+`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
   ## Broadcasted addition for scalar + tensor.
   result = t.map_inline(x + val)
 
-proc `.-`*[T: SomeNumber](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
+proc `.-`*[T: SomeNumber|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Broadcasted substraction for tensor - scalar.
   result = t.map_inline(val - x)
 
-proc `.-`*[T: SomeNumber](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
+proc `.-`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
   ## Broadcasted substraction for scalar - tensor.
   result = t.map_inline(x - val)
 
@@ -125,7 +126,7 @@ proc `./`*[T: SomeInteger](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Broadcasted division of an integer by a tensor of integers.
   result = t.map_inline(val div x)
 
-proc `./`*[T: SomeFloat](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
+proc `./`*[T: SomeFloat|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Broadcasted division of a float by a tensor of floats.
   result = t.map_inline(val / x)
 
@@ -133,33 +134,33 @@ proc `./`*[T: SomeInteger](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
   ## Broadcasted division of tensor of integers by an integer.
   result = t.map_inline(x div val)
 
-proc `./`*[T: SomeFloat](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
+proc `./`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
   ## Broadcasted division of a tensor of floats by a float.
   result = t.map_inline(x / val)
 
-proc `.^`*[T: SomeFloat](t: Tensor[T], exponent: T): Tensor[T] {.noInit.} =
+proc `.^`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T], exponent: T): Tensor[T] {.noInit.} =
   ## Compute element-wise exponentiation
   result = t.map_inline pow(x, exponent)
 
 # #####################################
 # # Broadcasting in-place Tensor-Scalar
 
-proc `.+=`*[T: SomeNumber](t: var Tensor[T], val: T) =
+proc `.+=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
   ## Tensor in-place addition with a broadcasted scalar.
   t.apply_inline(x + val)
 
-proc `.-=`*[T: SomeNumber](t: var Tensor[T], val: T) =
+proc `.-=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
   ## Tensor in-place substraction with a broadcasted scalar.
   t.apply_inline(x - val)
 
-proc `.^=`*[T: SomeFloat](t: var Tensor[T], exponent: T) =
+proc `.^=`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: var Tensor[T], exponent: T) =
   ## Compute in-place element-wise exponentiation
   t.apply_inline pow(x, exponent)
 
-proc `.*=`*[T: SomeNumber](t: var Tensor[T], val: T) =
+proc `.*=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
   ## Tensor in-place multiplication with a broadcasted scalar.
   t.apply_inline(x * val)
 
-proc `./=`*[T: SomeNumber](t: var Tensor[T], val: T) =
+proc `./=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
   ## Tensor in-place division with a broadcasted scalar.
   t.apply_inline(x - val)

--- a/src/tensor/private/p_complex.nim
+++ b/src/tensor/private/p_complex.nim
@@ -1,0 +1,14 @@
+from complex import Complex, complex32, complex64
+
+template numberOne*(T:type SomeNumber):SomeNumber= T(1)
+template numberOne*(T:type Complex[float32]):Complex[float32] = complex32(1.0, 0.0)
+template numberOne*(T:type Complex[float64]):Complex[float64] = complex64(1.0, 0.0)
+
+converter Complex64*[T:SomeNumber](x: T):Complex[float64]=
+  result.re = x.float64
+  result.im = 0'f64
+
+converter Complex32*[T:SomeNumber](x: T):Complex[float32]=
+  result.re = x.float32
+  result.im = 0'f32
+

--- a/src/tensor/ufunc.nim
+++ b/src/tensor/ufunc.nim
@@ -15,7 +15,7 @@
 import  ./data_structure,
         ./higher_order_applymap,
         sugar, math
-
+ 
 proc astype*[T, U](t: Tensor[T], typ: typedesc[U]): Tensor[U] {.noInit.} =
   ## Apply type conversion on the whole tensor
   result = t.map(x => x.U)

--- a/tests/tensor/test_accessors.nim
+++ b/tests/tensor/test_accessors.nim
@@ -14,6 +14,7 @@
 
 import ../../src/arraymancer
 import unittest, math
+import complex except Complex64, Complex32
 
 
 suite "Accessing and setting tensor values":
@@ -30,6 +31,9 @@ suite "Accessing and setting tensor values":
     b[2,3] = 111
     check: b[2,3] == 111
 
+    var c = zeros[Complex[float64]](@[3,4])
+    c[1,2] = complex64(12.0, 0.0)
+    check: c[1,2].re - 12.0 <= 1e9
 
   when compileOption("boundChecks") and not defined(openmp):
     test "Out of bounds checking":

--- a/tests/tensor/test_accessors_slicer.nim
+++ b/tests/tensor/test_accessors_slicer.nim
@@ -14,6 +14,7 @@
 
 import ../../src/arraymancer
 import unittest, math
+import complex except Complex64, Complex32
 
 
 suite "Testing indexing and slice syntax":
@@ -43,6 +44,7 @@ suite "Testing indexing and slice syntax":
   # |5      25      125     625     3125|
   test "Basic indexing - foo[2, 3]":
     check: t_van[2, 3] == 81
+    check: t_van.astype(Complex[float64])[2, 3] == 81.Complex64
 
   test "Basic indexing - foo[1+1, 2*2*1]":
     check: t_van[1+1, 2*2*1] == 243

--- a/tests/tensor/test_aggregate.nim
+++ b/tests/tensor/test_aggregate.nim
@@ -14,15 +14,18 @@
 
 import ../../src/arraymancer
 import unittest, math
+import complex except Complex64, Complex32
 
 suite "[Core] Testing aggregation functions":
   let t = [[0, 1, 2],
           [3, 4, 5],
           [6, 7, 8],
           [9, 10, 11]].toTensor()
+  let t_c = t.astype(Complex[float64])
 
   test "Sum":
     check: t.sum == 66
+    check: t_c.sum == 66
     let row_sum = [[18, 22, 26]].toTensor()
     let col_sum = [[3],
                    [12],
@@ -30,9 +33,12 @@ suite "[Core] Testing aggregation functions":
                    [30]].toTensor()
     check: t.sum(axis=0) == row_sum
     check: t.sum(axis=1) == col_sum
+    check: t_c.sum(axis=0) == row_sum.astype(Complex[float64])
+    check: t_c.sum(axis=1) == col_sum.astype(Complex[float64])
 
   test "Mean":
     check: t.astype(float).mean == 5.5 # Note: may fail due to float rounding
+    check: t_c.mean == 5.5 # Note: may fail due to float rounding
 
     let row_mean = [[4.5, 5.5, 6.5]].toTensor()
     let col_mean = [[1.0],
@@ -41,14 +47,21 @@ suite "[Core] Testing aggregation functions":
                     [10.0]].toTensor()
     check: t.astype(float).mean(axis=0) == row_mean
     check: t.astype(float).mean(axis=1) == col_mean
+    check: t_c.mean(axis=0) == row_mean.astype(Complex[float64])
+    check: t_c.mean(axis=1) == col_mean.astype(Complex[float64])
 
   test "Product":
     let a = [[1,2,4],[8,16,32]].toTensor()
+    let a_c = a.astype(Complex[float64])
     check: t.product() == 0
     check: a.product() == 32768
     check: a.astype(float).product() == 32768.0
     check: a.product(0) == [[8,32,128]].toTensor()
     check: a.product(1) == [[8],[4096]].toTensor()
+    check: t_c.product() == 0
+    check: a_c.product() == 32768.0
+    check: a_c.product(0) == [[8,32,128]].toTensor().astype(Complex[float64])
+    check: a_c.product(1) == [[8],[4096]].toTensor().astype(Complex[float64])
 
   test "Min":
     let a = [2,-1,3,-3,5,0].toTensor()

--- a/tests/tensor/test_broadcasting.nim
+++ b/tests/tensor/test_broadcasting.nim
@@ -14,6 +14,7 @@
 
 import ../../src/arraymancer
 import unittest, sugar, sequtils
+import complex except Complex64, Complex32
 
 suite "Shapeshifting - broadcasting and non linear algebra elementwise operations":
   test "Tensor element-wise multiplication (Hadamard product) and division":
@@ -32,6 +33,8 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
 
     check: u_float .* v_float == expected_mul_float
     check: u_float ./ v_float == expected_div_float
+    check: u_float.astype(Complex[float64]) .* v_float.astype(Complex[float64]) == expected_mul_float.astype(Complex[float64])
+    check: u_float.astype(Complex[float64]) ./ v_float.astype(Complex[float64]) == expected_div_float.astype(Complex[float64])
 
   test "Explicit broadcasting":
     block:
@@ -61,6 +64,11 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
                         [10, 11, 12],
                         [20, 21, 22],
                         [30, 31, 32]].toTensor
+      check: a.astype(Complex[float64]) .+ b.astype(Complex[float64]) == [[0, 1, 2],
+                        [10, 11, 12],
+                        [20, 21, 22],
+                        [30, 31, 32]].toTensor.astype(Complex[float64])
+
 
     block: # Substraction
       let a = [0, 10, 20, 30].toTensor().reshape(4,1)
@@ -70,6 +78,10 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
                         [10, 9, 8],
                         [20, 19, 18],
                         [30, 29, 28]].toTensor
+      check: a.astype(Complex[float64]) .- b.astype(Complex[float64]) == [[0, -1, -2],
+                        [10, 9, 8],
+                        [20, 19, 18],
+                        [30, 29, 28]].toTensor.astype(Complex[float64])
 
     block: # Multiplication
       let a = [0, 10, 20, 30].toTensor().reshape(4,1)
@@ -79,6 +91,10 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
                         [0, 10, 20],
                         [0, 20, 40],
                         [0, 30, 60]].toTensor
+      check: a.astype(Complex[float64]) .* b.astype(Complex[float64]) == [[0, 0, 0],
+                        [0, 10, 20],
+                        [0, 20, 40],
+                        [0, 30, 60]].toTensor.astype(Complex[float64])
 
     block: # Integer division
       let a = [100, 10, 20, 30].toTensor().reshape(4,1)
@@ -97,6 +113,10 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
                         [5.0, 2, 1],
                         [10.0, 4, 2],
                         [15.0, 6, 3]].toTensor
+      check: a.astype(Complex[float64]) ./ b.astype(Complex[float64]) == [[50.0, 20, 10],
+                        [5.0, 2, 1],
+                        [10.0, 4, 2],
+                        [15.0, 6, 3]].toTensor.astype(Complex[float64])
 
     block: # Float Exponentiation
       let a = [1.0, 10, 20, 30].toTensor().reshape(4,1)
@@ -106,44 +126,67 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
                           [400.0],
                           [900.0]].toTensor
 
-      check: a .^ -1 ==  [[1.0],
+      check: a .^ -1 == [[1.0],
                           [1.0/10.0],
                           [1.0/20.0],
                           [1.0/30.0]].toTensor
+
+      check: a.astype(Complex[float64]) .^ complex64(-1.0,0.0) == [[1.0],
+                          [1.0/10.0],
+                          [1.0/20.0],
+                          [1.0/30.0]].toTensor.astype(Complex[float64])
 
   test "Implicit tensor-tensor broadcasting - basic in-place operations .+=, .-=, .*=, ./=":
     block: # Addition
       # Note: We can't broadcast the lhs with in-place operations
       var a = [0, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).asContiguous
+      var a_c = [0, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).asContiguous.astype(Complex[float64])
       let b = [0, 1, 2].toTensor().reshape(1,3)
 
       a .+= b
+      a_c .+= b.astype(Complex[float64])
       check: a == [[0, 1, 2],
                   [10, 11, 12],
                   [20, 21, 22],
                   [30, 31, 32]].toTensor
+      check: a_c == [[0, 1, 2],
+                  [10, 11, 12],
+                  [20, 21, 22],
+                  [30, 31, 32]].toTensor.astype(Complex[float64])
 
     block: # Substraction
       # Note: We can't broadcast the lhs with in-place operations
       var a = [0, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).asContiguous
+      var a_c = [0, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).asContiguous.astype(Complex[float64])
       let b = [0, 1, 2].toTensor().reshape(1,3)
 
       a .-= b
-      check: a  == [[0, -1, -2],
+      a_c .-= b.astype(Complex[float64])
+      check: a == [[0, -1, -2],
                     [10, 9, 8],
                     [20, 19, 18],
                     [30, 29, 28]].toTensor
+      check: a_c == [[0, -1, -2],
+                    [10, 9, 8],
+                    [20, 19, 18],
+                    [30, 29, 28]].toTensor.astype(Complex[float64])
 
     block: # Multiplication
       # Note: We can't broadcast the lhs with in-place operations
       var a = [0, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).asContiguous
+      var a_c = [0, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).asContiguous.astype(Complex[float64])
       let b = [0, 1, 2].toTensor().reshape(1,3)
 
       a .*= b
+      a_c .*= b.astype(Complex[float64])
       check: a == [[0, 0, 0],
                   [0, 10, 20],
                   [0, 20, 40],
                   [0, 30, 60]].toTensor
+      check: a_c == [[0, 0, 0],
+                  [0, 10, 20],
+                  [0, 20, 40],
+                  [0, 30, 60]].toTensor.astype(Complex[float64])
 
     block: # Integer division
       # Note: We can't broadcast the lhs with in-place operations
@@ -159,54 +202,87 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
     block: # Float division
       # Note: We can't broadcast the lhs with in-place operations
       var a = [100.0, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).asContiguous
+      var a_c = [100.0, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).asContiguous.astype(Complex[float64])
       let b = [2.0, 5, 10].toTensor().reshape(1,3)
 
       a ./= b
+      a_c ./= b.astype(Complex[float64])
       check: a == [[50.0, 20, 10],
                   [5.0, 2, 1],
                   [10.0, 4, 2],
                   [15.0, 6, 3]].toTensor
+      check: a_c == [[50.0, 20, 10],
+                  [5.0, 2, 1],
+                  [10.0, 4, 2],
+                  [15.0, 6, 3]].toTensor.astype(Complex[float64])
 
 
   test "Implicit tensor-scalar broadcasting - basic operations .+=, .-=, .^=":
     block: # Addition
       var a = [0, 10, 20, 30].toTensor().reshape(4,1)
+      var a_c = [0, 10, 20, 30].toTensor().reshape(4,1).astype(Complex[float64])
 
       a .+= 100
+      a_c .+= complex64(100.0, 0.0)
       check: a == [[100],
                   [110],
                   [120],
                   [130]].toTensor
+      check: a_c == [[100],
+                  [110],
+                  [120],
+                  [130]].toTensor.astype(Complex[float64])
 
     block: # Substraction
       var a = [0, 10, 20, 30].toTensor().reshape(4,1)
+      var a_c = [0, 10, 20, 30].toTensor().reshape(4,1).astype(Complex[float64])
 
       a .-= 100
-      check: a  == [[-100],
+      a_c .-= complex64(100.0, 0.0)
+      check: a == [[-100],
                     [-90],
                     [-80],
                     [-70]].toTensor
+      check: a_c == [[-100],
+                    [-90],
+                    [-80],
+                    [-70]].toTensor.astype(Complex[float64])
 
     block: # Float Exponentiation
       var a = [1.0, 10, 20, 30].toTensor().reshape(4,1)
       var b = a.clone
+      var a_c = a.clone.astype(Complex[float64])
+      var b_c = b.clone.astype(Complex[float64])
 
       a .^= 2.0
-      check: a  == [[1.0],
+      a_c .^= 2.0
+      check: a == [[1.0],
                     [100.0],
                     [400.0],
                     [900.0]].toTensor
+      check: a_c == [[1.0],
+                    [100.0],
+                    [400.0],
+                    [900.0]].toTensor.astype(Complex[float64])
 
       b .^= -1
-      check: b  == [[1.0],
+      b_c .^= -1
+      check: b == [[1.0],
                     [1.0/10.0],
                     [1.0/20.0],
                     [1.0/30.0]].toTensor
+      check: b_c == [[1.0],
+                    [1.0/10.0],
+                    [1.0/20.0],
+                    [1.0/30.0]].toTensor.astype(Complex[float64])
 
   test "Implicit broadcasting - Sigmoid 1 ./ (1 .+ exp(-x)":
     block:
-      proc sigmoid[T: SomeFloat](t: Tensor[T]): Tensor[T]=
-        1.T ./ (1.T .+ exp(-t))
+      proc sigmoid[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T]): Tensor[T]=
+        1.T ./ (1.T .+ exp(0.T .- t))
 
       let a = newTensor[float32]([2,2])
       check: sigmoid(a) == [[0.5'f32, 0.5],[0.5'f32, 0.5]].toTensor
+
+      let a_c = newTensor[Complex[float32]]([2,2])
+      check: sigmoid(a_c) == [[0.5'f32, 0.5],[0.5'f32, 0.5]].toTensor.astype(Complex[float32])

--- a/tests/tensor/test_exporting.nim
+++ b/tests/tensor/test_exporting.nim
@@ -14,6 +14,7 @@
 
 import ../../src/arraymancer
 import unittest, sequtils
+import complex except Complex64, Complex32
 
 suite "Exporting":
   test "Raw sequence exporting":
@@ -23,6 +24,10 @@ suite "Exporting":
   test "Nested sequence exporting":
     block:
       let s = @[@[1, 2, 3], @[4, 5, 6]]
+      check s.toTensor().toSeq2D() == s
+    block:
+      let s = @[@[complex64(1'f64,0.0), complex64(2'f64,0.0), complex64(3'f64,0.0)],
+                @[complex64(4'f64,0.0), complex64(5'f64,0.0), complex64(6'f64,0.0)]]
       check s.toTensor().toSeq2D() == s
     block:
       let t = toSeq(1..24).toTensor().reshape(2, 3, 4)

--- a/tests/tensor/test_filling_data.nim
+++ b/tests/tensor/test_filling_data.nim
@@ -15,6 +15,7 @@
 
 import ../../src/arraymancer
 import unittest, math, sugar, sequtils
+import complex except Complex64, Complex32
 
 
 suite "Testing miscellaneous data functions":
@@ -26,3 +27,9 @@ suite "Testing miscellaneous data functions":
     b.copy_from(a)
 
     check: b == [[1],[2], [3], [4]].toTensor
+    block:
+      let a = [[1,2],[3,4]].toTensor.reshape(2,2).astype(Complex[float64])
+      var b = ones[Complex[float64]](4,1)
+      b.copy_from(a)
+      check: b == [[1],[2], [3], [4]].toTensor.astype(Complex[float64])
+

--- a/tests/tensor/test_higherorder.nim
+++ b/tests/tensor/test_higherorder.nim
@@ -14,28 +14,37 @@
 
 import ../../src/arraymancer
 import unittest, math, sugar, sequtils
+import complex except Complex32, Complex64
 
 suite "[Core] Testing higher-order functions":
   let t = [[0, 1, 2],
           [3, 4, 5],
           [6, 7, 8],
           [9, 10, 11]].toTensor()
+  let t_c = t.astype(Complex[float64])
 
-  proc customAdd[T: SomeNumber](x, y: T): T = x + y
+  proc customAdd[T: SomeNumber|Complex](x, y: T): T = x + y
 
   test "Map function":
 
     let t2 = [0, 1, 4, 9, 16, 25, 36, 49, 64, 81, 100, 121].toTensor.reshape([4,3])
 
     check: t.map(x => x*x) == t2
+    check: t_c.map(x => x*x) == t2.astype(Complex[float64])
 
   test "Apply functions - with in-place and out of place closure":
     var t = toSeq(0..11).toTensor().reshape([4,3])
     let t2 = toSeq(1..12).toTensor().reshape([4,3])
+    let t2_c = t2.astype(Complex[float64])
 
     var tmp1 = t.clone
     tmp1.apply(x => x+1) # out of place
     check: tmp1 == t2
+
+    var tmp1_c = t.clone.astype(Complex[float64])
+    tmp1_c.apply(x => x+1) # out of place
+    check: tmp1_c == t2_c
+
 
     var tmp2 = t[_,2].clone
 
@@ -43,17 +52,24 @@ suite "[Core] Testing higher-order functions":
     tmp2.apply(plus_one) # in-place
     check: tmp2 == t2[_,2]
 
+    var tmp2_c = t[_,2].clone.astype(Complex[float64])
+    tmp2_c.apply(plus_one) # in-place
+    check: tmp2_c == t2_c[_,2]
+
+
   test "Reduce function":
     check: t.reduce(customAdd) == 66
+    check: t_c.reduce(customAdd) == 66.Complex64
 
     proc customConcat(x, y: string): string = x & y
 
     check: t.map(x => $x).reduce(customConcat) == "01234567891011"
 
   test "Reduce over an axis":
-    proc customMin[T: SomeNumber](x,y: Tensor[T]): Tensor[T] = x - y
+    proc customMin[T: SomeNumber|Complex[float32]|Complex[float64]](x,y: Tensor[T]): Tensor[T] = x - y
 
     check: t.reduce(customMin, axis = 0) == [-18, -20, -22].toTensor.reshape([1,3])
+    check: t_c.reduce(customMin, axis = 0) == [-18, -20, -22].toTensor.reshape([1,3]).astype(Complex[float64])
 
   test "Fold with different in and result types":
     proc isEven(n: int): bool =
@@ -73,6 +89,7 @@ suite "[Core] Testing higher-order functions":
     let initval = [1,0,1,0].toTensor.reshape([4,1])
 
     check: t.fold(initval, `+`, axis = 1) == col_sum_plus_1010
+    check: t_c.fold(initval.astype(Complex[float64]), `+`, axis = 1) == col_sum_plus_1010.astype(Complex[float64])
 
 
 suite "[Core] Testing higher-order templates":

--- a/tests/tensor/test_init.nim
+++ b/tests/tensor/test_init.nim
@@ -14,6 +14,7 @@
 
 import ../../src/arraymancer
 import unittest, math, sequtils
+import complex except Complex64, Complex32
 
 suite "Creating a new Tensor":
   test "Creating from sequence":
@@ -64,6 +65,10 @@ suite "Creating a new Tensor":
     check: t3.rank == 3
     check: t3.shape == [4, 2, 3] # 4 rows, 2 cols, 3 depth. depth indices moves the fastest. Same scheme as Numpy.
 
+    let t4 = @[complex64(1.0,0.0),complex64(2.0,0.0),complex64(3.0,0.0)].toTensor()
+    check: t4.shape == [3]
+    check: t4.rank == 1
+
     let u = @[@[1.0, -1, 2],@[0.0, -1]]
 
     when compileOption("boundChecks") and not defined(openmp):
@@ -92,6 +97,10 @@ suite "Creating a new Tensor":
       let t = zeros[int]([4,4,4])
       for v in t.items:
         check v == 0
+    block:
+      let t = zeros[Complex[float64]]([4,4,4])
+      for v in t.items:
+        check v == complex64(0.0,0.0)
 
   test "Ones":
     block:
@@ -102,6 +111,10 @@ suite "Creating a new Tensor":
       let t = ones[int]([4,4,4])
       for v in t.items:
         check v == 1
+    block:
+      let t = ones[Complex[float64]]([4,4,4])
+      for v in t.items:
+        check v == complex64(1.0, 0.0)
 
   test "Filled new tensor":
     block:
@@ -112,15 +125,18 @@ suite "Creating a new Tensor":
       let t = newTensorWith([4,4,4], 2)
       for v in t.items:
         check v == 2
+    block:
+      let t = newTensorWith([4,4,4], complex64(2.0, 0.0))
+      for v in t.items:
+        check v == complex64(2.0, 0.0)
 
   test "Random tensor":
-    block:
-      # Check that randomTensor doesn't silently convert float32 to float64
-      let a = randomTensor([3, 4], 100'f32)
+    # Check that randomTensor doesn't silently convert float32 to float64
+    let a = randomTensor([3, 4], 100'f32)
 
-      check: a[0,0] is float32
+    check: a[0,0] is float32
   # TODO add tests for randomTensor
-
+   
   test "Random normal tensor":
     for i in 0..<4:
       let t = randomNormalTensor[float32](1000)

--- a/tests/tensor/test_math_functions.nim
+++ b/tests/tensor/test_math_functions.nim
@@ -14,30 +14,41 @@
 
 import ../../src/arraymancer
 import unittest, sugar, math
+import complex except Complex64, Complex32
 
 suite "Math functions":
   test "Reciprocal (element-wise 1/x)":
     var a = [1.0, 10, 20, 30].toTensor.reshape(4,1)
+    var a_c = [1.0, 10, 20, 30].toTensor.reshape(4,1).astype(Complex[float64])
 
 
-    check: a.reciprocal  == [[1.0],
+    check: a.reciprocal == [[1.0],
                             [1.0/10.0],
                             [1.0/20.0],
                             [1.0/30.0]].toTensor
+    check: a_c.reciprocal == [[1.0],
+                            [1.0/10.0],
+                            [1.0/20.0],
+                            [1.0/30.0]].toTensor.astype(Complex[float64])
 
     a.mreciprocal
+    a_c.mreciprocal
 
     check: a == [[1.0],
                 [1.0/10.0],
                 [1.0/20.0],
                 [1.0/30.0]].toTensor
+    check: a_c == [[1.0],
+                [1.0/10.0],
+                [1.0/20.0],
+                [1.0/30.0]].toTensor.astype(Complex[float64])
 
   test "Negate elements (element-wise -x)":
     block: # Out of place
       var a = [1.0, 10, 20, 30].toTensor.reshape(4,1)
 
 
-      check: a.negate  == [[-1.0],
+      check: a.negate == [[-1.0],
                           [-10.0],
                           [-20.0],
                           [-30.0]].toTensor
@@ -58,11 +69,16 @@ suite "Math functions":
 
   test "Absolute value":
     var a = [1.0, -10, -20, 30].toTensor.reshape(4,1)
+    var a_c = [1.0, -10, -20, 30].toTensor.reshape(4,1).astype(Complex[float64])
 
-    check: a.abs  == [[1.0],
+    check: a.abs == [[1.0],
                       [10.0],
                       [20.0],
                       [30.0]].toTensor
+    check: a_c.abs == [[1.0],
+                      [10.0],
+                      [20.0],
+                      [30.0]].toTensor.astype(float64)
 
     a.mabs
 

--- a/tests/tensor/test_operators_blas.nim
+++ b/tests/tensor/test_operators_blas.nim
@@ -447,3 +447,15 @@ suite "BLAS (Basic Linear Algebra Subprograms)":
                 [14,12, 9,22,27,17,51,23]].toTensor()
 
     check: n1 * n2 == n1n2
+
+  test "complex matrix product":
+    # [[1.+1.j, 2.+2.j, 3.+3.j]    [[1.+1.j, 4.+4.j],     [[0. +28.j, 0. +64.j],
+    #  [4.+4.j, 5.+5.j, 6.+6.j]] *  [2.+2.j, 5.+5.j],  ==  [0. +64.j, 0.+154.j]
+    #                               [3.+3.j, 6.+6.j]]
+    let m1 = [[1,2,3],[4,5,6]].toTensor().astype(Complex[float64])
+    let m2 = m1 * complex64(0,1)
+    let m3 = m1+m2
+    let m4 = m3.transpose()
+    let m5 = m3 * m4
+    let m6 = [[28,64],[64,154]].toTensor().astype(Complex[float64])
+    check: m5 == m6 * complex64(0,1)

--- a/tests/tensor/test_operators_comparison.nim
+++ b/tests/tensor/test_operators_comparison.nim
@@ -14,6 +14,7 @@
 
 import ../../src/arraymancer
 import unittest, math
+from complex import Complex
 
 
 suite "Testing tensor comparison":
@@ -35,6 +36,7 @@ suite "Testing tensor comparison":
         vandermonde[i].add(aa^bb)
 
     let t_van = vandermonde.toTensor()
+    let t_van_complex = t_van.astype(Complex[float64])
 
     # Tensor of shape 5x5 of type "int" on backend "Cpu"
     # |1      1       1       1       1|
@@ -45,14 +47,20 @@ suite "Testing tensor comparison":
 
     let test = @[@[4, 8, 16], @[9, 27, 81], @[16, 64, 256]]
     let t_test = test.toTensor()
+    let t_test_complex = t_test.astype(Complex[float64])
 
     check: t_van[1..^2,1..3] == t_test
     check: t_van[1..3,1..3] == t_test
+    check: t_van_complex[1..^2,1..3] == t_test_complex
+    check: t_van_complex[1..3,1..3] == t_test_complex
 
   test "Testing element-wise/broadcasted comparison":
     let
       a = [0, 2, 1, 3].toTensor
       b = [0, 1, 2, 3].toTensor
+      a_complex = a.astype(Complex[float64])
+      b_complex = b.astype(Complex[float64])
 
     check: (a .== b) == [true, false, false, true].toTensor
     check: (a .> b)  == [false, true, false, false].toTensor
+    check: (a_complex .== b_complex) == [true, false, false, true].toTensor

--- a/tests/tensor/test_shapeshifting.nim
+++ b/tests/tensor/test_shapeshifting.nim
@@ -14,11 +14,13 @@
 
 import ../../src/arraymancer
 import unittest, sugar, sequtils
+import complex except Complex64, Complex32
 
 suite "Shapeshifting":
   test "Contiguous conversion":
     block:
       let a = [7, 4, 3, 1, 8, 6, 8, 1, 6, 2, 6, 6, 2, 0, 4, 3, 2, 0].toTensor.reshape([3,6])
+      let a_c = [7, 4, 3, 1, 8, 6, 8, 1, 6, 2, 6, 6, 2, 0, 4, 3, 2, 0].toTensor.reshape([3,6]).astype(Complex[float64])
 
       # Tensor of shape 3x6 of type "int" on backend "Cpu"
       # |7      4       3       1       8       6|
@@ -26,7 +28,9 @@ suite "Shapeshifting":
       # |2      0       4       3       2       0|
 
       let b = a.asContiguous()
+      let b_c = a_c.asContiguous()
       check: b.toRawSeq == @[7, 4, 3, 1, 8, 6, 8, 1, 6, 2, 6, 6, 2, 0, 4, 3, 2, 0]
+      check: b_c.toRawSeq == @[complex64(7'f64,0.0), complex64(4'f64,0.0), complex64(3'f64,0.0), complex64(1'f64,0.0), complex64(8'f64,0.0), complex64(6'f64,0.0), complex64(8'f64,0.0), complex64(1'f64,0.0), complex64(6'f64,0.0), complex64(2'f64,0.0), complex64(6'f64,0.0), complex64(6'f64,0.0), complex64(2'f64,0.0), complex64(0'f64,0.0), complex64(4'f64,0.0), complex64(3'f64,0.0), complex64(2'f64,0.0), complex64(0'f64,0.0)]
 
       # a is already contiguous, even if wrong layout.
       # Nothing should be done

--- a/tests/tensor/test_ufunc.nim
+++ b/tests/tensor/test_ufunc.nim
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import ../../src/arraymancer
-import math, unittest
+import math, unittest, complex
+import complex except Complex64, Complex32
 
 suite "Universal functions":
   test "As type with slicing":
@@ -21,29 +22,43 @@ suite "Universal functions":
     let b = a[1..2].astype(float)
     check b == [2.0'f64,3.0'f64].toTensor()
 
+    let c = a[1..2].astype(Complex[float64])
+    check c == [complex64(2.0'f64,0'f64), complex64(3.0'f64,0'f64)].toTensor()
+
   test "Common math functions are exported":
     let a = @[@[1.0,2,3],@[4.0,5,6]]
     let b = @[@[7.0, 8],@[9.0, 10],@[11.0, 12]]
+    let c = @[@[complex64(1.0,0.0),complex64(2.0,0.0),complex64(3.0,0.0)],
+              @[complex64(4.0,0.0),complex64(5.0,0.0),complex64(6.0,0.0)]]
 
     let ta = a.toTensor()
     let tb = b.toTensor()
+    let tc = c.toTensor()
 
     let expected_a = @[@[cos(1'f64),cos(2'f64),cos(3'f64)],@[cos(4'f64),cos(5'f64),cos(6'f64)]]
     let expected_b = @[@[ln(7'f64), ln(8'f64)],@[ln(9'f64), ln(10'f64)],@[ln(11'f64), ln(12'f64)]]
+    let expected_c = @[@[cos(complex64(1'f64,0.0)),cos(complex64(2'f64,0.0)),cos(complex64(3'f64,0.0))],
+                       @[cos(complex64(4'f64,0.0)),cos(complex64(5'f64,0.0)),cos(complex64(6'f64,0.0))]]
 
     check: mean_absolute_error(cos(ta), expected_a.toTensor()) <= 1e-15 # We have slight precision loss with OpenMP
+    check: abs(mean_absolute_error(cos(tc), expected_c.toTensor())) <= 1e-15
     check: ln(tb) == expected_b.toTensor()
 
   test "Creating custom universal functions is supported":
     proc square_plus_one(x: int): int = x ^ 2 + 1
+    proc square_plus_one(x: Complex[float64]): Complex[float64] = x.pow(2) + 1
     makeUniversalLocal(square_plus_one)
 
     let c = @[@[2,4,8],@[3,9,27]]
     let tc = c.toTensor()
+    let tcc = tc.astype(Complex[float64])
 
     let expected_c = @[@[5, 17, 65],@[10, 82, 730]]
+    let expected_cc = @[@[complex64(5'f64,0.0), complex64(17'f64,0.0), complex64(65'f64,0.0)],
+                        @[complex64(10'f64,0.0), complex64(82'f64,0.0), complex64(730'f64,0.0)]]
 
     check: square_plus_one(tc) == expected_c.toTensor()
+    check: square_plus_one(tcc) == expected_cc.toTensor()
 
   ## MakeUniversal cannot change Tensor[B,T] to Tensor[B,U] for now
   ## map must be used instead
@@ -74,3 +89,6 @@ suite "Universal functions":
     check abs(a) == [2,1,0,1,2].toTensor()
     let b = [-2.0,-1,0,1,2].toTensor()
     check abs(b) == [2.0,1,0,1,2].toTensor()
+    # abs complex -> float
+    let c = [-2.0,-1,0,1,2].toTensor().astype(Complex[float64])
+    check abs(c) == [2.0,1,0,1,2].toTensor().astype(float64)


### PR DESCRIPTION
## summary
1. support create complex tensor `Tensor[Complex]`
2. support almost all math function
3. only `mabs` and `dot` cannot be support for now
4. this is a part of #129
## functions
### `tensor/init_cpu.nim`
- [x] `toTensor`
- [x] `zeros`
- [x] `ones`

### `tensor/ufunc.nim`
- [x] `astype`

### `tensor/aggregate.nim`
- [x] `sum`
- [x] `product`
- [x] `mean`
- [x] `min` : complex numbers can not be considered 'bigger' or 'smaller' than each others.
- [x] `max`: complex numbers can not be considered 'bigger' or 'smaller' than each others.
- [x] `variance`: not support because variance(complex) = variance(abs(complex))=float
- [x] `std`: not support because variance(complex) = variance(abs(complex))=float
- [x] `argmax_max`: complex numbers can not be considered 'bigger' or 'smaller' than each others.
- [x] `argmax`: complex numbers can not be considered 'bigger' or 'smaller' than each others.

### `tensor/operators_blas_l1.nim`
- [x]  `dot`: not support yet because it should use blas's `dotc` and `dotc`
- [x]  `+`
- [x]  `-`
- [x]  `+=`
- [x]  `-=`
- [x]  `*`
- [x]  `/`
- [x]  `div`
- [x]  `*=`
- [x]  `/=`

### `tensor/operators_blas_l2l3.nim`
- [x] `gemv`
- [x] `gemm`
- [x] `*`

### `tensor/operators_broadcasted.nim`
- [x] `.+`
- [x] `.-`
- [x] `.*`
- [x] `./`
- [x] `.+=`
- [x] `.-=`
- [x] `.*=`
- [x] `./=`
- [x] `.^`
- [x] `.^=`

### `tensor/math_functions.nim`
- [x] `elwise_mul`
- [x] `melwise_mul`
- [x] `elwise_div`
- [x] `melwise_div`
- [x] `reciprocal`
- [x] `mreciprocal`
- [x] `negate` : not support because negate complex number is ambiguous, 1+1i -> -1+1i or -1-1i
- [x] `mnegate`: not support beacuse negate complex number is ambiguous, 1+1i -> -1+1i or -1-1i
- [x] ``-`` : not support because negate complex number is ambiguous, 1+1i -> -1+1i or -1-1i
- [x] `abs`
- [X] `mabs` : how to inplace convert from `Tensor[Complex]` to `Tensor[float]`?
- [x] `clamp`: complex numbers can not be considered 'bigger' or 'smaller' than each others.
- [x] `mclamp`: complex numbers can not be considered 'bigger' or 'smaller' than each others.
- [x] `square`

## tests
- [x] `test_init.nim`
- [x] `test_ufunc.nim`
- [x] `test_operators_comparison.nim`
- [x] `test_operators_blas.nim`
- [x] `test_higherorder.nim`
- [x] `test_aggregate.nim`
- [x] `test_accessors.nim`
- [x] `test_accessors_slicer.nim`
- [x] `test_broadcasting.nim`
- [x] `test_display.nim`
- [x] `test_exporting.nim`
- [x] `test_filling_data.nim`
- [x] `test_math_functions.nim`
- [x] `test_shapeshifting.nim`
