### PR TITLE
Remove complex converter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,8 @@ Changes:
 
 Bug fixes:
   - ``gemm`` could crash when the result was column major
+  - Complex converters do not pollute the global namespace and do not
+    prevent string covnersion via `$` of number types due to ambiguous call.
 
 Breaking
   - In ``symeig``, the ``eigenvectors`` argument is now called ``return_eigenvectors``.
@@ -26,6 +28,9 @@ Breaking
   - pca output tuple used the names (results, components). It has been renamed to (projected, components).
   - A ``pca`` overload that projected a data matrix on already existing principal axes
     was removed. Simply multiply the mean-centered data matrix with the loadings instead.
+  - Complex converters were removed. This prevents hard to debug and workaround implicit conversion bug in downstream library.
+    If necessary, users can reimplement converters themselves.
+    This also provides a 20% boost in Arraymancer compilation times
 
 Deprecation:
   - The syntax gemm(A, B, C) is now deprecated.

--- a/src/ml/metrics/common_error_functions.nim
+++ b/src/ml/metrics/common_error_functions.nim
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import ../../tensor/tensor
-import complex except Complex64, Complex32
-
 
 # ####################################################
 
@@ -34,11 +32,12 @@ proc mean_squared_error*[T](y_true, y: Tensor[T]): T =
 
 # ####################################################
 
-proc relative_error*[T](y_true, y: T): T {.inline.} =
+proc relative_error*[T: SomeFloat](y_true, y: T): T {.inline.} =
   ## Relative error, |y_true - y|/max(|y_true|, |y|)
   ## Normally the relative error is defined as |y_true - y| / |y_true|,
   ## but here max is used to make it symmetric and to prevent dividing by zero,
   ## guaranteed to return zero in the case when both values are zero.
+  # We require float (and not complex as complex.abs will cause issue)
   let denom = max(abs(y_true), abs(y))
   if denom == 0.T:
     return 0.T
@@ -61,8 +60,9 @@ proc mean_relative_error*[T](y_true, y: Tensor[T]): T =
 
 # ####################################################
 
-proc absolute_error*[T](y_true, y: T): T {.inline.} =
+proc absolute_error*[T: SomeFloat](y_true, y: T): T {.inline.} =
   ## Absolute error for a single value, |y_true - y|
+  # We require float (and not complex as complex.abs will cause issue)
   result = abs(y_true - y)
 
 proc absolute_error*[T](y_true, y: Tensor[T]): Tensor[T] {.noInit.} =

--- a/src/tensor/aggregate.nim
+++ b/src/tensor/aggregate.nim
@@ -57,13 +57,23 @@ proc mean*[T: SomeInteger](t: Tensor[T], axis: int): Tensor[T] {.noInit,inline.}
   ## Warning ⚠: Since input is integer, output will also be integer (using integer division)
   t.sum(axis) div t.shape[axis].T
 
-proc mean*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T]): T {.inline.}=
+proc mean*[T: SomeFloat](t: Tensor[T]): T {.inline.}=
   ## Compute the mean of all elements
   t.sum / t.size.T
 
-proc mean*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T], axis: int): Tensor[T] {.noInit,inline.}=
+proc mean*[T: Complex[float32] or Complex[float64]](t: Tensor[T]): T {.inline.}=
+  ## Compute the mean of all elements
+  type F = T.T # Get float subtype of Complex[T]
+  t.sum / complex(t.size.F, 0.F)
+
+proc mean*[T: SomeFloat](t: Tensor[T], axis: int): Tensor[T] {.noInit,inline.}=
   ## Compute the mean along an axis
   t.sum(axis) / t.shape[axis].T
+
+proc mean*[T: Complex[float32] or Complex[float64]](t: Tensor[T], axis: int): Tensor[T] {.noInit,inline.}=
+  ## Compute the mean along an axis
+  type F = T.T # Get float subtype of Complex[T]
+  t.sum(axis) / complex(t.shape[axis].F, 0.F)
 
 proc min*[T](t: Tensor[T]): T =
   ## Compute the min of all elements

--- a/src/tensor/data_structure.nim
+++ b/src/tensor/data_structure.nim
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import  ./backend/metadataArray,
-        nimblas
+        nimblas, complex
 
-export nimblas.OrderType
+export nimblas.OrderType, complex
 
 type
   CpuStorage* {.shallow.} [T] = object

--- a/src/tensor/init_cpu.nim
+++ b/src/tensor/init_cpu.nim
@@ -21,7 +21,6 @@ import  ../private/[functional, nested_containers, sequninit],
         sequtils,
         random,
         math
