### PR TITLE
Reorder error function inputs for common error metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ let
 for t in 0 ..< 500:
   let
     y_pred = model.forward(x)
-    loss = mse_loss(y_pred, y)
+    loss = y_pred.mse_loss(y)
 
   echo &"Epoch {t}: loss {loss.value[0]}"
 

--- a/benchmarks/ex01_xor.nim
+++ b/benchmarks/ex01_xor.nim
@@ -41,7 +41,7 @@ for epoch in 0..10000:
     # Building the network
     let n1 = relu linear(x, layer_3neurons)
     let n2 = linear(n1, classifier_layer)
-    let loss = sigmoid_cross_entropy(n2, target)
+    let loss = n2.sigmoid_cross_entropy(target)
 
     # Compute the gradient (i.e. contribution of each parameter to the loss)
     loss.backprop()

--- a/benchmarks/ex01_xor_dsl.nim
+++ b/benchmarks/ex01_xor_dsl.nim
@@ -40,7 +40,7 @@ for epoch in 0..10000:
     let output = model.forward(x)
 
     # Computing the loss
-    let loss = sigmoid_cross_entropy(output, target)
+    let loss = output.sigmoid_cross_entropy(target)
 
     # Compute the gradient (i.e. contribution of each parameter to the loss)
     loss.backprop()

--- a/benchmarks/ex02_mnist.nim
+++ b/benchmarks/ex02_mnist.nim
@@ -54,7 +54,7 @@ for epoch in 0 ..< 2:
     var loss = 0.0
     for i in 0 ..< 10:
       let y_pred = model.forward(X_test[i*1000 ..< (i+1)*1000, _]).value.softmax.argmax(axis = 1).squeeze
-      score += accuracy_score(y_test[i*1000 ..< (i+1)*1000], y_pred)
+      score += y_pred.accuracy_score(y_test[i*1000 ..< (i+1)*1000])
 
       loss += model.forward(X_test[i*1000 ..< (i+1)*1000, _]).sparse_softmax_cross_entropy(y_test[i*1000 ..< (i+1)*1000]).value.data[0]
     score /= 10

--- a/benchmarks/implementation/softmax_cross_entropy_bench_batch_first.nim
+++ b/benchmarks/implementation/softmax_cross_entropy_bench_batch_first.nim
@@ -280,14 +280,14 @@ let pred = randomTensor(batch_size, nb_classes, -1.0..1.0)
 # echo labels
 
 echo "### Reference"
-let sce_loss = softmax_cross_entropy1(pred, labels)
+let sce_loss = pred.softmax_cross_entropy1(labels)
 echo sce_loss
 echo "### Challenger"
-echo softmax_cross_entropy2(pred, labels)
+echo pred.softmax_cross_entropy2(labels)
 echo "### Sparse reference"
-echo sparse_softmax_cross_entropy1(pred, sparse_labels)
+echo pred.sparse_softmax_cross_entropy1(sparse_labels)
 echo "### Sparse challenger"
-echo sparse_softmax_cross_entropy2(pred, sparse_labels) # Warning it's only accurate at 1e-3 and precision is at 1e-2 with OpenMP
+echo pred.sparse_softmax_cross_entropy2(sparse_labels) # Warning it's only accurate at 1e-3 and precision is at 1e-2 with OpenMP
 
 ## Warmup for OpenMP threadpool and CPU on "on-demand" governor
 discard pred .* pred
@@ -296,24 +296,24 @@ var start = epochTime()
 
 start = epochTime()
 for i in 0..<20:
-  discard softmax_cross_entropy1(pred, labels)
+  discard pred.softmax_cross_entropy1(labels)
 echo "Softmax xentropy zipAxis, mean(sum <- map2): ", epochTime() - start
 
 
 start = epochTime()
 for i in 0..<20:
-  discard softmax_cross_entropy2(pred, labels)
+  discard pred.softmax_cross_entropy2(labels)
 echo "Softmax xentropy Frobenius fold: ", epochTime() - start
 
 
 start = epochTime()
 for i in 0..<20:
-  discard sparse_softmax_cross_entropy1(pred, sparse_labels)
+  discard pred.sparse_softmax_cross_entropy1(sparse_labels)
 echo "Sparse softmax naive loop: ", epochTime() - start
 
 start = epochTime()
 for i in 0..<20:
-  discard sparse_softmax_cross_entropy2(pred, sparse_labels)
+  discard pred.sparse_softmax_cross_entropy2(sparse_labels)
 echo "Sparse softmax simplified loop + fold: ", epochTime() - start
 
 

--- a/benchmarks/implementation/softmax_cross_entropy_bench_batch_last.nim
+++ b/benchmarks/implementation/softmax_cross_entropy_bench_batch_last.nim
@@ -278,14 +278,14 @@ let pred = randomTensor(nb_classes, batch_size, -1.0..1.0)
 # echo labels
 
 echo "### Reference"
-let sce_loss = softmax_cross_entropy1(pred, labels)
+let sce_loss = pred.softmax_cross_entropy1(labels)
 echo sce_loss
 echo "### Challenger"
-echo softmax_cross_entropy2(pred, labels)
+echo pred.softmax_cross_entropy2(labels)
 echo "### Sparse reference"
-echo sparse_softmax_cross_entropy1(pred, sparse_labels)
+echo pred.sparse_softmax_cross_entropy1(sparse_labels)
 echo "### Sparse challenger"
-echo sparse_softmax_cross_entropy2(pred, sparse_labels) # Warning it's only accurate at 1e-3 and precision is at 1e-2 with OpenMP
+echo pred.sparse_softmax_cross_entropy2(sparse_labels) # Warning it's only accurate at 1e-3 and precision is at 1e-2 with OpenMP
 
 ## Warmup for OpenMP threadpool and CPU on "on-demand" governor
 discard pred .* pred
@@ -294,24 +294,24 @@ var start = epochTime()
 
 start = epochTime()
 for i in 0..<20:
-  discard softmax_cross_entropy1(pred, labels)
+  discard pred.softmax_cross_entropy1(labels)
 echo "Softmax xentropy zipAxis, mean(sum <- map2): ", epochTime() - start
 
 
 start = epochTime()
 for i in 0..<20:
-  discard softmax_cross_entropy2(pred, labels)
+  discard pred.softmax_cross_entropy2(labels)
 echo "Softmax xentropy Frobenius fold: ", epochTime() - start
 
 
 start = epochTime()
 for i in 0..<20:
-  discard sparse_softmax_cross_entropy1(pred, sparse_labels)
+  discard pred.sparse_softmax_cross_entropy1(sparse_labels)
 echo "Sparse softmax naive loop: ", epochTime() - start
 
 start = epochTime()
 for i in 0..<20:
-  discard sparse_softmax_cross_entropy2(pred, sparse_labels)
+  discard pred.sparse_softmax_cross_entropy2(sparse_labels)
 echo "Sparse softmax simplified loop + fold: ", epochTime() - start
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,8 @@ Changes:
     The matrix is suitable to stress test decompositions.
   - The ``arange`` procedure has been introduced. It creates evenly spaced value within a specified range
     and step
