### PR TITLE
Fix #386 - reshaping without copy on column-major tensors

### DIFF
--- a/src/tensor/shapeshifting_cuda.nim
+++ b/src/tensor/shapeshifting_cuda.nim
@@ -58,9 +58,9 @@ proc asContiguous*[T: SomeFloat](t: CudaTensor[T], layout: OrderType = colMajor,
 proc reshape*(t: CudaTensor, new_shape: varargs[int]): CudaTensor =
   ## Reshape a CudaTensor without copy.
   ##
-  ## ⚠ Reshaping without copy is only possible on contiguous Tensors
+  ## ⚠ Reshaping without copy is only possible on contiguous rowMajor Tensors
 
-  t.reshape_no_copy(new_shape, result)
+  t.reshape_no_copy(new_shape, result, rowMajor)
   result.storage = t.storage
 
 proc broadcast*(t: CudaTensor, shape: varargs[int]): CudaTensor {.noSideEffect.}=

--- a/tests/test_bugtracker.nim
+++ b/tests/test_bugtracker.nim
@@ -47,3 +47,18 @@ suite "Testing specific issues from bug tracker":
     let x = zeros[int]([1, 2, 3])
     expect(IndexError):
       let y{.used.} = x[1, _, _]
+
+  test "#386 Reshaping a contiguous permuted tensor":
+    # https://github.com/mratsim/Arraymancer/issues/386
+    block: # row-major
+      let x = [[0, 1], [2, 3]].toTensor
+      let expected = [[0, 2], [1, 3]].toTensor
+      check:
+        x.permute(1, 0) == expected
+        x.permute(1, 0).reshape(2, 2) == expected
+    block: # col-major
+      let x = [[0, 1], [2, 3]].toTensor.clone(colMajor)
+      let expected = [[0, 2], [1, 3]].toTensor
+      check:
+        x.permute(1, 0) == expected
+        x.permute(1, 0).reshape(2, 2) == expected


### PR DESCRIPTION
Reshaping without copy requires input and output to have the same contiguity.