### PR TITLE
Broadcast operator precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ import arraymancer
 let j = [0, 10, 20, 30].toTensor.reshape(4,1)
 let k = [0, 1, 2].toTensor.reshape(1,3)
 
-echo j .+ k
+echo j +. k
 # Tensor of shape 4x3 of type "int" on backend "Cpu"
 # |0      1       2|
 # |10     11      12|
@@ -264,7 +264,7 @@ For now Arraymancer is mostly at the multidimensional array stage, in particular
 - Matrix algebra primitives: Matrix-Matrix, Matrix-Vector multiplication.
 - Easy and efficient slicing including with ranges and steps.
 - No need to worry about "vectorized" operations.
-- Broadcasting support. Unlike Numpy it is explicit, you just need to use `.+` instead of `+`.
+- Broadcasting support. Unlike Numpy it is explicit, you just need to use `+.` instead of `+`.
 - Plenty of reshaping operations: concat, reshape, split, chunk, permute, transpose.
 - Supports tensors of up to 6 dimensions. For example a stack of 4 3D RGB minifilms of 10 seconds would be 6 dimensions:
   `[4, 10, 3, 64, 1920, 1080]` for `[nb_movies, time, colors, depth, height, width]`

--- a/benchmarks/ex01_xor.nim
+++ b/benchmarks/ex01_xor.nim
@@ -15,12 +15,12 @@ let y = y_bool.astype(float32)
 # Input --> Linear(out_features = 3) --> relu --> Linear(out_features = 1) --> Sigmoid --> Cross-Entropy Loss
 
 let layer_3neurons = ctx.variable(
-                      randomTensor(3, 2, 2.0f) .- 1.0f,
+                      randomTensor(3, 2, 2.0f) -. 1.0f,
                       requires_grad = true
                       )
 
 let classifier_layer = ctx.variable(
-                  randomTensor(1, 3, 2.0f) .- 1.0f,
+                  randomTensor(1, 3, 2.0f) -. 1.0f,
                   requires_grad = true
                   )
 

--- a/benchmarks/implementation/pca.nim
+++ b/benchmarks/implementation/pca.nim
@@ -69,7 +69,7 @@ when false:
   doAssert d == [1,2,3].toTensor().diag(3, 4)
   doAssert a * d == a.mul_diag([1,2,3].toTensor().asContiguous(colMajor, force = true), 3, 4)
   doAssert a * d == a.mul_diag([1,2,3].toTensor(), 3, 4)
-  # doAssert a * d == a .* [1,2,3].toTensor().unsqueeze(0)
+  # doAssert a * d == a *. [1,2,3].toTensor().unsqueeze(0)
 
   echo a * d
   # Tensor[system.int] of shape [4, 4]" on backend "Cpu"
@@ -77,7 +77,7 @@ when false:
   # |4      10      18      0|
   # |7      16      27      0|
   # |10     22      36      0|
-  echo a .* [1,2,3].toTensor().unsqueeze(0)
+  echo a *. [1,2,3].toTensor().unsqueeze(0)
   # Tensor[system.int] of shape [4, 3]" on backend "Cpu"
   # |1      4       9|
   # |4      10      18|
@@ -89,7 +89,7 @@ when false:
 
 proc pca_cov[T: SomeFloat](X: Tensor[T], n_components = 2): Tensor[T] {.noInit.}=
   # mean_centered
-  let X = X .- X.mean(axis=0)
+  let X = X -. X.mean(axis=0)
   let m = X.shape[0]
   let n = X.shape[1]
 
@@ -103,28 +103,28 @@ proc pca_cov[T: SomeFloat](X: Tensor[T], n_components = 2): Tensor[T] {.noInit.}
   result = X * rotation_matrix
 
 proc pca_svd_tXU[T: SomeFloat](X: Tensor[T], n_components = 2): Tensor[T] {.noInit.}=
-  let X = X .- X.mean(axis=0)
+  let X = X -. X.mean(axis=0)
 
   let (U, _, _) = svd(X.transpose)
   result = X * U[_, 0..<n_components]
 
 proc pca_svd_XV[T: SomeFloat](X: Tensor[T], n_components = 2): Tensor[T] {.noInit.}=
-  let X = X .- X.mean(axis=0)
+  let X = X -. X.mean(axis=0)
 
   let (_, _, Vh) = svd(X)
   result = X * Vh.transpose[_, 0..<n_components]
 
 proc pca_svd_US[T: SomeFloat](X: Tensor[T], n_components = 2): Tensor[T] {.noInit.}=
-  let X = X .- X.mean(axis=0)
+  let X = X -. X.mean(axis=0)
 
   let (U, S, _) = svd(X)
-  result = U[_, 0..<n_components] .* S[0..<n_components].unsqueeze(0)
+  result = U[_, 0..<n_components] *. S[0..<n_components].unsqueeze(0)
 
 proc pca_svd_tX_VhS[T: SomeFloat](X: Tensor[T], n_components = 2): Tensor[T] {.noInit.}=
-  let X = X .- X.mean(axis=0)
+  let X = X -. X.mean(axis=0)
 
   let (_, S, Vh) = svd(X.transpose)
-  result = Vh.transpose[_, 0..<n_components] .* S[0..<n_components].unsqueeze(0)
+  result = Vh.transpose[_, 0..<n_components] *. S[0..<n_components].unsqueeze(0)
 
 # Sanity checks
 # ---------------------------------------------------

--- a/benchmarks/implementation/softmax_cross_entropy_bench_batch_first.nim
+++ b/benchmarks/implementation/softmax_cross_entropy_bench_batch_first.nim
@@ -290,7 +290,7 @@ echo "### Sparse challenger"
 echo pred.sparse_softmax_cross_entropy2(sparse_labels) # Warning it's only accurate at 1e-3 and precision is at 1e-2 with OpenMP
 
 ## Warmup for OpenMP threadpool and CPU on "on-demand" governor
-discard pred .* pred
+discard pred *. pred
 
 var start = epochTime()
 

--- a/benchmarks/implementation/softmax_cross_entropy_bench_batch_last.nim
+++ b/benchmarks/implementation/softmax_cross_entropy_bench_batch_last.nim
@@ -288,7 +288,7 @@ echo "### Sparse challenger"
 echo pred.sparse_softmax_cross_entropy2(sparse_labels) # Warning it's only accurate at 1e-3 and precision is at 1e-2 with OpenMP
 
 ## Warmup for OpenMP threadpool and CPU on "on-demand" governor
-discard pred .* pred
+discard pred *. pred
 
 var start = epochTime()
 

--- a/benchmarks/implementation/stable_sigmoid_bench.nim
+++ b/benchmarks/implementation/stable_sigmoid_bench.nim
@@ -4,7 +4,7 @@ import times, ../../src/arraymancer, math
 # Some are numericall stable for positive, negative or both value
 
 # We create a random tensor with randomly positive and negative value
-let a = randomTensor(1000, 1000, 100.0f) .- 50.0f
+let a = randomTensor(1000, 1000, 100.0f) -. 50.0f
 
 proc sigmoid1[T: SomeFloat](t: Tensor[T]): Tensor[T] {.noInit.}=
   # Instable for large negative

--- a/changelog.md
+++ b/changelog.md
@@ -50,11 +50,18 @@ Deprecation:
   - The syntax gemm(A, B, C) is now deprecated.
     Use explicit "gemm(1.0, A, B, 0.0, C)" instead.
     Arguably not zero-ing C could also be a reasonable default.
+  - The dot in broadcasting and elementwise operators has changed place
+    Use `+.`, `*.`, `/.`, `-.`, `^.`, `+.=`, `*.=`, `/.=`, `-.=`, `^.=`
+    instead of the previous order `.+` and `.+=`.
+    This allows the broadcasting operators to have the same precedence as the
+    natural operators.
+    This also align Arraymancer with other Nim packages: Manu and NumericalNim
 
 Thanks to @dynalagreen for the SGD with Momentum,  @xcokazaki for spotting the in-place division typo,
 @Vindaar for fixing the automatic matrix multiplication and addition fusion,
 @Imperator26 for the Softmax layer, @brentp for reviewing and augmenting the SVD and PCA API,
 @auxym for the linear equation solver and @berquist for the reordering all error functions to the new API.
+Thanks @b3liever for suggesting the dot change to solve the precedence issue in broadcasting and elementwise operators.
 
 Arraymancer v0.5.1 Jul. 19 2019
 =====================================================

--- a/docs/howto.perceptron.rst
+++ b/docs/howto.perceptron.rst
@@ -30,13 +30,13 @@ Spellbook: How to do a multilayer perceptron
     # First hidden layer of 3 neurons, shape [3 out_features, 2 in_features]
     # We initialize with random weights between -1 and 1
     let layer_3neurons = ctx.variable(
-                          randomTensor(3, 2, 2.0f) .- 1.0f
+                          randomTensor(3, 2, 2.0f) -. 1.0f
                           )
 
     # Classifier layer with 1 neuron per feature. (In our case only one neuron overall)
     # We initialize with random weights between -1 and 1
     let classifier_layer = ctx.variable(
-                      randomTensor(1, 3, 2.0f) .- 1.0f
+                      randomTensor(1, 3, 2.0f) -. 1.0f
                       )
 
     # Stochastic Gradient Descent

--- a/docs/tuto.broadcasting.rst
+++ b/docs/tuto.broadcasting.rst
@@ -22,5 +22,5 @@ beginning with a dot:
 -  ``*.``: broadcasted element-wise matrix multiplication also called
    Hadamard product)
 -  ``./``: broadcasted element-wise division or integer-division
--  ``+.=``, ``-.=``, ``*.=``, ``./=``: in-place versions. Only the right
+-  ``+.=``, ``-.=``, ``*.=``, ``/.=``: in-place versions. Only the right
    operand is broadcastable.

--- a/docs/tuto.broadcasting.rst
+++ b/docs/tuto.broadcasting.rst
@@ -11,16 +11,16 @@ beginning with a dot:
     let j = [0, 10, 20, 30].toTensor.reshape(4,1)
     let k = [0, 1, 2].toTensor.reshape(1,3)
 