+  - The ordering of arguments to error functions has been converted to
+    `(y_pred, y)`, enabling the syntax `y_pred.accuracy_score(y)`.
 
 Bug fixes:
   - ``gemm`` could crash when the result was column major

--- a/docs/howto.perceptron.rst
+++ b/docs/howto.perceptron.rst
@@ -56,7 +56,7 @@ Spellbook: How to do a multilayer perceptron
         # Building the network
         let n1 = relu linear(x, layer_3neurons)
         let n2 = linear(n1, classifier_layer)
-        let loss = sigmoid_cross_entropy(n2, target)
+        let loss = n2.sigmoid_cross_entropy(target)
 
         echo "Epoch is:" & $epoch
         echo "Batch id:" & $batch_id

--- a/docs/uth.opencl_cuda_nim.rst
+++ b/docs/uth.opencl_cuda_nim.rst
@@ -214,7 +214,7 @@ Oh, and for those who wants to see real Nim code for neural networks, here is a 
                       .argmax(axis = 1)
                       .squeeze
 
-        let score = accuracy_score(y_train, y_pred)
+        let score = y_pred.accuracy_score(y_train)
         echo &"Accuracy: {score:.3f}%"
         echo "\n"
 

--- a/examples/ex01_xor_perceptron_from_scratch.nim
+++ b/examples/ex01_xor_perceptron_from_scratch.nim
@@ -47,7 +47,7 @@ for epoch in 0..5:
     let output = model.forward(x)
 
     # Computing the loss
-    let loss = sigmoid_cross_entropy(output, target)
+    let loss = output.sigmoid_cross_entropy(target)
 
     echo "Epoch is:" & $epoch
     echo "Batch id:" & $batch_id

--- a/examples/ex02_handwritten_digits_recognition.nim
+++ b/examples/ex02_handwritten_digits_recognition.nim
@@ -85,7 +85,7 @@ for epoch in 0 ..< 5:
     var loss = 0.0
     for i in 0 ..< 10:
       let y_pred = model.forward(X_test[i*1000 ..< (i+1)*1000, _]).value.softmax.argmax(axis = 1).squeeze
-      score += accuracy_score(y_test[i*1000 ..< (i+1)*1000], y_pred)
+      score += y_pred.accuracy_score(y_test[i*1000 ..< (i+1)*1000])
 
       loss += model.forward(X_test[i*1000 ..< (i+1)*1000, _]).sparse_softmax_cross_entropy(y_test[i*1000 ..< (i+1)*1000]).value.data[0]
     score /= 10

--- a/examples/ex03_simple_two_layers.nim
+++ b/examples/ex03_simple_two_layers.nim
@@ -42,7 +42,7 @@ let
 for t in 0 ..< 500:
   let
     y_pred = model.forward(x)
-    loss = mse_loss(y_pred, y)
+    loss = y_pred.mse_loss(y)
 
   echo &"Epoch {t}: loss {loss.value[0]}"
 

--- a/examples/ex04_fizzbuzz_interview_cheatsheet.nim
+++ b/examples/ex04_fizzbuzz_interview_cheatsheet.nim
@@ -93,7 +93,7 @@ for epoch in 0 ..< Epochs:
                   .argmax(axis = 1)
                   .squeeze
 
-    let score = accuracy_score(y_train, y_pred)
+    let score = y_pred.accuracy_score(y_train)
     echo &"Accuracy: {score:.3f}%"
     echo "\n"
 

--- a/examples/ex05_sequence_classification_GRU.nim
+++ b/examples/ex05_sequence_classification_GRU.nim
@@ -123,7 +123,7 @@ for epoch in 0 ..< Epochs:
                   .argmax(axis = 1)
                   .squeeze
 
-    let score = accuracy_score(y, y_pred)
+    let score = y_pred.accuracy_score(y)
     echo &"Epoch #{epoch:> 04}. Accuracy: {score*100:00.3f}%"
 
 ###################

--- a/src/linear_algebra/helpers/auxiliary_lapack.nim
+++ b/src/linear_algebra/helpers/auxiliary_lapack.nim
@@ -190,7 +190,7 @@ when isMainModule:
   # Materialize Q
   var Q = Q_reflectors.clone(colMajor)
   orgqr(Q, tau, scratchspace)
