### PR TITLE
Fix cuda/cudnn compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Reminder of supported compilation flags:
 - `-d:blas=mkl`: Use MKL, implies `openmp`
 - `-d:blas=openblas`: Use OpenBLAS
 - by default Arraymancer will try to use your default `blas.so/blas.dll`
-  Archlinux user may have to specify `-d:blas=cblas`.
+  Archlinux users may have to specify `-d:blas=cblas`.
   See [nimblas](https://github.com/unicredit/nimblas) for further configuration.
 - `-d:cuda`: Build with Cuda support
 - `-d:cudnn`: Build with CuDNN support, implies `cuda`.
@@ -208,31 +208,31 @@ Of them; she's murder'd of your galla?
 ## Table of Contents
 <!-- TOC -->
 
-- [Arraymancer - A n-dimensional tensor (ndarray) library.](#Arraymancer---A-n-dimensional-tensor-ndarray-library)
-  - [Performance notice on Nim 0.20 & compilation flags](#Performance-notice-on-Nim-020--compilation-flags)
-  - [Show me some code](#Show-me-some-code)
-    - [Tensor creation and slicing](#Tensor-creation-and-slicing)
-    - [Reshaping and concatenation](#Reshaping-and-concatenation)
-    - [Broadcasting](#Broadcasting)
-    - [A simple two layers neural network](#A-simple-two-layers-neural-network)
-    - [Teaser A text generated with Arraymancer's recurrent neural network](#Teaser-A-text-generated-with-Arraymancers-recurrent-neural-network)
-  - [Table of Contents](#Table-of-Contents)
-  - [Installation](#Installation)
-  - [Full documentation](#Full-documentation)
-  - [Features](#Features)
-    - [Arraymancer as a Deep Learning library](#Arraymancer-as-a-Deep-Learning-library)
-      - [Fizzbuzz with fully-connected layers (also called Dense, Affine or Linear layers)](#Fizzbuzz-with-fully-connected-layers-also-called-Dense-Affine-or-Linear-layers)
-      - [Handwritten digit recognition with convolutions](#Handwritten-digit-recognition-with-convolutions)
-      - [Sequence classification with stacked Recurrent Neural Networks](#Sequence-classification-with-stacked-Recurrent-Neural-Networks)
-    - [Tensors on CPU, on Cuda and OpenCL](#Tensors-on-CPU-on-Cuda-and-OpenCL)
-  - [What's new in Arraymancer v0.5.1 - July 2019](#Whats-new-in-Arraymancer-v051---July-2019)
-  - [4 reasons why Arraymancer](#4-reasons-why-Arraymancer)
-    - [The Python community is struggling to bring Numpy up-to-speed](#The-Python-community-is-struggling-to-bring-Numpy-up-to-speed)
-    - [A researcher workflow is a fight against inefficiencies](#A-researcher-workflow-is-a-fight-against-inefficiencies)
-    - [Can be distributed almost dependency free](#Can-be-distributed-almost-dependency-free)
-    - [Bridging the gap between deep learning research and production](#Bridging-the-gap-between-deep-learning-research-and-production)
-    - [So why Arraymancer ?](#So-why-Arraymancer)
-  - [Future ambitions](#Future-ambitions)
+- [Arraymancer - A n-dimensional tensor (ndarray) library.](#arraymancer---a-n-dimensional-tensor-ndarray-library)
+  - [Performance notice on Nim 0.20 & compilation flags](#performance-notice-on-nim-020--compilation-flags)
+  - [Show me some code](#show-me-some-code)
+    - [Tensor creation and slicing](#tensor-creation-and-slicing)
+    - [Reshaping and concatenation](#reshaping-and-concatenation)
+    - [Broadcasting](#broadcasting)
+    - [A simple two layers neural network](#a-simple-two-layers-neural-network)
+    - [Teaser A text generated with Arraymancer's recurrent neural network](#teaser-a-text-generated-with-arraymancers-recurrent-neural-network)
+  - [Table of Contents](#table-of-contents)
+  - [Installation](#installation)
+  - [Full documentation](#full-documentation)
+  - [Features](#features)
+    - [Arraymancer as a Deep Learning library](#arraymancer-as-a-deep-learning-library)
+      - [Fizzbuzz with fully-connected layers (also called Dense, Affine or Linear layers)](#fizzbuzz-with-fully-connected-layers-also-called-dense-affine-or-linear-layers)
+      - [Handwritten digit recognition with convolutions](#handwritten-digit-recognition-with-convolutions)
+      - [Sequence classification with stacked Recurrent Neural Networks](#sequence-classification-with-stacked-recurrent-neural-networks)
+    - [Tensors on CPU, on Cuda and OpenCL](#tensors-on-cpu-on-cuda-and-opencl)
+  - [What's new in Arraymancer v0.5.1 - July 2019](#whats-new-in-arraymancer-v051---july-2019)
+  - [4 reasons why Arraymancer](#4-reasons-why-arraymancer)
+    - [The Python community is struggling to bring Numpy up-to-speed](#the-python-community-is-struggling-to-bring-numpy-up-to-speed)
+    - [A researcher workflow is a fight against inefficiencies](#a-researcher-workflow-is-a-fight-against-inefficiencies)
+    - [Can be distributed almost dependency free](#can-be-distributed-almost-dependency-free)
+    - [Bridging the gap between deep learning research and production](#bridging-the-gap-between-deep-learning-research-and-production)
+    - [So why Arraymancer ?](#so-why-arraymancer)
+  - [Future ambitions](#future-ambitions)
 
 <!-- /TOC -->
 

--- a/nim.cfg
+++ b/nim.cfg
@@ -7,23 +7,27 @@
 # Nim cfg is not aware of new define within the file: https://github.com/nim-lang/Nim/issues/6698
 
 @if cuda or cudnn:
+  # compile with "cpp" backend.
   # See https://github.com/mratsim/Arraymancer/issues/371
-  # Nvidia NVCC cannot be used with the new Nim times module
-  # as it seems to redefine "nanosecond"
-  # We use Clang/LLVM instead
 
-  # cincludes:"/opt/cuda/include"
-  # cc:"gcc"
-  # # Compilation for Cuda requires C++
-  # gcc.cpp.exe:"/opt/cuda/bin/nvcc"
-  # gcc.cpp.linkerexe:"/opt/cuda/bin/nvcc"
-  # gcc.cpp.options.always:"-O3 -arch=sm_61 --x cu -Xcompiler -fpermissive -Xcompiler -march=native" # Important sm_61 architecture corresponds to Pascal. Change for your own card
-
+  # Nvidia NVCC
   cincludes:"/opt/cuda/include"
-  clibdir:"/opt/cuda/lib"
-  cc:"clang"
-  # Compile for Pascal (6.1) and Turing cards (7.5)
-  clang.cpp.options.always:"--cuda-path=/opt/cuda -lcudart_static -x cuda --cuda-gpu-arch=sm_61 --cuda-gpu-arch=sm_75"
+  cc:"gcc"
+  # Compilation for Cuda requires C++
+  gcc.cpp.exe:"/opt/cuda/bin/nvcc"
+  gcc.cpp.linkerexe:"/opt/cuda/bin/nvcc"
+  gcc.cpp.options.debug: "-Xcompiler -Og" # Additional "-Xcompiler -g3" crashes stb_image macros
+  gcc.cpp.options.speed: "-Xcompiler -O3 -Xcompiler -fno-strict-aliasing"
+  gcc.cpp.options.size: "-Xcompiler -Os"
+  # Important sm_61 architecture corresponds to Pascal and sm_75 to Turing. Change for your own card
+  gcc.cpp.options.always:"-gencode arch=compute_61,code=sm_61 -gencode arch=compute_75,code=sm_75 --x cu -Xcompiler -fpermissive"
+
+  # Clang
+  # cincludes:"/opt/cuda/include"
+  # clibdir:"/opt/cuda/lib"
+  # cc:"clang"
+  # # Compile for Pascal (6.1) and Turing cards (7.5)
+  # clang.cpp.options.always:"--cuda-path=/opt/cuda -lcudart_static -x cuda --cuda-gpu-arch=sm_61 --cuda-gpu-arch=sm_75"
 
 @end
 

--- a/nim.cfg
+++ b/nim.cfg
@@ -7,12 +7,24 @@
 # Nim cfg is not aware of new define within the file: https://github.com/nim-lang/Nim/issues/6698
 
 @if cuda or cudnn:
+  # See https://github.com/mratsim/Arraymancer/issues/371
+  # Nvidia NVCC cannot be used with the new Nim times module
+  # as it seems to redefine "nanosecond"
+  # We use Clang/LLVM instead
+
+  # cincludes:"/opt/cuda/include"
+  # cc:"gcc"
+  # # Compilation for Cuda requires C++
+  # gcc.cpp.exe:"/opt/cuda/bin/nvcc"
+  # gcc.cpp.linkerexe:"/opt/cuda/bin/nvcc"
+  # gcc.cpp.options.always:"-O3 -arch=sm_61 --x cu -Xcompiler -fpermissive -Xcompiler -march=native" # Important sm_61 architecture corresponds to Pascal. Change for your own card
+
   cincludes:"/opt/cuda/include"
-  cc:"gcc"
-  # Compilation for Cuda requires C++
-  gcc.cpp.exe:"/opt/cuda/bin/nvcc"
-  gcc.cpp.linkerexe:"/opt/cuda/bin/nvcc"
-  gcc.cpp.options.always:"-O3 -arch=sm_61 --x cu -Xcompiler -fpermissive -Xcompiler -march=native" # Important sm_61 architecture corresponds to Pascal. Change for your own card
+  clibdir:"/opt/cuda/lib"
+  cc:"clang"
+  # Compile for Pascal (6.1) and Turing cards (7.5)
+  clang.cpp.options.always:"--cuda-path=/opt/cuda -lcudart_static -x cuda --cuda-gpu-arch=sm_61 --cuda-gpu-arch=sm_75"
+
 @end
 
 @if openblas:

--- a/src/nn_primitives/backend/cudnn.nim
+++ b/src/nn_primitives/backend/cudnn.nim
@@ -59,7 +59,7 @@ template asCudnnType*[T: SomeFloat](typ: typedesc[T]): cudnnDataType_t =
 proc newCudnn4DTensorDesc*[T: SomeFloat](t: CudaTensor[T]): cudnnTensorDescriptor_t {.inline, noinit.}=
   # TODO: destroy descriptor automatically
   # TODO: generalize with the NDTensor Desc
-  check cudnnCreateTensorDescriptor addr result
+  check cudnnCreateTensorDescriptor(result.addr)
 
   check cudnnSetTensor4dDescriptorEx(
     result,

--- a/src/nn_primitives/backend/cudnn_conv_interface.nim
+++ b/src/nn_primitives/backend/cudnn_conv_interface.nim
@@ -76,7 +76,7 @@ proc newConv2dDesc*[T: SomeFloat](padding, strides, dilation: SizeHW): cudnnConv
 proc newCudnnConvKernelDesc*[T: SomeFloat](
   convKernel: CudaTensor[T]): cudnnFilterDescriptor_t {.inline, noInit.}=
   # TODO: destroy descriptor automatically
-  check cudnnCreateFilterDescriptor addr result
+  check cudnnCreateFilterDescriptor(result.addr)
 
   var filters = [ convKernel.shape[0].cint, # out features (for example 16 feature maps)
                   convKernel.shape[1].cint, # in features (for example 3 color channels)

--- a/src/nn_primitives/backend/cudnn_conv_interface.nim
+++ b/src/nn_primitives/backend/cudnn_conv_interface.nim
@@ -131,7 +131,7 @@ proc convOutDims*(input, kernel: CudaTensor, padding, strides, dilation: SizeHW)
 # ###############################################################
 # Forward convolution: Algorithm and Worksize space
 
-proc conv_algo_workspace*[T: SomeFloat](
+proc newConvAlgoSpace*[T: SomeFloat](
   srcTensorDesc: cudnnTensorDescriptor_t,
   kernelDesc: cudnnFilterDescriptor_t,
   convDesc: cudnnConvolutionDescriptor_t,

--- a/src/tensor/einsum.nim
+++ b/src/tensor/einsum.nim
@@ -1,6 +1,8 @@
 import macros, sequtils, sets, algorithm
-import tensor
 import ../private/ast_utils
+import ./shapeshifting
+  # Note: importing shapeshifting_cuda will trigger a Nim inference bug
+  #       in genContiguous with no workaround
 
 #[
 This module provides Einstein summation for an arbitrary number of tensors.
@@ -508,10 +510,11 @@ proc genContiguous(ts: seq[NimNode], subType: NimNode): (seq[NimNode], NimNode) 
   for t in ts:
     let tCIdent = makeContigIdent(t)
     res.add quote do:
+      # TODO: Nim inference bug that require the subtype
       let `tcIdent` = asContiguous[`subType`](`t`, layout = rowMajor, force = true)
     tsCont.add tcIdent
   result = (tsCont, res)
-  echo res.treeRepr
+  # echo res.treeRepr
 
 macro einsum*(tensors: varargs[typed], stmt: untyped): untyped =
   ## Performs Einstein summation of the given `tensors` defined by the `stmt`.


### PR DESCRIPTION
This is a potential fix to Cuda compilation being broken with the Nim times module (#371)

This seems to happen because Nvidia compiler NVCC defines (?) `nanosecond` symbol globally which conflicts with the std/times module.

Unfortunately the fix has an annoying version requirements as LLVM releases lag behind Cuda SDK and requires compiling from source to support Cuda 10.1 for example:

| clang++ | supported CUDA release | supported SMs |
| ------- | ---------------------- | ------------- |
| 3.9-5.0 | 7.0-8.0                | 2.0-(5.0)6.0  |
| 6.0     | [7.0-9.0](https://github.com/llvm-mirror/clang/blob/release_60/include/clang/Basic/Cuda.h) | [(2.0)3.0-7.0](https://github.com/llvm-mirror/clang/blob/release_60/lib/Basic/Targets/NVPTX.cpp#L163-L188) |
| 7.0     | [7.0-9.2](https://github.com/llvm-mirror/clang/blob/release_70/include/clang/Basic/Cuda.h) | [(2.0)3.0-7.2](https://github.com/llvm-mirror/clang/blob/release_70/lib/Basic/Targets/NVPTX.cpp#L196-L223) |
| 8.0     | [7.0-10.0](https://github.com/llvm-mirror/clang/blob/release_80/include/clang/Basic/Cuda.h) | [(2.0)3.0-7.5](https://github.com/llvm-mirror/clang/blob/release_70/lib/Basic/Targets/NVPTX.cpp#L199-L228) |
| trunk   | [7.0-10.1](https://github.com/llvm-mirror/clang/blob/master/include/clang/Basic/Cuda.h) | [(2.0)3.0-7.5](https://github.com/llvm-mirror/clang/blob/master/lib/Basic/Targets/NVPTX.cpp#L200-L229) |