-    echo j .+ k
+    echo j +. k
     # Tensor of shape 4x3 of type "int" on backend "Cpu"
     # |0      1       2|
     # |10     11      12|
     # |20     21      22|
     # |30     31      32|
 
--  ``.+``,\ ``.-``,
--  ``.*``: broadcasted element-wise matrix multiplication also called
+-  ``+.``,\ ``-.``,
+-  ``*.``: broadcasted element-wise matrix multiplication also called
    Hadamard product)
 -  ``./``: broadcasted element-wise division or integer-division
--  ``.+=``, ``.-=``, ``.*=``, ``./=``: in-place versions. Only the right
+-  ``+.=``, ``-.=``, ``*.=``, ``./=``: in-place versions. Only the right
    operand is broadcastable.

--- a/docs/tuto.linear_algebra.rst
+++ b/docs/tuto.linear_algebra.rst
@@ -11,7 +11,7 @@ rank 1 (vectors) and 2 (matrices):
 -  multiplication or division by a scalar using ``*`` and ``/``
 -  matrix-matrix multiplication using ``*``
 -  matrix-vector multiplication using ``*``
--  element-wise multiplication (Hadamard product) using ``.*``
+-  element-wise multiplication (Hadamard product) using ``*.``
 
 Note: Matrix operations for floats are accelerated using BLAS (Intel
 MKL, OpenBLAS, Apple Accelerate …). Unfortunately there is no

--- a/docs/tuto.map_reduce.rst
+++ b/docs/tuto.map_reduce.rst
@@ -22,7 +22,7 @@ or
     a.map(plusone) # Map the function plusone
 
 Note: for basic operation, you can use implicit broadcasting instead
-``a .+ 1``
+``a +. 1``
 
 ``apply`` is the same as ``map`` but in-place.
 

--- a/docs/uth.speed.rst
+++ b/docs/uth.speed.rst
@@ -34,14 +34,14 @@ data: - ``temp1 = -x`` - ``temp2 = math.exp(temp1)`` -
 So you suddenly get a o(n^4) algorithm.
 
 Arraymancer can do the same using the explicit broadcast operator ``./``
-and ``.+``. (To avoid name conflict we change the logistic sigmoid name)
+and ``+.``. (To avoid name conflict we change the logistic sigmoid name)
 
 .. code:: nim
 
     import arraymancer
 
     proc customSigmoid[T: SomeFloat](t: Tensor[T]): Tensor[T] =
-      result = 1 ./ (1 .+ exp(-t))
+      result = 1 ./ (1 +. exp(-t))
 
 Well, unfortunately, the only thing we gain here is parallelism but we
 still have 4 loops over the data implicitly. Another way would be to use
@@ -60,14 +60,14 @@ Now in a single loop over ``t``, Arraymancer will do
 elements of the first tensor argument.
 
 Here is another example with 3 tensors and element-wise fused
-multiply-add ``C += A .* B``:
+multiply-add ``C += A *. B``:
 
 .. code:: nim
 
     import arraymancer
 
     proc fusedMultiplyAdd[T: SomeNumber](c: var Tensor[T], a, b: Tensor[T]) =
-      ## Implements C += A .* B, .* is the element-wise multiply
+      ## Implements C += A *. B, *. is the element-wise multiply
       apply3_inline(c, a, b):
         x += y * z
 

--- a/examples/ex06_shakespeare_generator.nim
+++ b/examples/ex06_shakespeare_generator.nim
@@ -347,7 +347,7 @@ proc gen_text[TT](
       var preds = output.value
 
       # We scale by the temperature first.
-      preds ./= temperature
+      preds /.= temperature
       # Get a probability distribution.
       let probs = preds.softmax().squeeze(0)
 

--- a/src/autograd/gates_hadamard.nim
+++ b/src/autograd/gates_hadamard.nim
@@ -22,8 +22,8 @@ type HadamardGate* {.final.} [TT] = ref object of Gate[TT]
 proc hadamard_backward_ag[TT](self: HadamardGate[TT], payload: Payload[TT]): SmallDiffs[TT] =
   let gradient = payload.variable.grad
   result = newSeq[TT](2)
-  result[0] = gradient     .* self.b.value
-  result[1] = self.a.value .* gradient
+  result[0] = gradient     *. self.b.value
+  result[1] = self.a.value *. gradient
 
 proc hadamard_cache[TT](result: Variable[TT], a, b: Variable[TT]) =
   # Gate
@@ -45,14 +45,14 @@ proc hadamard_cache[TT](result: Variable[TT], a, b: Variable[TT]) =
     a, b
   )
 
-proc `.*`*[TT](a, b: Variable[TT]): Variable[TT] =
+proc `*.`*[TT](a, b: Variable[TT]): Variable[TT] =
   when compileOption("boundChecks"):
     check_ctx(a, b)
 
   # Resulting var
   new result
   result.context = a.context
-  result.value = a.value .* b.value
+  result.value = a.value *. b.value
 
   # Caching for backprop
   if a.is_grad_needed or b.is_grad_needed:

