### PR TITLE
Add linear equation solve

### DIFF
--- a/src/linear_algebra/helpers/solve_lapack.nim
+++ b/src/linear_algebra/helpers/solve_lapack.nim
@@ -1,0 +1,47 @@
+# Copyright (c) 2019-Present the Arraymancer contributors
+# Distributed under the Apache v2 License (license terms are at http://www.apache.org/licenses/LICENSE-2.0).
+# This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  nimlapack,
+  ./overload,
+  ../../tensor/tensor
+
+# Wrappers for Fortran LAPACK linear equation driver routines *SV
+# Currently only *GESV is wrapped
+# TODO: Implement GBSV, GTSV, POSV, PBSV, PTSV, SYSV
+
+overload(gesv, sgesv)
+overload(gesv, dgesv)
+
+proc gesv*[T: SomeFloat](a, b: var Tensor[T], pivot_indices: var seq[int32]) =
+  ## Wrapper for LAPACK *gesv routines
+  ## Solve AX = B for general matrix
+  ##
+  ## In-place version, this will overwrite a and b
+  assert a.rank == 2, "a is not a matrix"
+  assert a.is_F_contiguous, "a must be column-major"
+
+  assert b.rank == 2, "b is not a matrix"
+  assert b.is_F_contiguous, "b must be column-major"
+
+  # Temporaries
+  let
+    n = a.shape[0].int32 # colMajor in Fortran
+    nrhs = b.shape[1].int32
+    ldb = b.shape[0].int32
+
+  var info: int32
+
+  gesv(n=n.unsafeAddr, nrhs=nrhs.unsafeAddr, a=a.get_data_ptr,
+       lda=n.unsafeAddr, ipiv=pivot_indices[0].addr, b=b.get_data_ptr,
+       ldb=ldb.unsafeAddr, info=info.addr)
+
+  if info < 0:
+    raise newException(ValueError, "Illegal parameter in linear solve gesv: " & $(-info))
+  if info > 0:
+    let
+      cinfo = $(info - 1) # Fortran arrays are indexed by 1
+      msg = "Error: in LU factorization, diagonal U[" & cinfo & "," & cinfo & "] is zero. " &
+            "Matrix is singular/non-invertible and solution could not be computed."
+    raise newException(ValueError, msg)

--- a/src/linear_algebra/linear_algebra.nim
+++ b/src/linear_algebra/linear_algebra.nim
@@ -4,8 +4,8 @@
 
 import
   ./least_squares, ./special_matrices,
-  ./decomposition, ./decomposition_rand
+  ./decomposition, ./decomposition_rand, ./linear_systems
 
 export
   least_squares, special_matrices,
-  decomposition, decomposition_rand
+  decomposition, decomposition_rand, linear_systems

--- a/src/linear_algebra/linear_systems.nim
+++ b/src/linear_algebra/linear_systems.nim
@@ -1,0 +1,59 @@
+# Copyright (c) 2019-Present the Arraymancer contributors
+# Distributed under the Apache v2 License (license terms are at http://www.apache.org/licenses/LICENSE-2.0).
+# This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  strformat,
+  ../tensor/tensor,
+  ../private/sequninit,
+  ./helpers/solve_lapack
+
+type MatrixKind* = enum
+    mkGeneral,
+    mkGenBand,
+    mkGenTriDiag,
+    mkSymmetric,
+    mkPosDef,
+    mkPosDefBand,
+    mkPosDefTriDiag
+
+func solve*[T: SomeFloat](a, b: Tensor[T], kind: MatrixKind = mkGeneral): Tensor[T] =
+  ## Compute the solution ``X`` to the system of linear equations ``AX = B``.
+  ##
+  ## Multiple right-hand sides can be solved simultaneously.
+  ##
+  ## Input:
+  ##   - ``a``, a MxM matrix
+  ##   - ``b``, a vector of length M, or a MxN matrix. In the latter case, each
+  ##     column is interpreted as a separate RHS to solve for.
+  ##
+  ## Output:
+  ##   - Tensor with same shape as ``b``
+  assert a.rank == 2
+  assert b.rank <= 2
+
+  let k = min(a.shape[0], a.shape[1])
+
+  # mutated by lapack wrappers
+  var
+    pivot_indices = newSeqUninit[int32](k)
+    lu = a.clone(colMajor)
+  result = b.clone(colMajor)
+
+  # Automatically handle single or multiple RHS
+  if result.rank == 1:
+    result = result.reshape(result.shape[0], 1)
+  assert result.rank == 2
+
+  case kind:
+    of mkGeneral:
+      gesv(lu, result, pivot_indices)
+    else:
+      # TODO: add support for other matrices supported by LAPACK
+      raise newException(ValueError,
+                         fmt"solve not implemented for matrix kind {kind}")
+
+  # If single RHS, return vector
+  if b.rank == 1:
+    result = result.reshape(result.shape[0])
+  assert result.shape == b.shape

--- a/tests/linear_algebra/test_linear_algebra.nim
+++ b/tests/linear_algebra/test_linear_algebra.nim
@@ -427,3 +427,27 @@ suite "Linear algebra":
 
       let reconstructed = (U .* S.unsqueeze(0)) * Vh
       check: mean_absolute_error(H, reconstructed) < 1e-2
+
+  test "Solve linear equations general matrix":
+    block:
+      # From: https://software.intel.com/sites/products/documentation/doclib/mkl_sa/11/mkl_lapack_examples/dgesv_ex.c.htm
+      let a = [[ 6.80, -6.05, -0.45,  8.32, -9.67],
+               [-2.11, -3.30,  2.58,  2.71, -5.14],
+               [ 5.66,  5.36, -2.70,  4.35, -7.26],
+               [ 5.97, -4.44,  0.27, -7.17,  6.08],
+               [ 8.23,  1.08,  9.04,  2.14, -6.87]].toTensor
+
+      let b = [[ 4.02, -1.56,  9.81],
+               [ 6.19,  4.00, -4.09],
+               [-8.22, -8.67, -4.57],
+               [-7.57,  1.75, -8.61],
+               [-3.03,  2.86,  8.99]].toTensor
+
+      let x_known = [[-0.80, -0.39,  0.96],
+                     [-0.70, -0.55,  0.22],
+                     [ 0.59,  0.84,  1.90],
+                     [ 1.32, -0.10,  5.36],
+                     [ 0.57,  0.11,  4.04]].toTensor
+
+      let x = solve(a, b)
+      check mean_absolute_error(x, x_known) < 0.01


### PR DESCRIPTION
Re: #389 

Add `solve` proc that is meant to have a similar API to scipy's `linalg.solve`. That is, the different matrix structures handled by LAPACK's various *SV driver routines are selected by an argument to
`solve`, `kind`.

Only the general matrix case, `gesv`, is currently implemented.