### PR TITLE
fix #390 by copying `gemm` input tensor

### DIFF
--- a/src/tensor/optim_ops_fusion.nim
+++ b/src/tensor/optim_ops_fusion.nim
@@ -29,8 +29,7 @@ import  ../private/[nested_containers, ast_utils],
 proc tensor_multiplyAdd[T](
   A, B: Tensor[T],
   C: Tensor[T]): Tensor[T] =
-
-  result = C
+  result = deepCopy(C)
 
   if C.rank == 2:
     gemm(1.T, A, B, 1.T, result)

--- a/src/tensor/optim_ops_fusion.nim
+++ b/src/tensor/optim_ops_fusion.nim
@@ -29,7 +29,7 @@ import  ../private/[nested_containers, ast_utils],
 proc tensor_multiplyAdd[T](
   A, B: Tensor[T],
   C: Tensor[T]): Tensor[T] =
-  result = deepCopy(C)
+  result = C.clone()
 
   if C.rank == 2:
     gemm(1.T, A, B, 1.T, result)
@@ -110,4 +110,3 @@ template rewriteToTensorReshape*{reshape(toTensor(oa, dummy_bugfix), shape)}(
   ##
   ## Operation fusion leverage the Nim compiler and should not be called explicitly.
   toTensorReshape(oa, shape, dummy_bugfix)
-

--- a/tests/tensor/test_optim_ops_fusion.nim
+++ b/tests/tensor/test_optim_ops_fusion.nim
@@ -1,0 +1,26 @@
+# Copyright 2017 the Arraymancer contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ../../src/arraymancer
+import unittest, math
+
+suite "Testing fusion operations":
+  test "Multiply and add":
+    let
+      A = @[4.0].toTensor.reshape(1, 1)
+      x = @[3.0].toTensor
+      b = zeros[float](1)
+    for _ in 0..4:
+      check ((A * x) + b)[0] == 12.0
+      check b[0] == 0.0


### PR DESCRIPTION
Apparently when the change to reference semantics was made, this line wasn't changed accordingly. 

I'm not sure if `deepCopy` is the desired way here?