-  doAssert mean_absolute_error(Q, np_q) < 1e-8
+  doAssert Q.mean_absolute_error(np_q) < 1e-8
 
   # Check multiplication
   let Msrc = [[1.0, 2, 3],
@@ -200,19 +200,19 @@ when isMainModule:
   block: # M*Q
     var M = Msrc.clone(colMajor)
     ormqr(M, Q_reflectors, tau, side = 'R', trans = 'N', scratchspace)
-    doAssert mean_absolute_error(M, Msrc * Q) < 1e-8
+    doAssert M.mean_absolute_error(Msrc * Q) < 1e-8
 
   block: # Q*M
     var M = Msrc.clone(colMajor)
     ormqr(M, Q_reflectors, tau, side = 'L', trans = 'N', scratchspace)
-    doAssert mean_absolute_error(M, Q * Msrc) < 1e-8
+    doAssert M.mean_absolute_error(Q * Msrc) < 1e-8
 
   block: # M*Q.T
     var M = Msrc.clone(colMajor)
     ormqr(M, Q_reflectors, tau, side = 'R', trans = 'T', scratchspace)
-    doAssert mean_absolute_error(M, Msrc * Q.transpose()) < 1e-8
+    doAssert M.mean_absolute_error(Msrc * Q.transpose()) < 1e-8
 
   block: # Q.T * M
     var M = Msrc.clone(colMajor)
     ormqr(M, Q_reflectors, tau, side = 'L', trans = 'T', scratchspace)
-    doAssert mean_absolute_error(M, Q.transpose() * Msrc) < 1e-8
+    doAssert M.mean_absolute_error(Q.transpose() * Msrc) < 1e-8

--- a/src/linear_algebra/helpers/decomposition_lapack.nim
+++ b/src/linear_algebra/helpers/decomposition_lapack.nim
@@ -364,5 +364,5 @@ when isMainModule:
     var scratchspace: seq[float64]
     geqrf(r_v, tau, scratchspace)
 
-    doAssert mean_absolute_error(r_v, expected_rv) < 1e-6
-    doAssert mean_absolute_error(tau.toTensor, expected_tau) < 1e-15
+    doAssert r_v.mean_absolute_error(expected_rv) < 1e-6
+    doAssert tau.toTensor.mean_absolute_error(expected_tau) < 1e-15

--- a/src/ml/metrics/accuracy_score.nim
+++ b/src/ml/metrics/accuracy_score.nim
@@ -15,7 +15,7 @@
 import ../../tensor/tensor
 
 
-proc accuracy_score*[T](y_true, y_pred: Tensor[T]): float =
+proc accuracy_score*[T](y_pred, y_true: Tensor[T]): float =
   ## Input:
   ##   - y_true: Tensor[T] containing the ground truth (correct) labels
   ##   - y_pred: Tensor[T] containing the predicted labels

--- a/src/ml/metrics/common_error_functions.nim
+++ b/src/ml/metrics/common_error_functions.nim
@@ -16,23 +16,23 @@ import ../../tensor/tensor
 
 # ####################################################
 
-proc squared_error*[T](y_true, y: T): T {.inline.} =
+proc squared_error*[T](y, y_true: T): T {.inline.} =
   ## Squared error for a single value, |y_true - y| ^2
   result = square(y_true - y)
 
-proc squared_error*[T](y_true, y: Tensor[T]): Tensor[T] {.noInit.} =
+proc squared_error*[T](y, y_true: Tensor[T]): Tensor[T] {.noInit.} =
   ## Element-wise squared error for a tensor, |y_true - y| ^2
   result = map2_inline(y_true, y, squared_error(x,y))
 
-proc mean_squared_error*[T](y_true, y: Tensor[T]): T =
+proc mean_squared_error*[T](y, y_true: Tensor[T]): T =
   ## Also known as MSE or L2 loss, mean squared error between elements:
   ## sum(|y_true - y| ^2)/m
   ## where m is the number of elements
-  result = squared_error(y_true, y).mean()
+  result = y.squared_error(y_true).mean()
 
 # ####################################################
 
-proc relative_error*[T: SomeFloat](y_true, y: T): T {.inline.} =
+proc relative_error*[T: SomeFloat](y, y_true: T): T {.inline.} =
   ## Relative error, |y_true - y|/max(|y_true|, |y|)
   ## Normally the relative error is defined as |y_true - y| / |y_true|,
   ## but here max is used to make it symmetric and to prevent dividing by zero,
@@ -43,33 +43,33 @@ proc relative_error*[T: SomeFloat](y_true, y: T): T {.inline.} =
     return 0.T
   result = abs(y_true - y) / denom
 
-proc relative_error*[T](y_true, y: Tensor[T]): Tensor[T] {.noInit.} =
+proc relative_error*[T](y, y_true: Tensor[T]): Tensor[T] {.noInit.} =
   ## Relative error for Tensor, element-wise |y_true - x|/max(|y_true|, |x|)
   ## Normally the relative error is defined as |y_true - x| / |y_true|,
   ## but here max is used to make it symmetric and to prevent dividing by zero,
   ## guaranteed to return zero in the case when both values are zero.
   result = map2_inline(y_true, y, relative_error(x,y))
 
-proc mean_relative_error*[T](y_true, y: Tensor[T]): T =
+proc mean_relative_error*[T](y, y_true: Tensor[T]): T =
   ## Mean relative error for Tensor, mean of the element-wise
   ## |y_true - y|/max(|y_true|, |y|)
   ## Normally the relative error is defined as |y_true - y| / |y_true|,
   ## but here max is used to make it symmetric and to prevent dividing by zero,
   ## guaranteed to return zero in the case when both values are zero.
-  result = relative_error(y_true, y).mean()
+  result = y.relative_error(y_true).mean()
 
 # ####################################################
 
-proc absolute_error*[T: SomeFloat](y_true, y: T): T {.inline.} =
+proc absolute_error*[T: SomeFloat](y, y_true: T): T {.inline.} =
   ## Absolute error for a single value, |y_true - y|
   # We require float (and not complex as complex.abs will cause issue)
   result = abs(y_true - y)
 
-proc absolute_error*[T](y_true, y: Tensor[T]): Tensor[T] {.noInit.} =
+proc absolute_error*[T](y, y_true: Tensor[T]): Tensor[T] {.noInit.} =
   ## Element-wise absolute error for a tensor
   result = map2_inline(y_true, y, absolute_error(x,y))
 
-proc mean_absolute_error*[T](y_true, y: Tensor[T]): T =
+proc mean_absolute_error*[T](y, y_true: Tensor[T]): T =
   ## Also known as L1 loss, absolute error between elements:
   ## sum(|y_true - y|)/m
   ## where m is the number of elements

--- a/src/ml/metrics/common_error_functions.nim
+++ b/src/ml/metrics/common_error_functions.nim
@@ -67,10 +67,10 @@ proc absolute_error*[T: SomeFloat](y, y_true: T): T {.inline.} =
 
 proc absolute_error*[T](y, y_true: Tensor[T]): Tensor[T] {.noInit.} =
   ## Element-wise absolute error for a tensor
-  result = map2_inline(y_true, y, absolute_error(x,y))
+  result = map2_inline(y_true, y, y.absolute_error(x))
 
 proc mean_absolute_error*[T](y, y_true: Tensor[T]): T =
   ## Also known as L1 loss, absolute error between elements:
   ## sum(|y_true - y|)/m
   ## where m is the number of elements
-  result = map2_inline(y_true, y, absolute_error(x,y)).mean()
+  result = map2_inline(y_true, y, y.absolute_error(x)).mean()

--- a/tests/autograd/test_gate_hadamard.nim
+++ b/tests/autograd/test_gate_hadamard.nim
@@ -41,5 +41,5 @@ suite "Autograd of Hadamard product":
     loss.backprop()
 
     check:
-      mean_relative_error(va.grad, target_grad_a) < 1e-07
-      mean_relative_error(vb.grad, target_grad_b) < 1e-07
+      va.grad.mean_relative_error(target_grad_a) < 1e-07
+      vb.grad.mean_relative_error(target_grad_b) < 1e-07

--- a/tests/autograd/test_gate_shapeshifting.nim
+++ b/tests/autograd/test_gate_shapeshifting.nim
@@ -130,7 +130,7 @@ suite "Autograd of shapeshifting operations":
               )
 
     loss.backprop()
-    check: vx.grad.mean_relative_error(vx.expected) < 1e-07
+    check: vx.grad.mean_relative_error(expected) < 1e-07
 
   test "Gradient of squeeze operation (+ chunking)":
 

--- a/tests/autograd/test_gate_shapeshifting.nim
+++ b/tests/autograd/test_gate_shapeshifting.nim
@@ -49,10 +49,10 @@ suite "Autograd of shapeshifting operations":
     loss.backprop()
 
     check:
-      mean_relative_error(va.grad, target_grad_a) < 1e-07
-      mean_relative_error(vb.grad, target_grad_b) < 1e-07
-      mean_relative_error(vc.grad, target_grad_c) < 1e-07
-      mean_relative_error(vd.grad, target_grad_d) < 1e-07
+      va.grad.mean_relative_error(target_grad_a) < 1e-07
+      vb.grad.mean_relative_error(target_grad_b) < 1e-07
+      vc.grad.mean_relative_error(target_grad_c) < 1e-07
+      vd.grad.mean_relative_error(target_grad_d) < 1e-07
 
   test "Gradient of chunk operation":
     let
@@ -80,7 +80,7 @@ suite "Autograd of shapeshifting operations":
       loss = sum(vs[0] + vs[1] - (vs[2] + vs[3]))
 
     loss.backprop()