-include ./private/p_complex
 
 proc newTensorUninit*[T](shape: varargs[int]): Tensor[T] {.noSideEffect,noInit, inline.} =
   ## Creates a new Tensor on Cpu backend
@@ -147,7 +146,11 @@ proc ones*[T: SomeNumber|Complex[float32]|Complex[float64]](shape: varargs[int])
   ##      - Type of its elements
   ## Result:
   ##      - A one-ed Tensor of the same shape
-  newTensorWith[T](shape, 1.T)
+  when T is SomeNumber:
+    newTensorWith[T](shape, 1.T)
+  else:
+    type F = T.T # Get the float subtype of Complex[T]
+    newTensorWith[T](shape, complex(1.F, 0.F))
 
 proc ones*[T: SomeNumber|Complex[float32]|Complex[float64]](shape: MetadataArray): Tensor[T] {.noInit, inline, noSideEffect.} =
   ## Creates a new Tensor filled with 1
@@ -156,7 +159,11 @@ proc ones*[T: SomeNumber|Complex[float32]|Complex[float64]](shape: MetadataArray
   ##      - Type of its elements
   ## Result:
   ##      - A one-ed Tensor of the same shape
-  newTensorWith[T](shape, 1.T)
+  when T is SomeNumber:
+    newTensorWith[T](shape, 1.T)
+  else:
+    type F = T.T
+    newTensorWith[T](shape, complex(1.F, 0.F))
 
 proc ones_like*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T]): Tensor[T] {.noInit, inline, noSideEffect.} =
   ## Creates a new Tensor filled with 1 with the same shape as the input

--- a/src/tensor/math_functions.nim
+++ b/src/tensor/math_functions.nim
@@ -44,13 +44,23 @@ proc melwise_div*[T: SomeFloat](a: var Tensor[T], b: Tensor[T]) =
   ## Element-wise division (in-place)
   a.apply2_inline(b, x / y)
 
