### PR TITLE
Add SGD with Momentum Optimizer, addresses #298

### DIFF
--- a/src/nn/optimizers/optimizers.nim
+++ b/src/nn/optimizers/optimizers.nim
@@ -44,13 +44,13 @@ proc update*(self: var Sgd) =
     let v = self.params[i]
     # v.value -= learning rate * grad
     if v.requires_grad:
-      # When momentum = 0 this acts identically to SGD without momentum.
-      apply3_inline(v.value, v.grad, self.moments[i]):
-        x - self.lr * y + self.momentum * z
-
       # Update the moments with the previous update.
       apply2_inline(self.moments[i], v.grad):
         self.momentum * x - self.lr * y
+
+      # When momentum = 0 this acts identically to SGD without momentum.
+      apply2_inline(v.value, self.moments[i]):
+        x + y
 
       # Zero the gradient
       v.grad = v.value.zeros_like # TODO "setZero" instead of a new allocation

--- a/src/nn/optimizers/optimizers.nim
+++ b/src/nn/optimizers/optimizers.nim
@@ -30,9 +30,6 @@ type
     lr*: TT.T # Learning rate. T is the generic parameter of Tensor[T]
 
 proc newSGD*[T](params: varargs[Variable[Tensor[T]]], learning_rate: T): SGD[Tensor[T]] {.deprecated: "Use the optimizer macro instead".}=
-  var moments: seq[Tensor[T]] = @[]
-  for param in params:
-    moments.add param.grad.zeros_like
   SGD[Tensor[T]](params: @params, lr: learning_rate)
 
 proc update*(self: Sgd) =