-    check: mean_relative_error(vx.grad, expected) < 1e-07
+    check: vx.grad.mean_relative_error(expected) < 1e-07
 
   test "Gradient of uneven chunks + slicing operations":
 
@@ -130,7 +130,7 @@ suite "Autograd of shapeshifting operations":
               )
 
     loss.backprop()
-    check: mean_relative_error(vx.grad, expected) < 1e-07
+    check: vx.grad.mean_relative_error(vx.expected) < 1e-07
 
   test "Gradient of squeeze operation (+ chunking)":
 
@@ -182,9 +182,9 @@ suite "Autograd of shapeshifting operations":
 
     loss.backprop()
     check:
-      mean_relative_error(vx.grad, expected_x) < 1e-07
-      mean_relative_error(vy.grad, expected_y) < 1e-07
-      mean_relative_error(vz.grad, expected_z) < 1e-07
+      vx.grad.mean_relative_error(expected_x) < 1e-07
+      vy.grad.mean_relative_error(expected_y) < 1e-07
+      vz.grad.mean_relative_error(expected_z) < 1e-07
 
   test "Gradient of unsqueeze operation":
 
@@ -211,5 +211,5 @@ suite "Autograd of shapeshifting operations":
 
     loss.backprop()
     check:
-      mean_relative_error(vx.grad, expected_x) < 1e-07
-      mean_relative_error(vy.grad, expected_y) < 1e-07
+      vx.grad.mean_relative_error(expected_x) < 1e-07
+      vy.grad.mean_relative_error(expected_y) < 1e-07

--- a/tests/end_to_end/examples_run.nim
+++ b/tests/end_to_end/examples_run.nim
@@ -38,7 +38,7 @@ proc ex01() =
 
       let n1 = relu linear(x, layer_3neurons)
       let n2 = linear(n1, classifier_layer)
-      let loss = sigmoid_cross_entropy(n2, target)
+      let loss = n2.sigmoid_cross_entropy(target)
 
       # echo "Epoch is:" & $epoch
       # echo "Batch id:" & $batch_id

--- a/tests/end_to_end/examples_run.nim
+++ b/tests/end_to_end/examples_run.nim
@@ -101,7 +101,7 @@ proc ex02() =
       var loss = 0.0
       for i in 0 ..< 1:
         let y_pred = model.forward(X_test[i*1000 ..< (i+1)*1000, _]).value.softmax.argmax(axis = 1).squeeze
-        score += accuracy_score(y_test[i*1000 ..< (i+1)*1000], y_pred)
+        score += y_pred.accuracy_score(y_test[i*1000 ..< (i+1)*1000])
 
         loss += model.forward(X_test[i*1000 ..< (i+1)*1000, _]).sparse_softmax_cross_entropy(y_test[i*1000 ..< (i+1)*1000]).value.data[0]
       score /= 10

--- a/tests/linear_algebra/test_linear_algebra.nim
+++ b/tests/linear_algebra/test_linear_algebra.nim
@@ -43,10 +43,10 @@ suite "Linear algebra":
         expected_sv = [ 4.10003045f,  1.09075677].toTensor
 
       check:
-        mean_relative_error(solution, expected_sol) < 1e-6
-        mean_relative_error(residuals, expected_residuals) < 2e-6 # Due to parallelism hazards this sometimes go over 1e-6 on Travis
+        solution.mean_relative_error(expected_sol) < 1e-6
+        residuals.mean_relative_error(expected_residuals) < 2e-6 # Due to parallelism hazards this sometimes go over 1e-6 on Travis
         matrix_rank == expected_matrix_rank
-        mean_relative_error(singular_values, expected_sv) < 1e-6
+        singular_values.mean_relative_error(expected_sv) < 1e-6
 
     block: # Example from Eigen
            # https://eigen.tuxfamily.org/dox/group__LeastSquares.html
@@ -58,7 +58,7 @@ suite "Linear algebra":
       let (solution, _, _, _) = least_squares_solver(A, b)
       let expected_sol = [-0.67, 0.314].toTensor
 
-      check: mean_relative_error(solution, expected_sol) < 1e-3
+      check: solution.mean_relative_error(expected_sol) < 1e-3
 
     block: # "Multiple independant equations"
            # Example from Intel documentation:
@@ -90,10 +90,10 @@ suite "Linear algebra":
       let expected_sv = [ 18.66, 15.99, 10.01, 8.51].toTensor
 
       check:
-        mean_relative_error(solution, expected_sol) < 0.015
+        solution.mean_relative_error(expected_sol) < 0.015
         residuals.rank == 0 and residuals.shape[0] == 0 and residuals.strides[0] == 0
         matrix_rank == expected_matrix_rank
-        mean_relative_error(singular_values, expected_sv) < 1e-03
+        singular_values.mean_relative_error(expected_sv) < 1e-03
 
   test "Eigenvalues and eigenvector of symmetric matrices":
     # Note: Functions should return a unit vector (norm == 1).

--- a/tests/linear_algebra/test_linear_algebra.nim
+++ b/tests/linear_algebra/test_linear_algebra.nim
@@ -120,7 +120,7 @@ suite "Linear algebra":
 
       let (val, vec) = symeig(a, true, 'U')
 
-      check: mean_absolute_error(val, expected_val) < 1e-4
+      check: val.mean_absolute_error(expected_val) < 1e-4
 
       for col in 0..<5:
         check:  mean_absolute_error( vec[_, col], expected_vec[_, col]) < 1e-4 or
@@ -139,7 +139,7 @@ suite "Linear algebra":
 
       let (val, vec) = symeig(a, true, 'U')
 
-      check: mean_absolute_error(val, expected_val) < 1e-7
+      check: val.mean_absolute_error(expected_val) < 1e-7
 
       for col in 0..<2:
         check:  mean_absolute_error( vec[_, col], expected_vec[_, col]) < 1e-11 or
@@ -163,7 +163,7 @@ suite "Linear algebra":
 
       let (val, vec) = symeig(a, true, 'U')
 
-      check: mean_absolute_error(val, expected_val) < 1e-2
+      check: val.mean_absolute_error(expected_val) < 1e-2
 
       for col in 0..<5:
         check:  mean_absolute_error( vec[_, col], expected_vec[_, col]) < 1e-2 or
@@ -187,7 +187,7 @@ suite "Linear algebra":
 
       let (val, vec) = symeig(a, true, 'U', 0..2)
 
-      check: mean_absolute_error(val, selected_val) < 1e-1
+      check: val.mean_absolute_error(selected_val) < 1e-1
 
       for col in 0..<3:
         check:  mean_absolute_error( vec[_, col], selected_vec[_, col]) < 1e-2 or
@@ -215,7 +215,7 @@ suite "Linear algebra":
       block: # Sanity checks
         # A = QR
         let qr = q * r
-        check: mean_absolute_error(a, qr) < 1e-8
+        check: a.mean_absolute_error(qr) < 1e-8
         # TODO: r is triangular
 
       block: # vs NumPy implementation. Note that