--- a/src/ml/clustering/kmeans.nim
+++ b/src/ml/clustering/kmeans.nim
@@ -19,7 +19,7 @@ proc euclidean_distance[T: SomeFloat](u: Tensor[T], v: Tensor[T], squared: bool 
   ##
   ## Returns:
   ##  - A tensor of shape (nb samples)
-  let u_v = (u .- v).reshape(u.shape[1])
+  let u_v = (u -. v).reshape(u.shape[1])
   result = dot(u_v, u_v)
   if not squared:
     result = sqrt(result)

--- a/src/ml/dimensionality_reduction/pca.nim
+++ b/src/ml/dimensionality_reduction/pca.nim
@@ -46,8 +46,8 @@ proc pca*[T: SomeFloat](
   when center:
     # TODO: When we center, we could do in-place randomized SVD and save memory from cloning x
     #       but that only happen when the number of components is within 25% of [Observations, Features]
-    let X = X .- X.mean(axis=0)
+    let X = X -. X.mean(axis=0)
 
   let (U, S, Vh) = svd_randomized(X, n_components, n_oversamples=n_oversamples, n_power_iters=n_power_iters)
   result.components = Vh.transpose
-  result.projected = U .* S.unsqueeze(0) # S sparse diagonal, equivalent to multiplying by a dense diagonal matrix
+  result.projected = U *. S.unsqueeze(0) # S sparse diagonal, equivalent to multiplying by a dense diagonal matrix

--- a/src/nn_primitives/fallback/conv.nim
+++ b/src/nn_primitives/fallback/conv.nim
@@ -105,7 +105,7 @@ proc im2colgemm_conv2d*[T](input, kernel, bias: Tensor[T],
     gemm(1.T, kernel_col, input_col, 0.T, output)
 
   if bias.rank > 0:
-    result .+= bias.unsqueeze(0)
+    result +.= bias.unsqueeze(0)
 
 proc im2colgemm_conv2d_gradient*[T](input, kernel: Tensor[T],
                          padding: Size2D = (0,0),

--- a/src/nn_primitives/nnp_conv2d_cudnn.nim
+++ b/src/nn_primitives/nnp_conv2d_cudnn.nim
@@ -69,7 +69,7 @@ proc conv2d*[T: SomeFloat](input, kernel, bias: CudaTensor[T],
     result.get_offset_ptr
   )
 
-  result .+= bias.unsqueeze(0)
+  result +.= bias.unsqueeze(0)
 
 proc conv2d_backward*[T: SomeFloat](input, kernel, bias: CudaTensor[T],
                          padding: SizeHW = [0,0],

--- a/src/nn_primitives/nnp_embedding.nim
+++ b/src/nn_primitives/nnp_embedding.nim
@@ -84,6 +84,6 @@ proc embedding_backward*[T; Idx: byte or char or SomeNumber](
         # For speed don't respect IEEE-754 and avoid
         # division in tight loop by multiplying by the inverse
         let idf = 1.T div counts[word_idx] # inverse document frequency
-        grad_curr_word .+= flat_dOutput[i] * idf
+        grad_curr_word +.= flat_dOutput[i] * idf
       else:
-        grad_curr_word .+= flat_dOutput[i]
+        grad_curr_word +.= flat_dOutput[i]

--- a/src/nn_primitives/nnp_gru.nim
+++ b/src/nn_primitives/nnp_gru.nim
@@ -19,8 +19,8 @@ import
 #
 # r  =    σ(Wr * x + bWr +       Ur * h + bUr)
 # z  =    σ(Wz * x + bWz +       Uz * h + bUz)
-# n  = tanh(W  * x + bW  + r .* (U  * h + bU ))
-# h' = (1 - z) .* n + z .* h
+# n  = tanh(W  * x + bW  + r *. (U  * h + bU ))
+# h' = (1 - z) *. n + z *. h
 #
 # Those differs from the original paper for n and h'
 #   - The pointwise multiplication by r is after the matrix multiplication
@@ -163,13 +163,13 @@ proc gru_cell_backward*[T: SomeFloat](
   ##   - x, h, W3, U3: inputs saved from the forward pass
   ##   - r, z, n, Uh: intermediate results saved from the forward pass of shape [batch_size, hidden_size]
   # Backprop of step 4 - z part
-  let dz = (h - n) .* dnext
-  let dn = (1.0.T .- z) .* dnext
+  let dz = (h - n) *. dnext
+  let dn = (1.0.T -. z) *. dnext
 
   # Backprop of step 3.
   let dWx = tanh_backward(dn, n)
-  let dr = Uh .* dWx
-  let dUh = r .* dWx
+  let dr = Uh *. dWx
+  let dUh = r *. dWx
 
   # Backprop of step 2 - update gate z
   let dWzx = sigmoid_backward(dz, z)
@@ -500,7 +500,7 @@ proc gru_backward*[T: SomeFloat](
       tmp += dU3s_lts.unsqueeze(0)
 
       tmp = dbW3s[layer, _, _]
-      tmp .+= dbW3s_lts.unsqueeze(0)
+      tmp +.= dbW3s_lts.unsqueeze(0)
 
       tmp = dbU3s[layer, _, _]
-      tmp .+= dbU3s_lts.unsqueeze(0)
+      tmp +.= dbU3s_lts.unsqueeze(0)

--- a/src/nn_primitives/nnp_linear.nim
+++ b/src/nn_primitives/nnp_linear.nim
@@ -26,7 +26,7 @@ proc linear*[T](input, weight: Tensor[T], bias: Tensor[T], output: var Tensor[T]
   # Output is: Y = x * W.transpose + b
 
   output = input * weight.transpose # TODO: with the transpose the non-matching rows and cols is confusing
-  output .+= bias
+  output +.= bias
 
 proc linear*[T](input, weight: Tensor[T], output: var Tensor[T]) {.inline.} =
   # Linear (Dense) forward primitive with bias
@@ -64,4 +64,3 @@ proc linear_backward*[T](
   # Tensors are expected in a batch first shape [batch_size, n_features]
   gradInput = gradOutput * weight
   gradWeight = gradOutput.transpose * input
-

--- a/src/stats/stats.nim
+++ b/src/stats/stats.nim
@@ -24,8 +24,8 @@ proc covariance_matrix*[T: SomeFloat](x, y: Tensor[T]): Tensor[T] =
   assert x.rank == 2
   assert x.shape == y.shape
 
-  let deviation_X = (x .- x.mean(axis=0)).transpose # shape [features, batch_size]
-  let deviation_Y = y .- y.mean(axis=0)             # shape [batch_size, features]
+  let deviation_X = (x -. x.mean(axis=0)).transpose # shape [features, batch_size]
+  let deviation_Y = y -. y.mean(axis=0)             # shape [batch_size, features]
 
   result = newTensorUninit[T]([x.shape[1], x.shape[1]])
   gemm(1.T / T(x.shape[0]-1), deviation_X, deviation_Y, 0, result)

--- a/src/tensor/higher_order_applymap.nim
+++ b/src/tensor/higher_order_applymap.nim
@@ -127,7 +127,7 @@ proc map*[T; U: not (ref|string|seq)](t: Tensor[T], f: T -> U): Tensor[U] {.noIn
   ##   for basic operation, you can use implicit broadcasting instead
   ##   with operators prefixed by a dot :
   ##  .. code:: nim
-  ##     a .+ 1
+  ##     a +. 1
   ## ``map`` is especially useful to do multiple element-wise operations on a tensor in a single loop over the data.
   ##
   ## For OpenMP compatibility, this ``map`` doesn't allow ref types as result like seq or string

--- a/src/tensor/operators_broadcasted.nim
+++ b/src/tensor/operators_broadcasted.nim
@@ -22,17 +22,17 @@ import complex except Complex64, Complex32
 # # Broadcasting Tensor-Tensor
 # # And element-wise multiplication (Hadamard) and division
 
-proc `.+`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit,inline.} =
+proc `+.`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit,inline.} =
   ## Broadcasted addition for tensors of incompatible but broadcastable shape.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a + tmp_b
 
-proc `.-`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit,inline.} =
+proc `-.`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit,inline.} =
   ## Broadcasted addition for tensors of incompatible but broadcastable shape.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a - tmp_b
 
-proc `.*`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit.} =
+proc `*.`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Element-wise multiplication (Hadamard product).
   ##
   ## And broadcasted element-wise multiplication.
@@ -57,7 +57,7 @@ proc `./`*[T: SomeFloat|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Ten
 # ##############################################
 # # Broadcasting in-place Tensor-Tensor
 
-proc `.+=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
+proc `+.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
   ## Tensor broadcasted in-place addition.
   ##
   ## Only the right hand side tensor can be broadcasted.
@@ -66,7 +66,7 @@ proc `.+=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b
   let tmp_b = b.broadcast(a.shape)
   apply2_inline(a, tmp_b, x + y)
 
-proc `.-=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
+proc `-.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
   ## Tensor broadcasted in-place substraction.
   ##
   ## Only the right hand side tensor can be broadcasted.
@@ -75,7 +75,7 @@ proc `.-=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b
   let tmp_b = b.broadcast(a.shape)
   apply2_inline(a, tmp_b, x - y)
 
-proc `.*=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
+proc `*.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
   ## Tensor broadcasted in-place multiplication (Hadamard product)
   ##
   ## Only the right hand side tensor can be broadcasted
@@ -106,19 +106,19 @@ proc `./=`*[T: SomeFloat|Complex[float32]|Complex[float64]](a: var Tensor[T], b:
 # ##############################################
 # # Broadcasting Tensor-Scalar and Scalar-Tensor
 
-proc `.+`*[T: SomeNumber|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
+proc `+.`*[T: SomeNumber|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Broadcasted addition for tensor + scalar.
   result = t.map_inline(x + val)
 
-proc `.+`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
+proc `+.`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
   ## Broadcasted addition for scalar + tensor.
   result = t.map_inline(x + val)
 
-proc `.-`*[T: SomeNumber|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
+proc `-.`*[T: SomeNumber|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Broadcasted substraction for tensor - scalar.
   result = t.map_inline(val - x)
 
-proc `.-`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
+proc `-.`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
   ## Broadcasted substraction for scalar - tensor.
   result = t.map_inline(x - val)
 
@@ -145,11 +145,11 @@ proc `.^`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T], exponen
 # #####################################
 # # Broadcasting in-place Tensor-Scalar
 
-proc `.+=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
+proc `+.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
   ## Tensor in-place addition with a broadcasted scalar.
   t.apply_inline(x + val)
 
-proc `.-=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
+proc `-.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
   ## Tensor in-place substraction with a broadcasted scalar.
   t.apply_inline(x - val)
 
@@ -157,7 +157,7 @@ proc `.^=`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: var Tensor[T], ex
   ## Compute in-place element-wise exponentiation
   t.apply_inline pow(x, exponent)
 
-proc `.*=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
+proc `*.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
   ## Tensor in-place multiplication with a broadcasted scalar.
   t.apply_inline(x * val)
 

--- a/src/tensor/operators_broadcasted.nim
+++ b/src/tensor/operators_broadcasted.nim
@@ -27,10 +27,16 @@ proc `+.`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Te
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a + tmp_b
 
+proc `.+`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit,inline,deprecated:"Use `+.` instead".} =
+  a +. b
+
 proc `-.`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit,inline.} =
   ## Broadcasted addition for tensors of incompatible but broadcastable shape.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a - tmp_b
+
+proc `.-`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit,inline,deprecated:"Use `-.` instead".} =
+  a -. b
 
 proc `*.`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Element-wise multiplication (Hadamard product).
@@ -40,19 +46,28 @@ proc `*.`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Te
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = map2_inline(tmp_a, tmp_b, x * y)
 
-proc `./`*[T: SomeInteger](a, b: Tensor[T]): Tensor[T] {.noInit.} =
+proc `.*`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit,inline,deprecated:"Use `*.` instead".} =
+  a *. b
+
+proc `/.`*[T: SomeInteger](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Tensor element-wise division for integer numbers.
   ##
   ## And broadcasted element-wise division.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = map2_inline(tmp_a, tmp_b, x div y)
 
-proc `./`*[T: SomeFloat|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit.} =
+proc `/.`*[T: SomeFloat|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Tensor element-wise division for real numbers.
   ##
   ## And broadcasted element-wise division.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = map2_inline(tmp_a, tmp_b, x / y )
+
+proc `./`*[T: SomeInteger](a, b: Tensor[T]): Tensor[T] {.noInit,inline,deprecated:"Use `/.` instead".} =
+  a /. b
+
+proc `./`*[T: SomeFloat|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit,inline,deprecated:"Use `/.` instead".} =
+  a /. b
 
 # ##############################################
 # # Broadcasting in-place Tensor-Tensor
@@ -66,6 +81,9 @@ proc `+.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b
   let tmp_b = b.broadcast(a.shape)
   apply2_inline(a, tmp_b, x + y)
 
+proc `.+=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) {.inline,deprecated:"Use `+.=` instead".}=
+  a +.= b
+
 proc `-.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
   ## Tensor broadcasted in-place substraction.
   ##
@@ -74,6 +92,9 @@ proc `-.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b
 
   let tmp_b = b.broadcast(a.shape)
   apply2_inline(a, tmp_b, x - y)
+
+proc `.-=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) {.inline,deprecated:"Use `-.=` instead".}=
+  a -.= b
 
 proc `*.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
   ## Tensor broadcasted in-place multiplication (Hadamard product)
@@ -84,7 +105,10 @@ proc `*.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b
   let tmp_b = b.broadcast(a.shape)
   apply2_inline(a, tmp_b, x * y)
 
-proc `./=`*[T: SomeInteger](a: var Tensor[T], b: Tensor[T]) =
+proc `.*=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) {.inline,deprecated:"Use `*.=` instead".}=
+  a *.= b
+
+proc `/.=`*[T: SomeInteger](a: var Tensor[T], b: Tensor[T]) =
   ## Tensor broadcasted in-place integer division.
   ##
   ## Only the right hand side tensor can be broadcasted.
@@ -93,7 +117,7 @@ proc `./=`*[T: SomeInteger](a: var Tensor[T], b: Tensor[T]) =
   let tmp_b = b.broadcast(a.shape)
   apply2_inline(a, tmp_b, x div y)
 
-proc `./=`*[T: SomeFloat|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
+proc `/.=`*[T: SomeFloat|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
   ## Tensor broadcasted in-place float division.
   ##
   ## Only the right hand side tensor can be broadcasted.
@@ -102,6 +126,11 @@ proc `./=`*[T: SomeFloat|Complex[float32]|Complex[float64]](a: var Tensor[T], b:
   let tmp_b = b.broadcast(a.shape)
   apply2_inline(a, tmp_b, x / y)
 
+proc `./=`*[T: SomeInteger](a: var Tensor[T], b: Tensor[T]) {.inline,deprecated:"Use `/.=` instead".}=
+  a /.= b
+
+proc `./=`*[T: SomeFloat|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) {.inline,deprecated:"Use `/.=` instead".}=
+  a /.= b
 
 # ##############################################
 # # Broadcasting Tensor-Scalar and Scalar-Tensor
@@ -110,37 +139,69 @@ proc `+.`*[T: SomeNumber|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]
   ## Broadcasted addition for tensor + scalar.
   result = t.map_inline(x + val)
 
+proc `.+`*[T: SomeNumber|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noInit, deprecated:"Use `+.` instead".} =
+  val +. t
+
 proc `+.`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
   ## Broadcasted addition for scalar + tensor.
   result = t.map_inline(x + val)
+
+proc `.+`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit, deprecated:"Use `+.` instead".} =
+  t +. val
 
 proc `-.`*[T: SomeNumber|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Broadcasted substraction for tensor - scalar.
   result = t.map_inline(val - x)
 
+proc `.-`*[T: SomeNumber|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noInit, deprecated:"Use `-.` instead".} =
+  val -. t
+
 proc `-.`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
   ## Broadcasted substraction for scalar - tensor.
   result = t.map_inline(x - val)
 
-proc `./`*[T: SomeInteger](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
+proc `.-`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit, deprecated:"Use `-.` instead".} =
+  t -. val
+
+proc `/.`*[T: SomeInteger](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Broadcasted division of an integer by a tensor of integers.
   result = t.map_inline(val div x)
 
-proc `./`*[T: SomeFloat|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
+proc `/.`*[T: SomeFloat|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Broadcasted division of a float by a tensor of floats.
   result = t.map_inline(val / x)
 
-proc `./`*[T: SomeInteger](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
+proc `/.`*[T: SomeInteger](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
   ## Broadcasted division of tensor of integers by an integer.
   result = t.map_inline(x div val)
 
-proc `./`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
+proc `/.`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
   ## Broadcasted division of a tensor of floats by a float.
   result = t.map_inline(x / val)
 
-proc `.^`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T], exponent: T): Tensor[T] {.noInit.} =
+proc `./`*[T: SomeInteger](val: T, t: Tensor[T]): Tensor[T] {.noInit, deprecated:"Use `/.` instead".} =
+  ## Broadcasted division of an integer by a tensor of integers.
+  val /. t
+
+proc `./`*[T: SomeFloat|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noInit, deprecated:"Use `/.` instead".} =
+  ## Broadcasted division of a float by a tensor of floats.
+  val /. t
+
+proc `./`*[T: SomeInteger](t: Tensor[T], val: T): Tensor[T] {.noInit, deprecated:"Use `/.` instead".} =
+  ## Broadcasted division of tensor of integers by an integer.
+  t /. val
+
+proc `./`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit, deprecated:"Use `/.` instead".} =
+  ## Broadcasted division of a tensor of floats by a float.
+  t /. val
+
+proc `^.`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T], exponent: T): Tensor[T] {.noInit.} =
   ## Compute element-wise exponentiation
   result = t.map_inline pow(x, exponent)
+
+proc `.^`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T], exponent: T): Tensor[T] {.noInit, deprecated:"Use `^.` instead".} =
+  ## Compute element-wise exponentiation
+  t ^. exponent
 
 # #####################################
 # # Broadcasting in-place Tensor-Scalar
@@ -149,18 +210,34 @@ proc `+.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], v
   ## Tensor in-place addition with a broadcasted scalar.
   t.apply_inline(x + val)
 
+proc `.+=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) {.deprecated:"Use `+.=` instead".}=
+  t +.= val
+
 proc `-.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
   ## Tensor in-place substraction with a broadcasted scalar.
   t.apply_inline(x - val)
+
+proc `.-=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) {.deprecated:"Use `-.=` instead".}=
+  t -.= val
 
 proc `.^=`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: var Tensor[T], exponent: T) =
   ## Compute in-place element-wise exponentiation
   t.apply_inline pow(x, exponent)
 
+proc `^.=`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: var Tensor[T], exponent: T) {.deprecated:"Use `^.=` instead".}=
+  ## Compute in-place element-wise exponentiation
+  t ^.= exponent
+
 proc `*.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
   ## Tensor in-place multiplication with a broadcasted scalar.
   t.apply_inline(x * val)
 
-proc `./=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
+proc `.*=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) {.deprecated:"Use `*.=` instead".}=
+  t *.= val
+
+proc `/.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
   ## Tensor in-place division with a broadcasted scalar.
   t.apply_inline(x / val)
+
+proc `./=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) {.deprecated:"Use `/.=` instead".}=
+  t /.= val

--- a/src/tensor/operators_broadcasted_cuda.nim
+++ b/src/tensor/operators_broadcasted_cuda.nim
@@ -83,7 +83,7 @@ proc `+.=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   let tmp_b = b.broadcast(a.shape)
   a += tmp_b
 
-proc `.+=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) {.noInit, inline, deprecated: "Use `+.=` instead".} =
+proc `.+=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) {.inline, deprecated: "Use `+.=` instead".} =
   a +.= b
 
 proc `-.=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
@@ -95,7 +95,7 @@ proc `-.=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   let tmp_b = b.broadcast(a.shape)
   a -= tmp_b
 
-proc `.-=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) {.noInit, inline, deprecated: "Use `-.=` instead".} =
+proc `.-=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) {.inline, deprecated: "Use `-.=` instead".} =
   a -.= b
 
 proc `*.=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
@@ -107,7 +107,7 @@ proc `*.=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   let tmp_b = b.broadcast(a.shape)
   cuda_assign_call(cuda_mMulOp, a, tmp_b)
 
-proc `.*=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) {.noInit, inline, deprecated: "Use `*.=` instead".} =
+proc `.*=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) {.inline, deprecated: "Use `*.=` instead".} =
   a .*= b
 
 proc `/.=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
@@ -119,7 +119,7 @@ proc `/.=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   let tmp_b = b.broadcast(a.shape)
   cuda_assign_call(cuda_mDivOp, a, tmp_b)
 
-proc `./=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) {.noInit, inline, deprecated: "Use `/.=` instead".} =
+proc `./=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) {.inline, deprecated: "Use `/.=` instead".} =
   a /.= b
 
 # ##############################################