-proc reciprocal*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T]): Tensor[T] {.noInit.} =
+proc reciprocal*[T: SomeFloat](t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Return a tensor with the reciprocal 1/x of all elements
   t.map_inline(1.T/x)
 
-proc mreciprocal*[T: SomeFloat|Complex[float32]|Complex[float64]](t: var Tensor[T]) =
+proc mreciprocal*[T: SomeFloat](t: var Tensor[T]) =
   ## Apply the reciprocal 1/x in-place to all elements of the Tensor
   t.apply_inline(1.T/x)
+
+proc reciprocal*[T: Complex[float32] or Complex[float64]](t: Tensor[T]): Tensor[T] {.noInit.} =
+  ## Return a tensor with the reciprocal 1/x of all elements
+  type F = T.T # Get float subtype of Complex[T]
+  t.map_inline(complex(1.F, 0.F)/x)
+
+proc mreciprocal*[T: Complex[float32] or Complex[float64]](t: var Tensor[T]) =
+  ## Apply the reciprocal 1/x in-place to all elements of the Tensor
+  type F = T.T # Get float subtype of Complex[T]
+  t.apply_inline(complex(1.F, 0.F)/x)
 
 proc negate*[T: SomeSignedInt|SomeFloat](t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Return a tensor with all elements negated (10 -> -10)

--- a/src/tensor/ufunc.nim
+++ b/src/tensor/ufunc.nim
@@ -14,11 +14,21 @@
 
 import  ./data_structure,
         ./higher_order_applymap,
-        sugar, math
- 
-proc astype*[T, U](t: Tensor[T], typ: typedesc[U]): Tensor[U] {.noInit.} =
+        sugar, math, complex,
+        ../private/ast_utils
+
+proc astype*[T; U: not Complex](t: Tensor[T], typ: typedesc[U]): Tensor[U] {.noInit.} =
   ## Apply type conversion on the whole tensor
   result = t.map(x => x.U)
+
+proc astype*[T: SomeNumber, U: Complex](t: Tensor[T], typ: typedesc[U]): Tensor[U] {.noInit.} =
+  ## Apply type conversion on the whole tensor
+  when T is SomeNumber and U is Complex[float32]:
+    result = t.map(x => complex32(x.float32))
+  elif T is SomeNumber and U is Complex[float64]:
+    result = t.map(x => complex64(x.float64))
+  else:
+    {.error: "Unreachable".}
 
 # #############################################################
 # Autogen universal functions

--- a/tests/tensor/test_accessors_slicer.nim
+++ b/tests/tensor/test_accessors_slicer.nim
@@ -44,7 +44,7 @@ suite "Testing indexing and slice syntax":
   # |5      25      125     625     3125|
   test "Basic indexing - foo[2, 3]":
     check: t_van[2, 3] == 81
-    check: t_van.astype(Complex[float64])[2, 3] == 81.Complex64
+    check: t_van.astype(Complex[float64])[2, 3] == complex(81.0)
 
   test "Basic indexing - foo[1+1, 2*2*1]":
     check: t_van[1+1, 2*2*1] == 243

--- a/tests/tensor/test_aggregate.nim
+++ b/tests/tensor/test_aggregate.nim
@@ -25,7 +25,7 @@ suite "[Core] Testing aggregation functions":
 
   test "Sum":
     check: t.sum == 66
-    check: t_c.sum == 66
+    check: t_c.sum == complex(66'f64)
     let row_sum = [[18, 22, 26]].toTensor()
     let col_sum = [[3],
                    [12],
@@ -38,7 +38,7 @@ suite "[Core] Testing aggregation functions":
 
   test "Mean":
     check: t.astype(float).mean == 5.5 # Note: may fail due to float rounding
-    check: t_c.mean == 5.5 # Note: may fail due to float rounding
+    check: t_c.mean == complex(5.5) # Note: may fail due to float rounding
 
     let row_mean = [[4.5, 5.5, 6.5]].toTensor()
     let col_mean = [[1.0],
@@ -58,8 +58,8 @@ suite "[Core] Testing aggregation functions":
     check: a.astype(float).product() == 32768.0
     check: a.product(0) == [[8,32,128]].toTensor()
     check: a.product(1) == [[8],[4096]].toTensor()
-    check: t_c.product() == 0
-    check: a_c.product() == 32768.0
+    check: t_c.product() == complex(0.0)
+    check: a_c.product() == complex(32768.0)
     check: a_c.product(0) == [[8,32,128]].toTensor().astype(Complex[float64])
     check: a_c.product(1) == [[8],[4096]].toTensor().astype(Complex[float64])
 

--- a/tests/tensor/test_broadcasting.nim
+++ b/tests/tensor/test_broadcasting.nim
@@ -264,7 +264,7 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
       var b_c = b.clone.astype(Complex[float64])
 
       a .^= 2.0
-      a_c .^= 2.0
+      a_c .^= complex(2.0)
       check: a == [[1.0],
                     [100.0],
                     [400.0],
@@ -275,7 +275,7 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
                     [900.0]].toTensor.astype(Complex[float64])
 
       b .^= -1
-      b_c .^= -1
+      b_c .^= complex(-1.0)
       check: b == [[1.0],
                     [1.0/10.0],
                     [1.0/20.0],
@@ -287,8 +287,11 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
 
   test "Implicit broadcasting - Sigmoid 1 ./ (1 .+ exp(-x)":
     block:
-      proc sigmoid[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T]): Tensor[T]=
+      proc sigmoid[T: SomeFloat](t: Tensor[T]): Tensor[T]=
         1.T ./ (1.T .+ exp(0.T .- t))
+
+      proc sigmoid(t: Tensor[Complex32]): Tensor[Complex32]=
+        complex32(1) ./ (complex32(1) .+ exp(complex32(0) .- t))
 
       let a = newTensor[float32]([2,2])
       check: sigmoid(a) == [[0.5'f32, 0.5],[0.5'f32, 0.5]].toTensor

--- a/tests/tensor/test_higherorder.nim
+++ b/tests/tensor/test_higherorder.nim
@@ -52,14 +52,15 @@ suite "[Core] Testing higher-order functions":
     tmp2.apply(plus_one) # in-place
     check: tmp2 == t2[_,2]
 
+    proc plus_one_complex[T](x: var T) = x += complex(1'f64)
     var tmp2_c = t[_,2].clone.astype(Complex[float64])
-    tmp2_c.apply(plus_one) # in-place
+    tmp2_c.apply(plus_one_complex) # in-place
     check: tmp2_c == t2_c[_,2]
 
 
   test "Reduce function":
     check: t.reduce(customAdd) == 66
-    check: t_c.reduce(customAdd) == 66.Complex64
+    check: t_c.reduce(customAdd) == complex(66'f64)
 
     proc customConcat(x, y: string): string = x & y
 

--- a/tests/tensor/test_operators_blas.nim
+++ b/tests/tensor/test_operators_blas.nim
@@ -193,7 +193,6 @@ suite "BLAS (Basic Linear Algebra Subprograms)":
 
     check:
       mean_absolute_error(expected, val) < 1e-9
-      abs(mean_absolute_error(expected.astype(Complex[float64]), val.astype(Complex[float64]))) < 1e-9
 
   test "Scalar/dot product":
     ## TODO: test with slices
@@ -218,7 +217,7 @@ suite "BLAS (Basic Linear Algebra Subprograms)":
 
     let ufl_expected = @[2'f64, 6, -10].toTensor()
     check: ufl_expected / 2 == u_float
-    check: ufl_expected.astype(Complex[float64]) / 2 == u_float.astype(Complex[float64])
+    check: ufl_expected.astype(Complex[float64]) / complex(2'f64) == u_float.astype(Complex[float64])
 
   test "Multiplication/division by scalar (inplace)":
     var u_int = @[1, 3, -5].toTensor()
@@ -282,11 +281,11 @@ suite "BLAS (Basic Linear Algebra Subprograms)":
       let expected_sub = @[0, 2, -6].toTensor().astype(Complex[float64])
 
       u_complex += v_complex
-      check: u_complex == expected_add.astype(Complex[float64])
+      check: u_complex == expected_add
 
       u_complex -= v_complex
       u_complex -= v_complex
-      check: u_complex == expected_sub.astype(Complex[float64])
+      check: u_complex == expected_sub
 
   test "Tensor negative":
     let u_int = @[-1, 0, 2].toTensor()

--- a/tests/tensor/test_ufunc.nim
+++ b/tests/tensor/test_ufunc.nim
@@ -41,8 +41,10 @@ suite "Universal functions":
                        @[cos(complex64(4'f64,0.0)),cos(complex64(5'f64,0.0)),cos(complex64(6'f64,0.0))]]
 
     check: mean_absolute_error(cos(ta), expected_a.toTensor()) <= 1e-15 # We have slight precision loss with OpenMP
-    check: abs(mean_absolute_error(cos(tc), expected_c.toTensor())) <= 1e-15
     check: ln(tb) == expected_b.toTensor()
+
+    # TODO - complex errors
+    # check: abs(mean_absolute_error(cos(tc), expected_c.toTensor())) <= 1e-15
 
   test "Creating custom universal functions is supported":
     proc square_plus_one(x: int): int = x ^ 2 + 1
@@ -82,7 +84,6 @@ suite "Universal functions":
         discard td.map(stringify)[1,3]
     else:
       echo "Bound-checking is disabled or OpenMP is used. The incorrect seq shape test has been skipped."
-
 
   test "Abs":
     let a = [-2,-1,0,1,2].toTensor()


### PR DESCRIPTION
Fix #394

Converters pollute the namespace and cause hard-to-debug and hard-to-workaround issues.
This PR removes the complex converter which should instead be in a separate library/user file.

This also brings significant improvement to compile-time.

--------

Note that there was a huge compilation perf issue in 0.20.0 that was fixed in 0.20.2 (compared to #359)

Each were run twice so normalize the effect of caching. We are more interested in the cost of semantic checking.

1.0.2 - before removing complex converter

File                      | Time          | Memory
--------------------------|---------------|---------------
[test_accessors_slicer](https://github.com/mratsim/Arraymancer/blob/15bcead0/tests/tensor/test_accessors_slicer.nim)     | **1.518 sec** | **210.91MiB**
[test_operators_blas](https://github.com/mratsim/Arraymancer/blob/15bcead0/tests/tensor/test_operators_blas.nim)       | **2.156 sec** | **261.711MiB**
[test_aggregate](https://github.com/mratsim/Arraymancer/blob/15bcead0/tests/tensor/test_aggregate.nim)            | **1.939 sec** | **261.453MiB**
[test_shapeshifting](https://github.com/mratsim/Arraymancer/blob/15bcead0/tests/tensor/test_shapeshifting.nim)        | **1.643 sec** | **210.844MiB**
[test_broadcasting](https://github.com/mratsim/Arraymancer/blob/15bcead0/tests/tensor/test_broadcasting.nim)         | **2.060 sec** | **261.367MiB**

1.0.2 - after removing complex converter

File                      | Time          | Memory
--------------------------|---------------|---------------
[test_accessors_slicer](https://github.com/mratsim/Arraymancer/blob/305ae755/tests/tensor/test_accessors_slicer.nim)     | **1.379 sec** | **169.891MiB**
[test_operators_blas](https://github.com/mratsim/Arraymancer/blob/305ae755/tests/tensor/test_operators_blas.nim)       | **1.770 sec** | **262.086MiB**
[test_aggregate](https://github.com/mratsim/Arraymancer/blob/305ae755/tests/tensor/test_aggregate.nim)            | **1.645 sec** | **210.758MiB**
[test_shapeshifting](https://github.com/mratsim/Arraymancer/blob/305ae755/tests/tensor/test_shapeshifting.nim)        | **1.469 sec** | **210.93MiB**
[test_broadcasting](https://github.com/mratsim/Arraymancer/blob/305ae755/tests/tensor/test_broadcasting.nim)         | **1.734 sec** | **261.695MiB**