@@ -233,8 +233,8 @@ suite "Linear algebra":
                     [   0.0,    0.0,  -35.0]].toTensor()
 
         check:
-          mean_absolute_error(q, np_q) < 1e-8
-          mean_absolute_error(r, np_r) < 1e-8
+          q.mean_absolute_error(np_q) < 1e-8
+          r.mean_absolute_error(np_r) < 1e-8
 
     block: # M > N, from Numpy https://docs.scipy.org/doc/numpy-1.15.1/reference/generated/numpy.linalg.qr.html
       let a = [[0.0, 1.0],
@@ -247,7 +247,7 @@ suite "Linear algebra":
       block: # Sanity checks
         # A = QR
         let qr = q * r
-        check: mean_absolute_error(a, qr) < 1e-8
+        check: a.mean_absolute_error(qr) < 1e-8
         # TODO: r is triangular
 
       block: # vs NumPy implementation. Note that
@@ -265,8 +265,8 @@ suite "Linear algebra":
                     [ 0.0       ,  1.15470054]].toTensor()
 
         check:
-          mean_absolute_error(q, np_q) < 1e-8
-          mean_absolute_error(r, np_r) < 1e-8
+          q.mean_absolute_error(np_q) < 1e-8
+          r.mean_absolute_error(np_r) < 1e-8
 
     block: # M < N
       let a = [[0.0, 1.0, 1.0, 1.0],
@@ -277,7 +277,7 @@ suite "Linear algebra":
       block: # Sanity checks
         # A = QR
         let qr = q * r
-        check: mean_absolute_error(a, qr) < 1e-8
+        check: a.mean_absolute_error(qr) < 1e-8
         # TODO: r is triangular
 
       block: # vs NumPy implementation. Note that
@@ -293,8 +293,8 @@ suite "Linear algebra":
                     [ 0.0, -1.0, -1.0, -1.0]].toTensor()
 
         check:
-          mean_absolute_error(q, np_q) < 1e-8
-          mean_absolute_error(r, np_r) < 1e-8
+          q.mean_absolute_error(np_q) < 1e-8
+          r.mean_absolute_error(np_r) < 1e-8
 
   test "LU Factorization":
     block: # M > N
@@ -321,8 +321,8 @@ suite "Linear algebra":
 
       let (PL, U) = lu_permuted(a)
       check:
-        mean_absolute_error(PL, expected_pl) < 1e-8
-        mean_absolute_error(U, expected_u) < 1e-8
+        PL.mean_absolute_error(expected_pl) < 1e-8
+        U.mean_absolute_error(expected_u) < 1e-8
 
     block: # M < N
       # import numpy as np
@@ -346,8 +346,8 @@ suite "Linear algebra":
 
       let (PL, U) = lu_permuted(a)
       check:
-        mean_absolute_error(PL, expected_pl) < 1e-8
-        mean_absolute_error(U, expected_u) < 1e-8
+        PL.mean_absolute_error(expected_pl) < 1e-8
+        U.mean_absolute_error(expected_u) < 1e-8
 
   test "Singular Value Decomposition (SVD)":
     block: # From https://software.intel.com/sites/products/documentation/doclib/mkl_sa/11/mkl_lapack_examples/sgesdd_ex.c.htm
@@ -378,9 +378,9 @@ suite "Linear algebra":
       let k = min(a.shape[0], a.shape[1])
 
       check:
-        mean_absolute_error(U, expected_U) < 1e-2
-        mean_absolute_error(S, expected_S) < 1e-2
-        mean_absolute_error(Vh, expected_Vh) < 1e-2
+        U.mean_absolute_error(expected_U) < 1e-2
+        S.mean_absolute_error(expected_S) < 1e-2
+        Vh.mean_absolute_error(expected_Vh) < 1e-2
 
   test "Randomized SVD":
     # TODO: tests using spectral norm, see fbpca python package
@@ -399,12 +399,12 @@ suite "Linear algebra":
       check:
         U.shape[0] == H.shape[0]
         U.shape[1] == k
-        mean_absolute_error(S, expected_S) < 1.5e-5
+        S.mean_absolute_error(expected_S) < 1.5e-5
         Vh.shape[0] == k
         Vh.shape[1] == H.shape[1]
 
       let reconstructed = (U .* S.unsqueeze(0)) * Vh
-      check: mean_absolute_error(H, reconstructed) < 1e-2
+      check: H.mean_absolute_error(reconstructed) < 1e-2
 
     block: # Ensure that m > n / m < n logic is working fine
       const
@@ -421,12 +421,12 @@ suite "Linear algebra":
       check:
         U.shape[0] == H.shape[0]
         U.shape[1] == k
-        mean_absolute_error(S, expected_S) < 1.5e-5
+        S.mean_absolute_error(expected_S) < 1.5e-5
         Vh.shape[0] == k
         Vh.shape[1] == H.shape[1]
 
       let reconstructed = (U .* S.unsqueeze(0)) * Vh
-      check: mean_absolute_error(H, reconstructed) < 1e-2
+      check: H.mean_absolute_error(reconstructed) < 1e-2
 
   test "Solve linear equations general matrix":
     block:
@@ -450,4 +450,4 @@ suite "Linear algebra":
                      [ 0.57,  0.11,  4.04]].toTensor
 
       let x = solve(a, b)
-      check mean_absolute_error(x, x_known) < 0.01
+      check x.mean_absolute_error(x_known) < 0.01

--- a/tests/manual_checks/allocator_regression_178_1st_part.nim
+++ b/tests/manual_checks/allocator_regression_178_1st_part.nim
@@ -65,7 +65,7 @@ for sample_id, nonzero_idx in enumerate(sparse_labels):
 let pred = randomTensor(nb_classes, batch_size, -1.0..1.0)
 
 echo "### Reference"
-let sce_loss = softmax_cross_entropy1(pred, labels)
+let sce_loss = pred.softmax_cross_entropy1(labels)
 echo sce_loss
 
 

--- a/tests/manual_checks/softmax_cross_entropy.nim
+++ b/tests/manual_checks/softmax_cross_entropy.nim
@@ -21,8 +21,8 @@ let pred = randomTensor(nb_classes, batch_size, -1.0..1.0)
 
 echo pred
 
-let sce_loss = softmax_cross_entropy(pred, labels)
-let sparse_sce_loss = sparse_softmax_cross_entropy(pred, sparse_labels)
+let sce_loss = pred.softmax_cross_entropy(labels)
+let sparse_sce_loss = pred.sparse_softmax_cross_entropy(sparse_labels)
 
 echo sce_loss
 echo sparse_sce_loss

--- a/tests/ml/test_dimensionality_reduction.nim
+++ b/tests/ml/test_dimensionality_reduction.nim
@@ -39,7 +39,7 @@ suite "[ML] Dimensionality reduction":
 
       # Projecting the original data with the axes matrix
       let centered = data .- data.mean(axis=0)