@@ -181,12 +181,12 @@ proc `+.=`*[T: SomeFloat](t: var CudaTensor[T], val: T) =
   ## Broadcasted addition for scalar + tensor.
   cuda_assignscal_call(cuda_mscalAdd, t, val)
 
-proc `.+=`*[T: SomeFloat](t: var CudaTensor[T], val: T) {.noInit, inline, deprecated: "Use `+.=` instead".} =
+proc `.+=`*[T: SomeFloat](t: var CudaTensor[T], val: T) {.inline, deprecated: "Use `+.=` instead".} =
   t +.= val
 
 proc `-.=`*[T: SomeFloat](t: var CudaTensor[T], val: T) =
   ## Broadcasted substraction for scalar - tensor.
   cuda_assignscal_call(cuda_mscalSub, t, val)
 
-proc `.-=`*[T: SomeFloat](t: var CudaTensor[T], val: T) {.noInit, inline, deprecated: "Use `-.=` instead".} =
+proc `.-=`*[T: SomeFloat](t: var CudaTensor[T], val: T) {.inline, deprecated: "Use `-.=` instead".} =
   t -.= val

--- a/src/tensor/operators_broadcasted_cuda.nim
+++ b/src/tensor/operators_broadcasted_cuda.nim
@@ -28,18 +28,23 @@ include ./private/incl_accessors_cuda,
 cuda_binary_glue("cuda_Mul", "MulOp", cuda_Mul)
 cuda_binary_glue("cuda_Div", "DivOp", cuda_Div)
 
-proc `.+`*[T: SomeFloat](a, b: CudaTensor[T]): CudaTensor[T] {.noInit,inline.} =
+proc `+.`*[T: SomeFloat](a, b: CudaTensor[T]): CudaTensor[T] {.noInit,inline.} =
   ## Broadcasted addition for tensors of incompatible but broadcastable shape.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a + tmp_b
 
-proc `.-`*[T: SomeFloat](a, b: CudaTensor[T]): CudaTensor[T] {.noInit,inline.} =
+proc `.+`*[T: SomeFloat](a, b: CudaTensor[T]): CudaTensor[T] {.noInit,inline, deprecated: "Use `+.` instead".} =
+  a +. b
+
+proc `-.`*[T: SomeFloat](a, b: CudaTensor[T]): CudaTensor[T] {.noInit,inline.} =
   ## Broadcasted addition for tensors of incompatible but broadcastable shape.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a - tmp_b
 
+proc `.-`*[T: SomeFloat](a, b: CudaTensor[T]): CudaTensor[T] {.noInit,inline, deprecated: "Use `-.` instead".} =
+  a -. b
 
