### PR TITLE
Keep test suite memory usage under 3GB for CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,7 +49,7 @@ install:
   # - appveyor DownloadFile %LAPACK_URL% dlls\lapack.dll
 
 build_script:
-  - nimble.exe refresh
+  - nimble.exe install -y
 
 test_script:
   - nimble.exe test_no_lapack

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ install:
   - choosenim $CHANNEL
 
 script:
-    - nimble refresh
+    - nimble install -y
     - if [[$BLIS]];
         then nimble test_blis;
         else nimble test;

--- a/tests/_split_tests/tests_cpu_remainder.nim
+++ b/tests/_split_tests/tests_cpu_remainder.nim
@@ -1,0 +1,46 @@
+# Copyright 2017 the Arraymancer contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests were split to save on memory
+# (https://github.com/mratsim/Arraymancer/issues/359#issuecomment-500107895)
+
+import  ../io/test_csv,
+        ../io/test_numpy,
+        ../datasets/test_mnist,
+        ../datasets/test_imdb,
+        ../nn_primitives/test_nnp_numerical_gradient,
+        ../nn_primitives/test_nnp_convolution,
+        ../nn_primitives/test_nnp_loss,
+        ../nn_primitives/test_nnp_maxpool,
+        ../nn_primitives/test_nnp_gru,
+        ../nn_primitives/test_nnp_embedding,
+        ../autograd/test_gate_basic,
+        ../autograd/test_gate_blas,
+        ../autograd/test_gate_hadamard,
+        ../autograd/test_gate_shapeshifting,
+        ../ml/test_metrics,
+        ../test_bugtracker
+
+when not defined(windows) and not sizeof(int) == 4:
+  # STB image does not work on windows 32-bit, https://github.com/mratsim/Arraymancer/issues/358
+  import ../io/test_image
+
+when not defined(no_lapack):
+  import ../linear_algebra/test_linear_algebra,
+        ../ml/test_dimensionality_reduction,
+        ../ml/test_clustering
+
+import  ../stability_tests/test_stability_openmp,
+        # /end_to_end/examples_compile
+        ../end_to_end/examples_run

--- a/tests/_split_tests/tests_tensor_part01.nim
+++ b/tests/_split_tests/tests_tensor_part01.nim
@@ -1,0 +1,23 @@
+# Copyright 2017-Present Mamy André-Ratsimbazafy & the Arraymancer contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Split tests to save on memory
+# (https://github.com/mratsim/Arraymancer/issues/359#issuecomment-500107895)
+
+import
+  ../tensor/test_init,
+  ../tensor/test_operators_comparison,
+  ../tensor/test_accessors,
+  ../tensor/test_accessors_slicer,
+  ../tensor/test_display

--- a/tests/_split_tests/tests_tensor_part02.nim
+++ b/tests/_split_tests/tests_tensor_part02.nim
@@ -1,0 +1,19 @@
+# Copyright 2017-Present Mamy André-Ratsimbazafy & the Arraymancer contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Split tests to save on memory
+# (https://github.com/mratsim/Arraymancer/issues/359#issuecomment-500107895)
+
+import
+  ../tensor/test_operators_blas

--- a/tests/_split_tests/tests_tensor_part03.nim
+++ b/tests/_split_tests/tests_tensor_part03.nim
@@ -1,0 +1,21 @@
+# Copyright 2017-Present Mamy André-Ratsimbazafy & the Arraymancer contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Split tests to save on memory
+# (https://github.com/mratsim/Arraymancer/issues/359#issuecomment-500107895)
+
+import
+  ../tensor/test_math_functions,
+  ../tensor/test_higherorder,
+  ../tensor/test_aggregate

--- a/tests/_split_tests/tests_tensor_part04.nim
+++ b/tests/_split_tests/tests_tensor_part04.nim
@@ -1,0 +1,20 @@
+# Copyright 2017-Present Mamy André-Ratsimbazafy & the Arraymancer contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Split tests to save on memory
+# (https://github.com/mratsim/Arraymancer/issues/359#issuecomment-500107895)
+
+import
+  ../tensor/test_shapeshifting,
+  ../tensor/test_broadcasting

--- a/tests/_split_tests/tests_tensor_part05.nim
+++ b/tests/_split_tests/tests_tensor_part05.nim
@@ -1,0 +1,22 @@
+# Copyright 2017-Present Mamy André-Ratsimbazafy & the Arraymancer contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Split tests to save on memory
+# (https://github.com/mratsim/Arraymancer/issues/359#issuecomment-500107895)
+
+import
+  ../tensor/test_ufunc,
+  ../tensor/test_filling_data,
+  ../tensor/test_optimization,
+  ../tensor/test_exporting

--- a/tests/nn_primitives/test_nnp_loss.nim
+++ b/tests/nn_primitives/test_nnp_loss.nim
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ../../src/arraymancer, unittest
+import ../../src/arraymancer, unittest, random
 
+# Fix random seed for reproducibility
+randomize(1234)
 
 suite "[NN primitives] Loss functions":
   proc `~=`[T: SomeFloat](a, b: T): bool =


### PR DESCRIPTION
Following the merging of #350, the test suite memor usage is over 3GB which is a hard limit for Travis instances (#359)

This splits the test suite to allow CI.