-      check: mean_absolute_error(projected, centered * components) < 1e-08
+      check: projected.mean_absolute_error(centered * components) < 1e-08
 
     block: # https://www.cgg.com/technicaldocuments/cggv_0000014063.pdf
       let data =  [[ 1.0, -1.0],
@@ -58,4 +58,4 @@ suite "[ML] Dimensionality reduction":
 
       # Projecting the original data with the components matrix
       let centered = data .- data.mean(axis=0)
-      check: mean_absolute_error(projected, centered * components) < 1e-08
+      check: projected.mean_absolute_error(centered * components) < 1e-08

--- a/tests/ml/test_metrics.nim
+++ b/tests/ml/test_metrics.nim
@@ -21,7 +21,7 @@ suite "[ML] Metrics":
       y_pred = [0, 2, 1, 3].toTensor
       y_true = [0, 1, 2, 3].toTensor
 
-    check: accuracy_score(y_true, y_pred) == 0.5
+    check: y_pred.accuracy_score(y_true) == 0.5
 
   test "Mean absolute error":
     var y_true = [0.9, 0.2, 0.1, 0.4, 0.9].toTensor()

--- a/tests/ml/test_metrics.nim
+++ b/tests/ml/test_metrics.nim
@@ -26,17 +26,17 @@ suite "[ML] Metrics":
   test "Mean absolute error":
     var y_true = [0.9, 0.2, 0.1, 0.4, 0.9].toTensor()
     var y =      [1.0, 0.0, 0.0, 1.0, 1.0].toTensor()
-    check: absolute_error(y_true, y).sum() == 1.1
-    check: mean_absolute_error(y_true, y) == (1.1 / 5.0)
+    check: y.absolute_error(y_true).sum() == 1.1
+    check: y.mean_absolute_error(y_true) == (1.1 / 5.0)
 
   test "Relative error":
     var y_true = [0.0,  0.0, -1.0, 1e-8, 1e-8].toTensor()
     var y =      [0.0, -1.0,  0.0, 0.0,  1e-7].toTensor()
-    check: relative_error(y_true, y) == [0.0, 1.0, 1.0, 1.0, 0.9].toTensor()
-    check: mean_relative_error(y_true, y) == 0.78
+    check: y.relative_error(y_true) == [0.0, 1.0, 1.0, 1.0, 0.9].toTensor()
+    check: y.mean_relative_error(y_true) == 0.78
 
   test "Mean squared error":
     var y_true = [0.9, 0.2, 0.1, 0.4, 0.9].toTensor()
     var y =      [1.0, 0.0, 0.0, 1.0, 1.0].toTensor()
-    check: squared_error(y_true, y).sum() == 0.43
-    check: mean_squared_error(y_true, y) == (0.43 / 5.0)
+    check: y.squared_error(y_true).sum() == 0.43
+    check: y.mean_squared_error(y_true) == (0.43 / 5.0)

--- a/tests/nn_primitives/test_nnp_convolution.nim
+++ b/tests/nn_primitives/test_nnp_convolution.nim
@@ -42,14 +42,13 @@ suite "Convolution 2D":
       ftarget = target.astype(float32)
 
     test "Simple Conv2D [Im2ColGEMM]":
-      check: mean_absolute_error(finput.conv2d(fkernel, fbias, padding=(1,1)), ftarget) <= 1e-7'f32
+      check: finput.conv2d(fkernel, fbias, padding=(1,1)).mean_absolute_error(ftarget) <= 1e-7'f32
 
     when defined(nnpack):
       test "Simple Conv2D [NNPack]":
-        check: mean_absolute_error(
-          finput.conv2d(
-            fkernel, fbias, padding=(1,1), algorithm=Conv2DAlgorithm.NNPackAuto
-            ), ftarget) <= 5e-6'f32 # TODO understand the loss of precision
+        check: finput.conv2d(
+          fkernel, fbias, padding=(1,1), algorithm=Conv2DAlgorithm.NNPackAuto
+        ).mean_absolute_error(ftarget) <= 5e-6'f32 # TODO understand the loss of precision
 
   test "Strided Conv2D [Im2ColGEMM]":
     let input = [

--- a/tests/nn_primitives/test_nnp_convolution.nim
+++ b/tests/nn_primitives/test_nnp_convolution.nim
@@ -162,15 +162,15 @@ suite "Convolution 2D":
     test "Conv2D Forward + Backward [Im2ColGEMM]":
       conv2d_backward(input, kernel, bias, padding, stride,
                       grad_output, grad_input, grad_weight, grad_bias)
-      check: mean_relative_error(target_grad_bias, grad_bias.astype(float)) < 1e-6
-      check: mean_relative_error(target_grad_weight, grad_weight.astype(float)) < 1e-6
-      check: mean_relative_error(target_grad_input, grad_input.astype(float)) < 1e-6
+      check: grad_bias.astype(float).mean_relative_error(target_grad_bias) < 1e-6
+      check: grad_weight.astype(float).mean_relative_error(target_grad_weight) < 1e-6
+      check: grad_input.astype(float).mean_relative_error(target_grad_input) < 1e-6
 
     when defined(nnpack):
       test "Conv2D Forward + Backward [NNPack]":
         conv2d_backward(input, kernel, bias, padding, stride,
                         grad_output, grad_input, grad_weight, grad_bias,
                         algorithm=Conv2DAlgorithm.NNPackAuto)
-        check: mean_relative_error(target_grad_bias, grad_bias.astype(float)) < 1e-6
-        check: mean_relative_error(target_grad_weight, grad_weight.astype(float)) < 1e-6
-        check: mean_relative_error(target_grad_input, grad_input.astype(float)) < 1e-6
+        check: grad_bias.astype(float).mean_relative_error(target_grad_bias) < 1e-6
+        check: grad_weight.astype(float).mean_relative_error(target_grad_weight) < 1e-6
+        check: grad_input.astype(float).mean_relative_error(target_grad_input) < 1e-6

--- a/tests/nn_primitives/test_nnp_convolution_cudnn.nim
+++ b/tests/nn_primitives/test_nnp_convolution_cudnn.nim
@@ -35,9 +35,8 @@ template test_conv(T: typedesc[SomeFloat]) =
     let bias = [0].toTensor().reshape(1,1,1).astype(T).cuda
 
     # TODO: padding should accept a tuple (i.e. unify Size2D and SizeHW)
-    check: mean_absolute_error(
-      input.conv2d(kernel, bias, padding=[1,1]).cpu,
-      target) <= T(1e-7)
+    check: input.conv2d(kernel, bias, padding=[1,1]).cpu
+             .mean_absolute_error(target) <= T(1e-7)
 
   test "Conv2D Forward + Backward [" & $T & ']':
 

--- a/tests/nn_primitives/test_nnp_convolution_cudnn.nim
+++ b/tests/nn_primitives/test_nnp_convolution_cudnn.nim
@@ -81,9 +81,9 @@ template test_conv(T: typedesc[SomeFloat]) =
     # Ideally we would need a Cuda numerical_gradient
     # In practice it is not relevant as we can use low precision (float16) without issue in deep learning
 
-    check: mean_relative_error(target_grad_bias.astype(T), grad_bias.cpu) < 1e-6
-    check: mean_relative_error(target_grad_kernel.astype(T), grad_kernel.cpu) < 0.2
-    check: mean_relative_error(target_grad_input.astype(T), grad_input.cpu) < 0.2
+    check: grad_bias.cpu.mean_relative_error(target_grad_bias.astype(T)) < 1e-6
+    check: grad_kernel.cpu.mean_relative_error(target_grad_kernel.astype(T)) < 0.2
+    check: grad_input.cpu.mean_relative_error(target_grad_input.astype(T)) < 0.2
 
     # echo "output"
     # echo output

--- a/tests/nn_primitives/test_nnp_embedding.nim
+++ b/tests/nn_primitives/test_nnp_embedding.nim
@@ -143,7 +143,7 @@ suite "[NN Primitive] Embedding":
       scale_grad_by_freq = false # We don't reduce contribution of common words
     )
 
-    check: mean_absolute_error(target_grad_embed, dWeight) < 1e-8
+    check: dWeight.mean_absolute_error(target_grad_embed) < 1e-8
 
   test "Embedding backpropagation - vocabulary of shape [batch_size, seq_len]":
     const
@@ -170,4 +170,4 @@ suite "[NN Primitive] Embedding":
       scale_grad_by_freq = false # We don't reduce contribution of common words
     )
 