-proc `.*`*[T: SomeFloat](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
+proc `*.`*[T: SomeFloat](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   ## Element-wise multiplication (Hadamard product).
   ##
   ## And broadcasted element-wise multiplication.
@@ -49,7 +54,10 @@ proc `.*`*[T: SomeFloat](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   result = newCudaTensor[T](tmp_a.shape)
   cuda_binary_call(cuda_Mul, result, tmp_a, tmp_b)
 
-proc `./`*[T: SomeFloat](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
+proc `.*`*[T: SomeFloat](a,b: CudaTensor[T]): CudaTensor[T] {.noInit, inline, deprecated: "Use `*.` instead".} =
+  a *. b
+
+proc `/.`*[T: SomeFloat](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   ## CudaTensor substraction
 
   let (tmp_a, tmp_b) = broadcast2(a, b)
@@ -57,13 +65,16 @@ proc `./`*[T: SomeFloat](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   result = newCudaTensor[T](tmp_a.shape)
   cuda_binary_call(cuda_Div, result, tmp_a, tmp_b)
 
+proc `./`*[T: SomeFloat](a,b: CudaTensor[T]): CudaTensor[T] {.noInit, inline, deprecated: "Use `/.` instead".} =
+  a /. b
+
 # ##############################################
 # # Broadcasting in-place Tensor-Tensor
 
 cuda_assign_glue("cuda_mMulOp", "mMulOp", cuda_mMulOp)
 cuda_assign_glue("cuda_mDivOp", "mDivOp", cuda_mDivOp)
 
-proc `.+=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
+proc `+.=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   ## Tensor broadcasted in-place addition.
   ##
   ## Only the right hand side tensor can be broadcasted.
@@ -72,7 +83,10 @@ proc `.+=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   let tmp_b = b.broadcast(a.shape)
   a += tmp_b
 
-proc `.-=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
+proc `.+=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) {.noInit, inline, deprecated: "Use `+.=` instead".} =
+  a +.= b
+
+proc `-.=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   ## Tensor broadcasted in-place substraction.
   ##
   ## Only the right hand side tensor can be broadcasted.
@@ -81,7 +95,10 @@ proc `.-=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   let tmp_b = b.broadcast(a.shape)
   a -= tmp_b
 
-proc `.*=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
+proc `.-=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) {.noInit, inline, deprecated: "Use `-.=` instead".} =
+  a -.= b
+
+proc `*.=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   ## Tensor broadcasted in-place multiplication (Hadamard product)
   ##
   ## Only the right hand side tensor can be broadcasted
@@ -90,7 +107,10 @@ proc `.*=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   let tmp_b = b.broadcast(a.shape)
   cuda_assign_call(cuda_mMulOp, a, tmp_b)
 
-proc `./=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
+proc `.*=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) {.noInit, inline, deprecated: "Use `*.=` instead".} =
+  a .*= b
+
+proc `/.=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   ## Tensor broadcasted in-place float division.
   ##
   ## Only the right hand side tensor can be broadcasted.
@@ -99,51 +119,74 @@ proc `./=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   let tmp_b = b.broadcast(a.shape)
   cuda_assign_call(cuda_mDivOp, a, tmp_b)
 
+proc `./=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) {.noInit, inline, deprecated: "Use `/.=` instead".} =
+  a /.= b
+
 # ##############################################
 # # Broadcasting Tensor-Scalar and Scalar-Tensor
 
 cuda_rscal_glue("cuda_rscalSub","RscalSub", cuda_rscalSub)
 cuda_rscal_glue("cuda_rscalAdd","RscalAdd", cuda_rscalAdd)
 
-proc `.+`*[T: SomeFloat](t: CudaTensor[T], val: T): CudaTensor[T] {.noInit.} =
+proc `+.`*[T: SomeFloat](t: CudaTensor[T], val: T): CudaTensor[T] {.noInit.} =
   ## Broadcasted addition for scalar + tensor.
   result = newCudaTensor[T](t.shape)
   cuda_rscal_call(cuda_rscalAdd, result, t, val)
 
-proc `.-`*[T: SomeFloat](t: CudaTensor[T], val: T): CudaTensor[T] {.noInit.} =
+proc `.+`*[T: SomeFloat](t: CudaTensor[T], val: T): CudaTensor[T] {.noInit, inline, deprecated: "Use `+.` instead".} =
+  t +. val
+
+proc `-.`*[T: SomeFloat](t: CudaTensor[T], val: T): CudaTensor[T] {.noInit.} =
   ## Broadcasted substraction for scalar - tensor.
   result = newCudaTensor[T](t.shape)
   cuda_rscal_call(cuda_rscalSub, result, t, val)
 
+proc `.-`*[T: SomeFloat](t: CudaTensor[T], val: T): CudaTensor[T] {.noInit, inline, deprecated: "Use `-.` instead".} =
+  t -. val
 
 cuda_lscal_glue("cuda_lscalSub","LscalSub", cuda_lscalSub)
 cuda_lscal_glue("cuda_lscalAdd","LscalAdd", cuda_lscalAdd)
 cuda_lscal_glue("cuda_lscalDiv","LscalDiv", cuda_lscalDiv)
 
-proc `.+`*[T: SomeFloat](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit.} =
+proc `+.`*[T: SomeFloat](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   ## Broadcasted addition for tensor + scalar.
   result = newCudaTensor[T](t.shape)
   cuda_lscal_call(cuda_lscalAdd, result, val, t)
 
-proc `.-`*[T: SomeFloat](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit.} =
+proc `.+`*[T: SomeFloat](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit, inline, deprecated: "Use `+.` instead".} =
+  val +. t
+
+proc `-.`*[T: SomeFloat](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   ## Broadcasted substraction for tensor - scalar.
   result = newCudaTensor[T](t.shape)
   cuda_lscal_call(cuda_lscalSub, result, val, t)
 
-proc `./`*[T: SomeFloat](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit.} =
+proc `.-`*[T: SomeFloat](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit, inline, deprecated: "Use `-.` instead".} =
+  val -. t
+
+proc `/.`*[T: SomeFloat](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   ## Broadcasted division of a float by a tensor of floats.
   result = newCudaTensor[T](t.shape)
   cuda_lscal_call(cuda_lscalDiv, result, val, t)
+
+proc `./`*[T: SomeFloat](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit, inline, deprecated: "Use `/.` instead".} =
+  val /. t
 
 # ##############################################
 # # Broadcasting in-place Tensor-Scalar
 cuda_assignscal_glue("cuda_mscalSub","mscalSubOp", cuda_mscalSub)
 cuda_assignscal_glue("cuda_mscalAdd","mscalAddOp", cuda_mscalAdd)
 
-proc `.+=`*[T: SomeFloat](t: var CudaTensor[T], val: T) =
+proc `+.=`*[T: SomeFloat](t: var CudaTensor[T], val: T) =
   ## Broadcasted addition for scalar + tensor.
   cuda_assignscal_call(cuda_mscalAdd, t, val)
 
-proc `.-=`*[T: SomeFloat](t: var CudaTensor[T], val: T) =
+proc `.+=`*[T: SomeFloat](t: var CudaTensor[T], val: T) {.noInit, inline, deprecated: "Use `+.=` instead".} =
+  t +.= val
+
+proc `-.=`*[T: SomeFloat](t: var CudaTensor[T], val: T) =
   ## Broadcasted substraction for scalar - tensor.
   cuda_assignscal_call(cuda_mscalSub, t, val)
+
+proc `.-=`*[T: SomeFloat](t: var CudaTensor[T], val: T) {.noInit, inline, deprecated: "Use `-.=` instead".} =
+  t -.= val

--- a/src/tensor/operators_broadcasted_opencl.nim
+++ b/src/tensor/operators_broadcasted_opencl.nim
@@ -28,10 +28,16 @@ proc `+.`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline.} =
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a + tmp_b
 
+proc `.+`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline, deprecated:"Use `+.` instead".} =
+  a +. b
+
 proc `-.`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline.} =
   ## Broadcasted addition for tensors of incompatible but broadcastable shape.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a - tmp_b
+
+proc `.-`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline, deprecated:"Use `-.` instead".} =
+  a -. b
 
 genClInfixOp(float32, "float", elwise_mul, "clMul", "*", exported = false)
 genClInfixOp(float64, "double", elwise_mul, "clAdd", "*", exported = false)
@@ -45,9 +51,15 @@ proc `*.`*[T: SomeFloat](a,b: ClTensor[T]): ClTensor[T] {.noInit.} =
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = elwise_mul(tmp_a, tmp_b)
 
+proc `.*`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline, deprecated:"Use `*.` instead".} =
+  a *. b
+
 proc `./`*[T: SomeFloat](a,b: ClTensor[T]): ClTensor[T] {.noInit.} =
   ## Element-wise multiplication (Hadamard product).
   ##
   ## And broadcasted element-wise multiplication.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = elwise_div(tmp_a, tmp_b)
+
+proc `./`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline, deprecated:"Use `/.` instead".} =
+  a /. b

--- a/src/tensor/operators_broadcasted_opencl.nim
+++ b/src/tensor/operators_broadcasted_opencl.nim
@@ -54,7 +54,7 @@ proc `*.`*[T: SomeFloat](a,b: ClTensor[T]): ClTensor[T] {.noInit.} =
 proc `.*`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline, deprecated:"Use `*.` instead".} =
   a *. b
 
-proc `./`*[T: SomeFloat](a,b: ClTensor[T]): ClTensor[T] {.noInit.} =
+proc `/.`*[T: SomeFloat](a,b: ClTensor[T]): ClTensor[T] {.noInit.} =
   ## Element-wise multiplication (Hadamard product).
   ##
   ## And broadcasted element-wise multiplication.

--- a/src/tensor/operators_broadcasted_opencl.nim
+++ b/src/tensor/operators_broadcasted_opencl.nim
@@ -23,12 +23,12 @@ import  ./backend/opencl_backend,
 # #########################################################
 # # Broadcasting Tensor-Tensor
 # # And element-wise multiplication (Hadamard) and division
-proc `.+`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline.} =
+proc `+.`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline.} =
   ## Broadcasted addition for tensors of incompatible but broadcastable shape.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a + tmp_b
 
-proc `.-`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline.} =
+proc `-.`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline.} =
   ## Broadcasted addition for tensors of incompatible but broadcastable shape.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a - tmp_b
@@ -38,7 +38,7 @@ genClInfixOp(float64, "double", elwise_mul, "clAdd", "*", exported = false)
 genClInfixOp(float32, "float", elwise_div, "clSub", "/", exported = false)
 genClInfixOp(float64, "double", elwise_div, "clSub", "/", exported = false)
 
-proc `.*`*[T: SomeFloat](a,b: ClTensor[T]): ClTensor[T] {.noInit.} =
+proc `*.`*[T: SomeFloat](a,b: ClTensor[T]): ClTensor[T] {.noInit.} =
   ## Element-wise multiplication (Hadamard product).
   ##
   ## And broadcasted element-wise multiplication.