--- a/tests/nn/test_optimizers.nim
+++ b/tests/nn/test_optimizers.nim
@@ -1,0 +1,63 @@
+# Copyright 2017-Present Mamy André-Ratsimbazafy & the Arraymancer contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import
+  ../../src/arraymancer, aux_rosenbrock,
+  unittest, random, strformat
+
+# ############################################################
+#
+#                    Test suite
+#
+# ############################################################
+
+const
+  # Keep these around so we know what these values are.
+  a = 1'f64
+  b = 100'f64
+  num_epochs = 100
+
+let start_x = [1.5'f64].toTensor
+let start_y = [1.5'f64].toTensor
+type Model = object
+  x, y: Variable[Tensor[float64]]
+
+suite "[Optimizer] Optimizer on the Rosenbrock function":
+  setup:
+    let ctx = newContext Tensor[float64]
+    let model = Model(x: ctx.variable(start_x.clone, requires_grad = true),
+                      y: ctx.variable(start_y.clone, requires_grad = true))
+
+  test "Stochastic gradient descent - Momentum":
+    var optim = optimizerSGDMomentum[model, float64](model, learning_rate = 1e-4, momentum = 0.95)
+
+    for epoch in 1 .. num_epochs:
+      var s = &"Epoch {epoch:>3}/{num_epochs} - "
+      s &= &"Rosenbrock({model.x.value[0]:>.12f}, {model.y.value[0]:>.12f}) = "
+      s &= &"{rosenbrock(model.x.value, model.y.value)[0]:>.12f}"
+      echo s
+      (model.x.grad, model.y.grad) = drosenbrock(model.x.value, model.y.value)
+      optim.update()
+
+
+  test "Stochastic gradient descent - Nesterov Momentum":
+    var optim = optimizerSGDMomentum[model, float64](model, learning_rate = 1e-4, momentum = 0.95, nesterov=true
+    )
+    for epoch in 1 .. num_epochs:
+      var s = &"Epoch {epoch:>3}/{num_epochs} - "
+      s &= &"Rosenbrock({model.x.value[0]:>.12f}, {model.y.value[0]:>.12f}) = "
+      s &= &"{rosenbrock(model.x.value, model.y.value)[0]:>.12f}"
+      echo s
+      (model.x.grad, model.y.grad) = drosenbrock(model.x.value, model.y.value)
+      optim.update()

--- a/tests/nn/test_optimizers.py
+++ b/tests/nn/test_optimizers.py
@@ -1,0 +1,63 @@
+import json
+import torch
+import torch.optim as optim
+
+def rosenbrock(x, y):
+    return (1 - x) ** 2 + 100 * (y - x ** 2) ** 2
+
+def drosenbrock(x, y):
+    dx = torch.Tensor([-400 * x * (y - x ** 2) - 2 * (1 - x)])
+    dy = torch.Tensor([200 * (y - x ** 2)])
+    return (dx, dy)
+
+# Print the configuration nicely instead of a disgusting dict.
+def pretty_format(config):
+    s = ""
+    for key, value in config["param_groups"][0].items():
+        if key != "params":
+            s += f"{key}: {value}, "
+    return s[:-1] # Strips the final comma
+
+algorithms = {
+    'adadelta': optim.Adadelta,
+    'adagrad': optim.Adagrad,
+    'adam': optim.Adam,
+    #'adamw': optim.Adamw, # Bleeding Edge optimizer not in 1.1.0 but is in HEAD
+    'adamax': optim.Adamax,
+    'asgd': optim.ASGD,
+    'lbfgs': optim.LBFGS,
+    'rmsprop': optim.RMSprop,
+    'rprop': optim.Rprop,
+    'sgd': optim.SGD,
+}
+
+with open('tests.json', 'r') as f:
+    tests = json.loads(f.read())
+
+for test in tests:
+    print(test['algorithm'] + '\t')
+    opt_type = algorithms[test['algorithm']]
+    for config in test['config']:
+        # Print the config so we know what this run is.
+        print(pretty_format(config))
+        print('================================================================================\t')
+        params = (torch.Tensor([1.5]), torch.Tensor([1.5]))
+        # As far as I'm aware a learning rate is always required.
+        opt = opt_type(params, 1e-4)
+        # To load the proper config we load state_dicts for the optimizer which
+        # is the easiest way to load it from JSON since the non legacy optim
+        # module redefined Optimizers to no longer take in dictionaries of
+        # their parameter options.
+        config["param_groups"][0]["params"] = params
+        opt.load_state_dict(config)
+        for epoch in range(1, 101):
+            val = float(rosenbrock(params[0], params[1]))
+            print(f"Epoch {epoch:>3}/100: ({float(params[0]):>.12f}, {float(params[1]):>.12f}) = {val}")
+
+            dx, dy = drosenbrock(params[0], params[1])
+            params[0].grad = dx
+            params[1].grad = dy
+            opt.step()
+
+        print()
+

--- a/tests/nn/tests.json
+++ b/tests/nn/tests.json
@@ -1,0 +1,16 @@
+[
+  {
+    "algorithm": "adam",
+    "config": [
+      {"state": {}, "param_groups": [{"lr": 0.0001, "betas": [0.9, 0.999], "eps": 1e-08, "weight_decay": 0, "amsgrad": false, "params": [1.5, 1.5]}]}
+    ]
+  },
+  {
+    "algorithm": "sgd",
+    "config": [
+      {"state": {}, "param_groups": [{"lr": 0.0001, "momentum": 0.0, "dampening": 0, "weight_decay": 0, "nesterov": false, "params": [1.5, 1.5]}]},
+      {"state": {}, "param_groups": [{"lr": 0.0001, "momentum": 0.95, "dampening": 0, "weight_decay": 0, "nesterov": false, "params": [1.5, 1.5]}]},
+      {"state": {}, "param_groups": [{"lr": 0.0001, "momentum": 0.95, "dampening": 0, "weight_decay": 0, "nesterov": true, "params": [1.5, 1.5]}]}
+    ]
+  }
+]


### PR DESCRIPTION
This PR adds momentum with a new SGDMomentum object. The default values for SGDMomentum are the same as SGD, and when left as default the SGDMomentum optimizer will operate in the same way the base SGD optimizer. SGDMomentum optimizers must be declared with `var`, similarly to Adam and unlike SGD. Additionally an SGDMomentum object has a parameter that allows it to use Nesterov momentum rather than regular momentum. I've included a link to the paper that proposes Nesterov momentum in the documentation.

This implementation of SGD with Momentum is within 3-4 decimal places with the PyTorch implementation in both the Nesterov and base momentum cases. I have included a PyTorch output for three SGD test cases (without momentum, with momentum, and with nesterov momentum) as well as one for Adam. Tests for SGDMomentum are located in tests/nn/test_optimizers.nim. The included PyTorch implementation is a modification of the following legacy PyTorch test: https://github.com/pytorch/pytorch/blob/master/test/optim/test.py. 

It may be possible to automate these tests, right now I've done them manually by eye. If the output of the PyTorch impl. is saved to a file the Arraymancer test could load the results and check that at each optimizer step the new values of the (x, y) model points is "close enough" to the PyTorch output. 