-    check: mean_absolute_error(target_grad_embed, dWeight) < 1e-8
+    check: dWeight.mean_absolute_error(target_grad_embed) < 1e-8

--- a/tests/nn_primitives/test_nnp_gru.nim
+++ b/tests/nn_primitives/test_nnp_gru.nim
@@ -54,7 +54,7 @@ suite "[NN Primitives - Gated Recurrent Unit - Cell]":
                         bW3, bU3,
                         h)
 
-      check: mean_relative_error(pytorch_expected, h) < 1e-8
+      check: h.mean_relative_error(pytorch_expected) < 1e-8
 
     test "GRU Cell forward - equivalent to PyTorch/CuDNN":
 
@@ -70,7 +70,7 @@ suite "[NN Primitives - Gated Recurrent Unit - Cell]":
                       r, z, n, Uh,
                       h)
 
-      check: mean_relative_error(pytorch_expected, h) < 1e-8
+      check: h.mean_relative_error(pytorch_expected) < 1e-8
 
   ################################
 
@@ -278,8 +278,8 @@ suite "[NN Primitives - GRU: Stacked, sequences, bidirectional]":
                   output, h)
 
     check:
-      mean_relative_error(py_expected_output, output) < 1e-8
-      mean_relative_error(py_expected_hiddenN, h) < 1e-8
+      output.mean_relative_error(py_expected_output) < 1e-8
+      h.mean_relative_error(py_expected_hiddenN) < 1e-8
 
   test "GRU forward - equivalent to PyTorch/CuDNN":
     # 1 direction hence `hidden.shape[0] * 1`
@@ -300,8 +300,8 @@ suite "[NN Primitives - GRU: Stacked, sequences, bidirectional]":
                 cached_inputs, cached_hidden)
 
     check:
-      mean_relative_error(py_expected_output, output) < 1e-8
-      mean_relative_error(py_expected_hiddenN, h) < 1e-8
+      output.mean_relative_error(py_expected_output) < 1e-8
+      h.mean_relative_error(py_expected_hiddenN) < 1e-8
 
   type GradKind = enum
     HiddenN, Output, Both

--- a/tests/nn_primitives/test_nnp_gru.nim
+++ b/tests/nn_primitives/test_nnp_gru.nim
@@ -168,12 +168,12 @@ suite "[NN Primitives - Gated Recurrent Unit - Cell]":
                       r, z, n, Uh)
 
     check:
-      mean_absolute_error(target_grad_x, dx) < 1e-8
-      mean_absolute_error(target_grad_hidden, dhidden) < 1e-8
-      mean_absolute_error(target_grad_W3, dW3) < 1e-8
-      mean_absolute_error(target_grad_U3, dU3) < 1e-8
-      mean_absolute_error(target_grad_bW3, dbW3) < 1e-8
-      mean_absolute_error(target_grad_bU3, dbU3) < 1e-8
+      dx.mean_absolute_error(target_grad_x) < 1e-8
+      dhidden.mean_absolute_error(target_grad_hidden) < 1e-8
+      dW3.mean_absolute_error(target_grad_W3) < 1e-8
+      dU3.mean_absolute_error(target_grad_U3) < 1e-8
+      dbW3.mean_absolute_error(target_grad_bW3) < 1e-8
+      dbU3.mean_absolute_error(target_grad_bU3) < 1e-8
 
 suite "[NN Primitives - GRU: Stacked, sequences, bidirectional]":
 
@@ -466,16 +466,16 @@ suite "[NN Primitives - GRU: Stacked, sequences, bidirectional]":
               rs, zs, ns, Uhs)
 
       check:
-        mean_absolute_error(target_grad_x, dx) < tol
-        mean_absolute_error(target_grad_hidden, dhidden0) < tol
-        mean_absolute_error(target_grad_W3s0, dW3s0) < tol
-        mean_absolute_error(target_grad_U3s, dU3s) < tol
-        mean_absolute_error(target_grad_bW3s, dbW3s) < tol
-        mean_absolute_error(target_grad_bU3s, dbU3s) < tol
+        dx.mean_absolute_error(target_grad_x) < tol
+        dhidden0.mean_absolute_error(target_grad_hidden) < tol
+        dW3s0.mean_absolute_error(target_grad_W3s0) < tol
+        dU3s.mean_absolute_error(target_grad_U3s) < tol
+        dbW3s.mean_absolute_error(target_grad_bW3s) < tol
+        dbU3s.mean_absolute_error(target_grad_bU3s) < tol
 
       when Layers > 1:
-        let target_grad_W3sN   = W3sN.numerical_gradient(gru_W3sN)
-        check: mean_absolute_error(target_grad_W3sN, dW3sN) < tol
+        let target_grad_W3sN = W3sN.numerical_gradient(gru_W3sN)
+        check: dW3sN.mean_absolute_error(target_grad_W3sN) < tol
 
 
   GRU_backprop( 1,  1,  Output,   1e-8)