--- a/src/tensor/private/p_kernels_interface_opencl.nim
+++ b/src/tensor/private/p_kernels_interface_opencl.nim
@@ -126,11 +126,11 @@ template genClInfixOp*( T: typedesc,
     export procName
 
 template gen_cl_apply2*(kern_name, ctype, op: string): string =
-  ## Generates an OpenCL kernel for an elementwise in-place binary infix operation (like +=, -=, .*= or ./=)
+  ## Generates an OpenCL kernel for an elementwise in-place binary infix operation (like +=, -=, *.= or ./=)
   ## Input:
   ##   - The C type
   ##   - The C kernel name (this only helps debugging the C code)
-  ##   - The C operation (+=, -=, .*= or ./=)
+  ##   - The C operation (+=, -=, *.= or ./=)
 
   opencl_getIndexOfElementID() & """
   __kernel
@@ -165,13 +165,13 @@ template genClInPlaceOp*( T: typedesc,
                         cInfixOp: string,
                         exported: static[bool] = true): untyped =
   ## Generates an OpenCL kernel for an elementwise in-place binary
-  ## infix operation (like +=, -=, .*= or ./=)
+  ## infix operation (like +=, -=, *.= or ./=)
   ## Input:
   ##   - The Nim type of the elements of the input tensors
   ##   - The equivalent C type
   ##   - The Nim identifier of the resulting proc
   ##   - The C kernel name (this only helps debugging the C code)
-  ##   - The C operation (+=, -=, .*= or ./=)
+  ##   - The C operation (+=, -=, *.= or ./=)
 
   proc procName(dst: var ClTensor[T], src: ClTensor[T]) =
     when compileOption("boundChecks"):

--- a/src/tensor/private/p_kernels_interface_opencl.nim
+++ b/src/tensor/private/p_kernels_interface_opencl.nim
@@ -126,11 +126,11 @@ template genClInfixOp*( T: typedesc,
     export procName
 
 template gen_cl_apply2*(kern_name, ctype, op: string): string =
-  ## Generates an OpenCL kernel for an elementwise in-place binary infix operation (like +=, -=, *.= or ./=)
+  ## Generates an OpenCL kernel for an elementwise in-place binary infix operation (like +=, -=, *.= or /.=)
   ## Input:
   ##   - The C type
   ##   - The C kernel name (this only helps debugging the C code)
-  ##   - The C operation (+=, -=, *.= or ./=)
+  ##   - The C operation (+=, -=, *.= or /.=)
 
   opencl_getIndexOfElementID() & """
   __kernel
@@ -165,13 +165,13 @@ template genClInPlaceOp*( T: typedesc,
                         cInfixOp: string,
                         exported: static[bool] = true): untyped =
   ## Generates an OpenCL kernel for an elementwise in-place binary
-  ## infix operation (like +=, -=, *.= or ./=)
+  ## infix operation (like +=, -=, *.= or /.=)
   ## Input:
   ##   - The Nim type of the elements of the input tensors
   ##   - The equivalent C type
   ##   - The Nim identifier of the resulting proc
   ##   - The C kernel name (this only helps debugging the C code)
-  ##   - The C operation (+=, -=, *.= or ./=)
+  ##   - The C operation (+=, -=, *.= or /.=)
 
   proc procName(dst: var ClTensor[T], src: ClTensor[T]) =
     when compileOption("boundChecks"):

--- a/tests/autograd/test_gate_hadamard.nim
+++ b/tests/autograd/test_gate_hadamard.nim
@@ -25,8 +25,8 @@ suite "Autograd of Hadamard product":
       a = randomTensor([height, width], 1.0)
       b = randomTensor([height, width], 1.0)
 
-    proc hadamard_a(a: Tensor[float64]): float64 = (a .* b).sum()
-    proc hadamard_b(b: Tensor[float64]): float64 = (a .* b).sum()
+    proc hadamard_a(a: Tensor[float64]): float64 = (a *. b).sum()
+    proc hadamard_b(b: Tensor[float64]): float64 = (a *. b).sum()
 
     let # Compute the numerical gradients
       target_grad_a = a.numerical_gradient(hadamard_a)
@@ -37,7 +37,7 @@ suite "Autograd of Hadamard product":
       va = ctx.variable(a, requires_grad = true)
       vb = ctx.variable(b, requires_grad = true)
 
-    let loss = (va .* vb).sum()
+    let loss = (va *. vb).sum()
     loss.backprop()
 
     check:

--- a/tests/end_to_end/examples_run.nim
+++ b/tests/end_to_end/examples_run.nim
@@ -16,12 +16,12 @@ proc ex01() =
   let y = y_bool.astype(float32)
 
   let layer_3neurons = ctx.variable(
-                        randomTensor(3, 2, 2.0f) .- 1.0f,
+                        randomTensor(3, 2, 2.0f) -. 1.0f,
                         true
                         )
 
   let classifier_layer = ctx.variable(
-                    randomTensor(1, 3, 2.0f) .- 1.0f,
+                    randomTensor(1, 3, 2.0f) -. 1.0f,
                     true
                     )
 

--- a/tests/linear_algebra/test_linear_algebra.nim
+++ b/tests/linear_algebra/test_linear_algebra.nim
@@ -403,7 +403,7 @@ suite "Linear algebra":
         Vh.shape[0] == k
         Vh.shape[1] == H.shape[1]
 
-      let reconstructed = (U .* S.unsqueeze(0)) * Vh
+      let reconstructed = (U *. S.unsqueeze(0)) * Vh
       check: H.mean_absolute_error(reconstructed) < 1e-2
 
     block: # Ensure that m > n / m < n logic is working fine
@@ -425,7 +425,7 @@ suite "Linear algebra":
         Vh.shape[0] == k
         Vh.shape[1] == H.shape[1]
 
-      let reconstructed = (U .* S.unsqueeze(0)) * Vh
+      let reconstructed = (U *. S.unsqueeze(0)) * Vh
       check: H.mean_absolute_error(reconstructed) < 1e-2
 
   test "Solve linear equations general matrix":

--- a/tests/ml/test_dimensionality_reduction.nim
+++ b/tests/ml/test_dimensionality_reduction.nim
@@ -38,7 +38,7 @@ suite "[ML] Dimensionality reduction":
                 mean_absolute_error(-projected[_, col], expected[_, col]) < 1e-08
 
       # Projecting the original data with the axes matrix
-      let centered = data .- data.mean(axis=0)
+      let centered = data -. data.mean(axis=0)
       check: projected.mean_absolute_error(centered * components) < 1e-08
 
     block: # https://www.cgg.com/technicaldocuments/cggv_0000014063.pdf
@@ -57,5 +57,5 @@ suite "[ML] Dimensionality reduction":
                 mean_absolute_error(-projected[_, col], expected[_, col]) < 1e-10
 
       # Projecting the original data with the components matrix
-      let centered = data .- data.mean(axis=0)
+      let centered = data -. data.mean(axis=0)
       check: projected.mean_absolute_error(centered * components) < 1e-08

--- a/tests/nn_primitives/test_nnp_maxpool.nim
+++ b/tests/nn_primitives/test_nnp_maxpool.nim
@@ -35,7 +35,7 @@ suite "[NN Primitives] Maxpool":
     proc mpool(t: Tensor[float]): float =
       maxpool2d(t, (2,2), (0,0), (2,2)).maxpooled.sum()
 
-    let expected_grad = a.astype(float) .* numerical_gradient(a.astype(float), mpool)
+    let expected_grad = a.astype(float) *. numerical_gradient(a.astype(float), mpool)
     let grad = maxpool2d_backward(a.shape, max_indices, pooled).astype(float)
 
     check: grad.mean_relative_error(expected_grad) < 1e-6

--- a/tests/tensor/test_broadcasting.nim
+++ b/tests/tensor/test_broadcasting.nim
@@ -23,7 +23,7 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
     let expected_mul_int = @[-8, 0, 27].toTensor()
     let expected_div_int = @[-2, 0, 3].toTensor()
 
-    check: u_int .* v_int == expected_mul_int
+    check: u_int *. v_int == expected_mul_int
     check: u_int ./ v_int == expected_div_int
 
     let u_float = @[1.0, 8.0, -3.0].toTensor()
@@ -31,9 +31,9 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
     let expected_mul_float = @[4.0, 16.0, -30.0].toTensor()
     let expected_div_float = @[0.25, 4.0, -0.3].toTensor()
 
-    check: u_float .* v_float == expected_mul_float
+    check: u_float *. v_float == expected_mul_float
     check: u_float ./ v_float == expected_div_float
-    check: u_float.astype(Complex[float64]) .* v_float.astype(Complex[float64]) == expected_mul_float.astype(Complex[float64])
+    check: u_float.astype(Complex[float64]) *. v_float.astype(Complex[float64]) == expected_mul_float.astype(Complex[float64])
     check: u_float.astype(Complex[float64]) ./ v_float.astype(Complex[float64]) == expected_div_float.astype(Complex[float64])
 
   test "Explicit broadcasting":
@@ -55,16 +55,16 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
       check b == [[1,1],
                   [2,2]].toTensor()
 
-  test "Implicit tensor-tensor broadcasting - basic operations .+, .-, .*, ./, .^":
+  test "Implicit tensor-tensor broadcasting - basic operations +., -., *., ./, .^":
     block: # Addition
       let a = [0, 10, 20, 30].toTensor().reshape(4,1)
       let b = [0, 1, 2].toTensor().reshape(1,3)
 
-      check: a .+ b == [[0, 1, 2],
+      check: a +. b == [[0, 1, 2],
                         [10, 11, 12],
                         [20, 21, 22],
                         [30, 31, 32]].toTensor
-      check: a.astype(Complex[float64]) .+ b.astype(Complex[float64]) == [[0, 1, 2],
+      check: a.astype(Complex[float64]) +. b.astype(Complex[float64]) == [[0, 1, 2],
                         [10, 11, 12],
                         [20, 21, 22],
                         [30, 31, 32]].toTensor.astype(Complex[float64])
@@ -74,11 +74,11 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
       let a = [0, 10, 20, 30].toTensor().reshape(4,1)
       let b = [0, 1, 2].toTensor().reshape(1,3)
 
-      check: a .- b == [[0, -1, -2],
+      check: a -. b == [[0, -1, -2],
                         [10, 9, 8],
                         [20, 19, 18],
                         [30, 29, 28]].toTensor
-      check: a.astype(Complex[float64]) .- b.astype(Complex[float64]) == [[0, -1, -2],
+      check: a.astype(Complex[float64]) -. b.astype(Complex[float64]) == [[0, -1, -2],
                         [10, 9, 8],
                         [20, 19, 18],
                         [30, 29, 28]].toTensor.astype(Complex[float64])
@@ -87,11 +87,11 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
       let a = [0, 10, 20, 30].toTensor().reshape(4,1)
       let b = [0, 1, 2].toTensor().reshape(1,3)
 
-      check: a .* b == [[0, 0, 0],
+      check: a *. b == [[0, 0, 0],
                         [0, 10, 20],
                         [0, 20, 40],
                         [0, 30, 60]].toTensor
-      check: a.astype(Complex[float64]) .* b.astype(Complex[float64]) == [[0, 0, 0],
+      check: a.astype(Complex[float64]) *. b.astype(Complex[float64]) == [[0, 0, 0],
                         [0, 10, 20],
                         [0, 20, 40],
                         [0, 30, 60]].toTensor.astype(Complex[float64])
@@ -145,15 +145,15 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
                           [1.0/20.0],
                           [1.0/30.0]].toTensor.astype(Complex[float64])
 
-  test "Implicit tensor-tensor broadcasting - basic in-place operations .+=, .-=, .*=, ./=":
+  test "Implicit tensor-tensor broadcasting - basic in-place operations +.=, -.=, *.=, ./=":
     block: # Addition
       # Note: We can't broadcast the lhs with in-place operations
       var a = [0, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).asContiguous
       var a_c = [0, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).asContiguous.astype(Complex[float64])
       let b = [0, 1, 2].toTensor().reshape(1,3)
 
-      a .+= b
-      a_c .+= b.astype(Complex[float64])
+      a +.= b
+      a_c +.= b.astype(Complex[float64])
       check: a == [[0, 1, 2],
                   [10, 11, 12],
                   [20, 21, 22],
@@ -169,8 +169,8 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
       var a_c = [0, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).asContiguous.astype(Complex[float64])
       let b = [0, 1, 2].toTensor().reshape(1,3)
 
-      a .-= b
-      a_c .-= b.astype(Complex[float64])
+      a -.= b
+      a_c -.= b.astype(Complex[float64])
       check: a == [[0, -1, -2],
                     [10, 9, 8],
                     [20, 19, 18],
@@ -186,8 +186,8 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
       var a_c = [0, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).asContiguous.astype(Complex[float64])
       let b = [0, 1, 2].toTensor().reshape(1,3)
 
-      a .*= b
-      a_c .*= b.astype(Complex[float64])
+      a *.= b
+      a_c *.= b.astype(Complex[float64])
       check: a == [[0, 0, 0],
                   [0, 10, 20],
                   [0, 20, 40],
@@ -226,13 +226,13 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
                   [15.0, 6, 3]].toTensor.astype(Complex[float64])
 
 
-  test "Implicit tensor-scalar broadcasting - basic operations .+=, .-=, .^=":
+  test "Implicit tensor-scalar broadcasting - basic operations +.=, -.=, .^=":
     block: # Addition
       var a = [0, 10, 20, 30].toTensor().reshape(4,1)
       var a_c = [0, 10, 20, 30].toTensor().reshape(4,1).astype(Complex[float64])
 
-      a .+= 100
-      a_c .+= complex64(100.0, 0.0)
+      a +.= 100
+      a_c +.= complex64(100.0, 0.0)
       check: a == [[100],
                   [110],
                   [120],
@@ -246,8 +246,8 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
       var a = [0, 10, 20, 30].toTensor().reshape(4,1)
       var a_c = [0, 10, 20, 30].toTensor().reshape(4,1).astype(Complex[float64])
 
-      a .-= 100
-      a_c .-= complex64(100.0, 0.0)
+      a -.= 100
+      a_c -.= complex64(100.0, 0.0)
       check: a == [[-100],
                     [-90],
                     [-80],
@@ -285,13 +285,13 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
                     [1.0/20.0],
                     [1.0/30.0]].toTensor.astype(Complex[float64])
 
-  test "Implicit broadcasting - Sigmoid 1 ./ (1 .+ exp(-x)":
+  test "Implicit broadcasting - Sigmoid 1 ./ (1 +. exp(-x)":
     block:
       proc sigmoid[T: SomeFloat](t: Tensor[T]): Tensor[T]=
-        1.T ./ (1.T .+ exp(0.T .- t))
+        1.T ./ (1.T +. exp(0.T -. t))
 
       proc sigmoid(t: Tensor[Complex32]): Tensor[Complex32]=
-        complex32(1) ./ (complex32(1) .+ exp(complex32(0) .- t))
+        complex32(1) ./ (complex32(1) +. exp(complex32(0) -. t))
 
       let a = newTensor[float32]([2,2])
       check: sigmoid(a) == [[0.5'f32, 0.5],[0.5'f32, 0.5]].toTensor

--- a/tests/tensor/test_broadcasting.nim
+++ b/tests/tensor/test_broadcasting.nim
@@ -120,7 +120,7 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
 
     block: # Float division
       var a = [100.0, 10, 20, 30].toTensor().reshape(4,1)
-      a ./= 10.0
+      a /.= 10.0
 
       check: a == [[10.0],
                    [1.0],
@@ -145,7 +145,7 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
                           [1.0/20.0],
                           [1.0/30.0]].toTensor.astype(Complex[float64])
 
-  test "Implicit tensor-tensor broadcasting - basic in-place operations +.=, -.=, *.=, ./=":
+  test "Implicit tensor-tensor broadcasting - basic in-place operations +.=, -.=, *.=, /.=":
     block: # Addition
       # Note: We can't broadcast the lhs with in-place operations
       var a = [0, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).asContiguous
@@ -202,7 +202,7 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
       var a = [100, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).asContiguous
       let b = [2, 5, 10].toTensor().reshape(1,3)
 
-      a ./= b
+      a /.= b
       check: a == [[50, 20, 10],
                   [5, 2, 1],
                   [10, 4, 2],
@@ -214,8 +214,8 @@ suite "Shapeshifting - broadcasting and non linear algebra elementwise operation
       var a_c = [100.0, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).asContiguous.astype(Complex[float64])
       let b = [2.0, 5, 10].toTensor().reshape(1,3)
 
-      a ./= b
-      a_c ./= b.astype(Complex[float64])
+      a /.= b
+      a_c /.= b.astype(Complex[float64])
       check: a == [[50.0, 20, 10],
                   [5.0, 2, 1],
                   [10.0, 4, 2],

--- a/tests/tensor/test_broadcasting_cuda.nim
+++ b/tests/tensor/test_broadcasting_cuda.nim
@@ -23,7 +23,7 @@ suite "CUDA: Shapeshifting - broadcasting and non linear algebra elementwise ope
       let expected_mul = @[-8, 0, 27].toTensor().astype(float32)
       let expected_div = @[-2, 0, 3].toTensor().astype(float32)
 
-      check: (u .* v).cpu == expected_mul
+      check: (u *. v).cpu == expected_mul
       check: (u ./ v).cpu == expected_div
 
     block:
@@ -32,15 +32,15 @@ suite "CUDA: Shapeshifting - broadcasting and non linear algebra elementwise ope
       let expected_mul = @[4.0, 16.0, -30.0].toTensor().astype(float32)
       let expected_div = @[0.25, 4.0, -0.3].toTensor().astype(float32)
 
-      check: (u .* v).cpu == expected_mul
+      check: (u *. v).cpu == expected_mul
       check: (u ./ v).cpu == expected_div
 
-  test "Implicit tensor-tensor broadcasting - basic operations .+, .-, .*, ./, .^":
+  test "Implicit tensor-tensor broadcasting - basic operations +., -., *., ./, .^":
     block: # Addition
       let a = [0, 10, 20, 30].toTensor().reshape(4,1).astype(float32).cuda
       let b = [0, 1, 2].toTensor().reshape(1,3).astype(float32).cuda
 
-      check: (a .+ b).cpu == [[0, 1, 2],
+      check: (a +. b).cpu == [[0, 1, 2],
                               [10, 11, 12],
                               [20, 21, 22],
                               [30, 31, 32]].toTensor.astype(float32)
@@ -49,7 +49,7 @@ suite "CUDA: Shapeshifting - broadcasting and non linear algebra elementwise ope
       let a = [0, 10, 20, 30].toTensor().reshape(4,1).astype(float32).cuda
       let b = [0, 1, 2].toTensor().reshape(1,3).astype(float32).cuda
 
-      check: (a .- b).cpu == [[0, -1, -2],
+      check: (a -. b).cpu == [[0, -1, -2],
                               [10, 9, 8],
                               [20, 19, 18],
                               [30, 29, 28]].toTensor.astype(float32)
@@ -58,7 +58,7 @@ suite "CUDA: Shapeshifting - broadcasting and non linear algebra elementwise ope
       let a = [0, 10, 20, 30].toTensor().reshape(4,1).astype(float32).cuda
       let b = [0, 1, 2].toTensor().reshape(1,3).astype(float32).cuda
 
-      check: (a .* b).cpu == [[0, 0, 0],
+      check: (a *. b).cpu == [[0, 0, 0],
                               [0, 10, 20],
                               [0, 20, 40],
                               [0, 30, 60]].toTensor.astype(float32)
@@ -72,13 +72,13 @@ suite "CUDA: Shapeshifting - broadcasting and non linear algebra elementwise ope
                               [10.0, 4, 2],
                               [15.0, 6, 3]].toTensor
 
-  test "Implicit tensor-tensor broadcasting - basic in-place operations .+=, .-=, .*=, ./=":
+  test "Implicit tensor-tensor broadcasting - basic in-place operations +.=, -.=, *.=, ./=":
     block: # Addition
       # Note: We can't broadcast the lhs with in-place operations
       var a = [0, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).astype(float32).cuda
       let b = [0, 1, 2].toTensor().reshape(1,3).astype(float32).cuda
 
-      a .+= b
+      a +.= b
       check: a.cpu == [[0, 1, 2],
                       [10, 11, 12],
                       [20, 21, 22],
@@ -89,7 +89,7 @@ suite "CUDA: Shapeshifting - broadcasting and non linear algebra elementwise ope
       var a = [0, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).astype(float32).cuda
       let b = [0, 1, 2].toTensor().reshape(1,3).astype(float32).cuda
 
-      a .-= b
+      a -.= b
       check: a.cpu  == [[0, -1, -2],
                     [10, 9, 8],
                     [20, 19, 18],
@@ -100,7 +100,7 @@ suite "CUDA: Shapeshifting - broadcasting and non linear algebra elementwise ope
       var a = [0, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).astype(float32).cuda
       let b = [0, 1, 2].toTensor().reshape(1,3).astype(float32).cuda
 
-      a .*= b
+      a *.= b
       check: a.cpu == [[0, 0, 0],
                       [0, 10, 20],
                       [0, 20, 40],
@@ -128,11 +128,11 @@ suite "CUDA: Shapeshifting - broadcasting and non linear algebra elementwise ope
                       [10.0, 4, 2],
                       [15.0, 6, 3]].toTensor
 
-  test "Implicit tensor-scalar broadcasting - basic operations .+, .-":
+  test "Implicit tensor-scalar broadcasting - basic operations +., -.":
     block: # Addition
       var a = [0, 10, 20, 30].toTensor().reshape(4,1).astype(float32).cuda
 
-      check: (a .+ 100'f32).cpu == [[100],
+      check: (a +. 100'f32).cpu == [[100],
                                     [110],
                                     [120],
                                     [130]].toTensor.astype(float32)
@@ -140,16 +140,16 @@ suite "CUDA: Shapeshifting - broadcasting and non linear algebra elementwise ope
     block: # Substraction
       var a = [0, 10, 20, 30].toTensor().reshape(4,1).astype(float32).cuda
 
-      check: (a .- 100'f32).cpu == [[-100],
+      check: (a -. 100'f32).cpu == [[-100],
                                     [-90],
                                     [-80],
                                     [-70]].toTensor.astype(float32)
 
-  test "Implicit scalar-tensor broadcasting - basic operations .+, .-, ./":
+  test "Implicit scalar-tensor broadcasting - basic operations +., -., ./":
     block: # Addition
       var a = [0, 10, 20, 30].toTensor().reshape(4,1).astype(float32).cuda
 
-      check: (100'f32 .+ a).cpu == [[100],
+      check: (100'f32 +. a).cpu == [[100],
                                     [110],
                                     [120],
                                     [130]].toTensor.astype(float32)
@@ -157,7 +157,7 @@ suite "CUDA: Shapeshifting - broadcasting and non linear algebra elementwise ope
     block: # Substraction
       var a = [0, 10, 20, 30].toTensor().reshape(4,1).astype(float32).cuda
 
-      check: (100'f32 .- a).cpu == [[100],
+      check: (100'f32 -. a).cpu == [[100],
                                     [90],
                                     [80],
                                     [70]].toTensor.astype(float32)
@@ -169,11 +169,11 @@ suite "CUDA: Shapeshifting - broadcasting and non linear algebra elementwise ope
                                     [6],
                                     [4]].toTensor.astype(float32)
 
-  test "Implicit tensor-scalar broadcasting - basic operations .+=, .-=":
+  test "Implicit tensor-scalar broadcasting - basic operations +.=, -.=":
     block: # Addition
       var a = [0, 10, 20, 30].toTensor().reshape(4,1).astype(float32).cuda
 
-      a .+= 100
+      a +.= 100
       check: a.cpu == [[100],
                       [110],
                       [120],
@@ -182,7 +182,7 @@ suite "CUDA: Shapeshifting - broadcasting and non linear algebra elementwise ope
     block: # Substraction
       var a = [0, 10, 20, 30].toTensor().reshape(4,1).astype(float32).cuda
 
-      a .-= 100
+      a -.= 100
       check: a.cpu == [[-100],
                       [-90],
                       [-80],

--- a/tests/tensor/test_broadcasting_cuda.nim
+++ b/tests/tensor/test_broadcasting_cuda.nim
@@ -72,7 +72,7 @@ suite "CUDA: Shapeshifting - broadcasting and non linear algebra elementwise ope
                               [10.0, 4, 2],
                               [15.0, 6, 3]].toTensor
 
-  test "Implicit tensor-tensor broadcasting - basic in-place operations +.=, -.=, *.=, ./=":
+  test "Implicit tensor-tensor broadcasting - basic in-place operations +.=, -.=, *.=, /.=":
     block: # Addition
       # Note: We can't broadcast the lhs with in-place operations
       var a = [0, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).astype(float32).cuda
@@ -111,7 +111,7 @@ suite "CUDA: Shapeshifting - broadcasting and non linear algebra elementwise ope
       var a = [100, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).astype(float32).cuda
       let b = [2, 5, 10].toTensor().reshape(1,3).astype(float32).cuda
 
-      a ./= b
+      a /.= b
       check: a.cpu == [[50, 20, 10],
                       [5, 2, 1],
                       [10, 4, 2],
@@ -122,7 +122,7 @@ suite "CUDA: Shapeshifting - broadcasting and non linear algebra elementwise ope
       var a = [100.0, 10, 20, 30].toTensor().reshape(4,1).bc([4,3]).cuda
       let b = [2.0, 5, 10].toTensor().reshape(1,3).cuda
 
-      a ./= b
+      a /.= b
       check: a.cpu == [[50.0, 20, 10],
                       [5.0, 2, 1],
                       [10.0, 4, 2],

--- a/tests/tensor/test_broadcasting_opencl.nim
+++ b/tests/tensor/test_broadcasting_opencl.nim
@@ -23,7 +23,7 @@ suite "OpenCL: Shapeshifting - broadcasting and non linear algebra elementwise o
       let expected_mul = @[-8, 0, 27].toTensor().astype(float32)
       let expected_div = @[-2, 0, 3].toTensor().astype(float32)
 
-      check: (u .* v).cpu == expected_mul
+      check: (u *. v).cpu == expected_mul
       check: (u ./ v).cpu == expected_div
 
     block:
@@ -32,15 +32,15 @@ suite "OpenCL: Shapeshifting - broadcasting and non linear algebra elementwise o
       let expected_mul = @[4.0, 16.0, -30.0].toTensor().astype(float32)
       let expected_div = @[0.25, 4.0, -0.3].toTensor().astype(float32)
 
-      check: (u .* v).cpu == expected_mul
+      check: (u *. v).cpu == expected_mul
       check: (u ./ v).cpu == expected_div
 
-  test "Implicit tensor-tensor broadcasting - basic operations .+, .-, .*, ./, .^":
+  test "Implicit tensor-tensor broadcasting - basic operations +., -., *., ./, .^":
     block: # Addition
       let a = [0, 10, 20, 30].toTensor().reshape(4,1).astype(float32).opencl
       let b = [0, 1, 2].toTensor().reshape(1,3).astype(float32).opencl
 
-      check: (a .+ b).cpu == [[0, 1, 2],
+      check: (a +. b).cpu == [[0, 1, 2],
                               [10, 11, 12],
                               [20, 21, 22],
                               [30, 31, 32]].toTensor.astype(float32)
@@ -49,7 +49,7 @@ suite "OpenCL: Shapeshifting - broadcasting and non linear algebra elementwise o
       let a = [0, 10, 20, 30].toTensor().reshape(4,1).astype(float32).opencl
       let b = [0, 1, 2].toTensor().reshape(1,3).astype(float32).opencl
 
-      check: (a .- b).cpu == [[0, -1, -2],
+      check: (a -. b).cpu == [[0, -1, -2],
                               [10, 9, 8],
                               [20, 19, 18],
                               [30, 29, 28]].toTensor.astype(float32)
@@ -58,7 +58,7 @@ suite "OpenCL: Shapeshifting - broadcasting and non linear algebra elementwise o
       let a = [0, 10, 20, 30].toTensor().reshape(4,1).astype(float32).opencl
       let b = [0, 1, 2].toTensor().reshape(1,3).astype(float32).opencl
 
-      check: (a .* b).cpu == [[0, 0, 0],
+      check: (a *. b).cpu == [[0, 0, 0],
                               [0, 10, 20],
                               [0, 20, 40],
                               [0, 30, 60]].toTensor.astype(float32)

--- a/tests/tensor/test_operators_blas.nim
+++ b/tests/tensor/test_operators_blas.nim
@@ -448,9 +448,9 @@ suite "BLAS (Basic Linear Algebra Subprograms)":
     check: n1 * n2 == n1n2
 
   test "complex matrix product":
-    # [[1.+1.j, 2.+2.j, 3.+3.j]    [[1.+1.j, 4.+4.j],     [[0. +28.j, 0. +64.j],
-    #  [4.+4.j, 5.+5.j, 6.+6.j]] *  [2.+2.j, 5.+5.j],  ==  [0. +64.j, 0.+154.j]
-    #                               [3.+3.j, 6.+6.j]]
+    # [[1. + 1.j, 2. + 2.j, 3. + 3.j]    [[1. + 1.j, 4. + 4.j],     [[0. + 28.j, 0. + 64.j],
+    #  [4. +4.j, 5. + 5.j, 6. + 6.j]] *  [2. + 2.j, 5. +5.j],  ==  [0. + 64.j, 0. + 154.j]
+    #                               [3. + 3.j, 6. + 6.j]]
     let m1 = [[1,2,3],[4,5,6]].toTensor().astype(Complex[float64])
     let m2 = m1 * complex64(0,1)
     let m3 = m1+m2


### PR DESCRIPTION
This exchanges the dot ordering on broadcasting / elementwise operators

i.e. it is now `+.` and `*.` instead of `.+` and `.*`.
The previous order caused operator precedence issue.

This convention was discussed in the Nim community (IRC) and acted upon:
- in Manu https://github.com/b3liever/manu/commit/ec2242a7b3684363bdc5cee3e9813fe892e9fb76
- in NumericalNim https://github.com/HugoGranstrom/numericalnim/commit/53de465b4aa808237e3928179c76ee6c74241505