--- a/tests/nn_primitives/test_nnp_loss.nim
+++ b/tests/nn_primitives/test_nnp_loss.nim
@@ -31,12 +31,12 @@ suite "[NN primitives] Loss functions":
       let predicted = [-3.44, 1.16, -0.81, 3.91].toTensor.reshape(1,4)
       let truth = [0'f64, 0, 0, 1].toTensor.reshape(1,4)
 
-      let sce_loss = softmax_cross_entropy(predicted, truth)
+      let sce_loss = predicted.softmax_cross_entropy(truth)
       check: sce_loss ~= 0.0709
 
       let sparse_truth = [3].toTensor
 
-      let sparse_sce_loss = sparse_softmax_cross_entropy(predicted, sparse_truth)
+      let sparse_sce_loss = predicted.sparse_softmax_cross_entropy(sparse_truth)
       check: sparse_sce_loss ~= 0.0709
 
 
@@ -76,8 +76,8 @@ suite "[NN primitives] Loss functions":
       # Create a random tensor with predictions:
       let pred = randomTensor(batch_size, nb_classes, -1.0..1.0)
 
-      let sce_loss = softmax_cross_entropy(pred, labels)
-      let sparse_sce_loss = sparse_softmax_cross_entropy(pred, sparse_labels)
+      let sce_loss = pred.softmax_cross_entropy(labels)
+      let sparse_sce_loss = pred.sparse_softmax_cross_entropy(sparse_labels)
 
       check: sce_loss ~= sparse_sce_loss
 

--- a/tests/nn_primitives/test_nnp_loss.nim
+++ b/tests/nn_primitives/test_nnp_loss.nim
@@ -53,11 +53,11 @@ suite "[NN primitives] Loss functions":
       check: mean_relative_error(expected_grad, expected_sparse_grad) < 1e-6
 
       let grad = softmax_cross_entropy_backward(sce_loss, predicted, truth)
-      check: mean_relative_error(grad, expected_grad) < 1e-6
+      check: grad.mean_relative_error(expected_grad) < 1e-6
 
 
       let sparse_grad = sparse_softmax_cross_entropy_backward(sparse_sce_loss, predicted, sparse_truth)
-      check: mean_relative_error(sparse_grad, expected_sparse_grad) < 1e-6
+      check: sparse_grad.mean_relative_error(expected_sparse_grad) < 1e-6
 
     block: # with batch
       let batch_size = 256
@@ -94,7 +94,7 @@ suite "[NN primitives] Loss functions":
       check: mean_relative_error(expected_grad, expected_sparse_grad) < 1e-6
 
       let grad = softmax_cross_entropy_backward(sce_loss, pred, labels)
-      check: mean_relative_error(grad, expected_grad) < 1e-6
+      check: grad.mean_relative_error(expected_grad) < 1e-6
 
       let sparse_grad = sparse_softmax_cross_entropy_backward(sparse_sce_loss, pred, sparse_labels)
-      check: mean_relative_error(sparse_grad, expected_sparse_grad) < 1e-6
+      check: sparse_grad.mean_relative_error(expected_sparse_grad) < 1e-6

--- a/tests/nn_primitives/test_nnp_maxpool.nim
+++ b/tests/nn_primitives/test_nnp_maxpool.nim
@@ -38,4 +38,4 @@ suite "[NN Primitives] Maxpool":
     let expected_grad = a.astype(float) .* numerical_gradient(a.astype(float), mpool)
     let grad = maxpool2d_backward(a.shape, max_indices, pooled).astype(float)
 
-    check: mean_relative_error(expected_grad, grad) < 1e-6
+    check: grad.mean_relative_error(expected_grad) < 1e-6

--- a/tests/nn_primitives/test_nnp_numerical_gradient.nim
+++ b/tests/nn_primitives/test_nnp_numerical_gradient.nim
@@ -26,4 +26,4 @@ suite "Test the numerical gradient proc":
       x*x + y*y + x*y + x + y + 1.0
     let input = [2.0, 3.0].toTensor()
     let grad = [8.0, 9.0].toTensor()
-    check: mean_relative_error(numerical_gradient(input, g), grad) < 1e-8
+    check: numerical_gradient(input, g).mean_relative_error(grad) < 1e-8

--- a/tests/nn_primitives/test_nnp_numerical_gradient.nim
+++ b/tests/nn_primitives/test_nnp_numerical_gradient.nim
@@ -18,7 +18,7 @@ import unittest
 suite "Test the numerical gradient proc":
   test "Numerical gradient":
     proc f(x: float): float = x*x + x + 1.0
-    check: relative_error(numerical_gradient(2.0, f), 5.0) < 1e-8
+    check: numerical_gradient(2.0, f).relative_error(5.0) < 1e-8
 
     proc g(t: Tensor[float]): float =
       let x = t[0]

--- a/tests/stats/test_stats.nim
+++ b/tests/stats/test_stats.nim
@@ -21,7 +21,7 @@ suite "Statistics":
 
       let computed = covariance_matrix(x,x)
 
-      check: mean_absolute_error(computed, expected) <= 1e-04 # The website seems to have precision issue
+      check: computed.mean_absolute_error(expected) <= 1e-04 # The website seems to have precision issue
 
     block: # p13 of http://www.cs.otago.ac.nz/cosc453/student_tutorials/principal_components.pdf
       let data = [[2.5, 2.4],
@@ -40,7 +40,7 @@ suite "Statistics":
 
       let computed = covariance_matrix(data, data)
 
-      check: mean_absolute_error(computed, expected) <= 1e-09
+      check: computed.mean_absolute_error(expected) <= 1e-09
 
     block: # Numpy doc https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.cov.html
 
@@ -53,7 +53,7 @@ suite "Statistics":
 
       let computed = covariance_matrix(x, x)
 
-      check: mean_absolute_error(computed, expected) <= 1e-14
+      check: computed.mean_absolute_error(expected) <= 1e-14
 
     block: # Numpy example 2
       let x =  [[-2.1, 3.0],
@@ -65,4 +65,4 @@ suite "Statistics":
 
       let computed = covariance_matrix(x, x)
 
-      check: mean_absolute_error(computed, expected) <= 1e-09
+      check: computed.mean_absolute_error(expected) <= 1e-09

--- a/tests/tensor/test_operators_blas.nim
+++ b/tests/tensor/test_operators_blas.nim
@@ -192,7 +192,7 @@ suite "BLAS (Basic Linear Algebra Subprograms)":
                     [-1.22382056,  -0.162675287]].toTensor
 
     check:
-      mean_absolute_error(expected, val) < 1e-9
+      expected.mean_absolute_error(val) < 1e-9
 
   test "Scalar/dot product":
     ## TODO: test with slices

--- a/tests/tensor/test_ufunc.nim
+++ b/tests/tensor/test_ufunc.nim
@@ -40,7 +40,7 @@ suite "Universal functions":
     let expected_c = @[@[cos(complex64(1'f64,0.0)),cos(complex64(2'f64,0.0)),cos(complex64(3'f64,0.0))],
                        @[cos(complex64(4'f64,0.0)),cos(complex64(5'f64,0.0)),cos(complex64(6'f64,0.0))]]
 
-    check: mean_absolute_error(cos(ta), expected_a.toTensor()) <= 1e-15 # We have slight precision loss with OpenMP
+    check: cos(ta).mean_absolute_error(expected_a.toTensor()) <= 1e-15 # We have slight precision loss with OpenMP
     check: ln(tb) == expected_b.toTensor()
 
     # TODO - complex errors


### PR DESCRIPTION
Closes #380 

I'm not sure if I caught all the function signatures, but a `rg -Fl 'y_true'` only hits these files. I also changed a few (but intentionally not most) of the examples using the error functions. Let me know if there is anything else I should change.