### PR TITLE
Deprecation helper

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,14 @@ Arraymancer v0.x.x
 Changes (TODO):
   - Fancy Indexing (#434)
 
+Deprecation
+  - The dot in broadcasting and elementwise operators has changed place. This was not propagated to logical comparison
+    Use `==.`, `!=.`, `<=.`, `<.`, `>=.`, `>.`
+    instead of the previous order `.==`.
+    This allows the broadcasting operators to have the same precedence as the
+    natural operators.
+    This also align Arraymancer with other Nim packages: Manu and NumericalNim
+
 Arraymancer v0.6.0 Jan. 09 2020
 =====================================================
 

--- a/src/nn_dsl/dsl_utils.nim
+++ b/src/nn_dsl/dsl_utils.nim
@@ -5,13 +5,8 @@
 import
   macros, tables,
   ../autograd/autograd,
+  ../private/ast_utils,
   ./dsl_types
-
-template letsGoDeeper =
-  var rTree = node.kind.newTree()
-  for child in node:
-    rTree.add inspect(child)
-  return rTree
 
 proc replaceInputNodes*(self: TopoTable, in_shape: NimNode): NimNode =
   # Args:
@@ -35,19 +30,6 @@ proc replaceInputNodes*(self: TopoTable, in_shape: NimNode): NimNode =
     else:
       letsGoDeeper()
   result = inspect(in_shape)
-
-proc replaceSymsByIdents*(ast: NimNode): NimNode =
-  proc inspect(node: NimNode): NimNode =
-    case node.kind:
-    of {nnkIdent, nnkSym}:
-      return ident($node)
-    of nnkEmpty:
-      return node
-    of nnkLiterals:
-      return node
-    else:
-      letsGoDeeper()
-  result = inspect(ast)
 
 macro ctxSubtype*(context: Context): untyped =
   ## Extract the subtype from a Context

--- a/src/private/ast_utils.nim
+++ b/src/private/ast_utils.nim
@@ -50,3 +50,22 @@ proc pop*(tree: var NimNode): NimNode {. compileTime .}=
 macro getSubType*(TT: typedesc): untyped =
   # Get the subtype T of an AnyTensor[T] input
   getTypeInst(TT)[1][1]
+
+template letsGoDeeper* =
+  var rTree = node.kind.newTree()
+  for child in node:
+    rTree.add inspect(child)
+  return rTree
+
+proc replaceSymsByIdents*(ast: NimNode): NimNode =
+  proc inspect(node: NimNode): NimNode =
+    case node.kind:
+    of {nnkIdent, nnkSym}:
+      return ident($node)
+    of nnkEmpty:
+      return node
+    of nnkLiterals:
+      return node
+    else:
+      letsGoDeeper()
+  result = inspect(ast)

--- a/src/private/deprecate.nim
+++ b/src/private/deprecate.nim
@@ -1,0 +1,69 @@
+# Copyright 2017-2020 Mamy André-Ratsimbazafy
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import macros
+
+# Handle deprecation and replacement
+# --------------------------------------------------------------------------------------
+
+macro implDeprecatedBy*(procName: untyped, replacement: typed{nkSym}): untyped =
+  ## Implement a proc that is deprecated
+  let impl = replacement.getImpl()
+  impl.expectKind {nnkProcDef, nnkFuncDef}
+
+  impl[3].expectKind nnkFormalParams
+  var
+    params = @[impl[3][0]] # Return value
+    body = newCall(replacement)
+
+  for idx in 1 ..< impl[3].len:
+    params.add impl[3][idx]
+    body.add impl[3][idx][0]
+
+  impl[4].expectKind({nnkEmpty, nnkPragma})
+  var pragmas = impl[4]
+  if pragmas.kind == nnkEmpty:
+    pragmas = nnkPragma.newTree()
+
+  pragmas.add ident"inline"
+  pragmas.add ident"noInit"
+  pragmas.add nnkExprColonExpr.newTree(
+    ident"deprecated",
+    newLit("Use `" & $replacement & "` instead")
+  )
+
+  result = newProc(
+    name = procName,
+    params = params,
+    body = body,
+    procType = nnkProcDef,
+    pragmas = pragmas
+  )
+
+  when false:
+    # View proc signature.
+    echo result.toStrLit
+
+# Sanity check
+# -----------------------------------------------
+
+when isMainModule:
+
+  proc foo(x: int): int =
+    result = x + 2
+
+  implDeprecatedBy(bar, foo)
+
+  let z = bar(10)
+  echo z

--- a/src/private/deprecate.nim
+++ b/src/private/deprecate.nim
@@ -12,58 +12,104 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import macros
+import macros, ./ast_utils
 
 # Handle deprecation and replacement
 # --------------------------------------------------------------------------------------
 
-macro implDeprecatedBy*(procName: untyped, replacement: typed{nkSym}): untyped =
-  ## Implement a proc that is deprecated
+proc overloadSingleSym(oldName, replacement: NimNode, exported: bool): NimNode =
   let impl = replacement.getImpl()
   impl.expectKind {nnkProcDef, nnkFuncDef}
 
   impl[3].expectKind nnkFormalParams
-  var
-    params = @[impl[3][0]] # Return value
-    body = newCall(replacement)
+  let cleanedParams = impl[3].replaceSymsByIdents()
 
-  for idx in 1 ..< impl[3].len:
-    params.add impl[3][idx]
-    body.add impl[3][idx][0]
+  var body = newCall(replacement)
+
+  for paramIdx in 1 ..< cleanedParams.len:
+    for identIdx in 0 ..< cleanedParams[paramIdx].len - 2:
+      body.add cleanedParams[paramIdx][identIdx]
 
   impl[4].expectKind({nnkEmpty, nnkPragma})
   var pragmas = impl[4]
   if pragmas.kind == nnkEmpty:
     pragmas = nnkPragma.newTree()
 
-  pragmas.add ident"inline"
-  pragmas.add ident"noInit"
+  # pragmas.add ident"inline"
+  # pragmas.add ident"noInit"
   pragmas.add nnkExprColonExpr.newTree(
     ident"deprecated",
     newLit("Use `" & $replacement & "` instead")
   )
 
-  result = newProc(
-    name = procName,
-    params = params,
-    body = body,
-    procType = nnkProcDef,
-    pragmas = pragmas
+  # Generic params
+  var generics = newEmptyNode()
+  if impl[2].kind != nnkEmpty:
+    generics = nnkGenericParams.newTree()
+    for genParam in impl[2]:
+      if genParam.kind == nnkSym: # Bound symbol
+        generics.add nnkIdentDefs.newTree(
+          genParam.replaceSymsByIdents(),
+          newEmptyNode(),
+          newEmptyNode()
+        )
+      else: # unbound - can this happen?
+        genParam.expectKind(nnkIdentDefs)
+
+  let name = if exported: nnkPostFix.newTree(ident"*", oldName)
+            else: oldName
+
+  result = nnkProcDef.newTree(
+    name,
+    newEmptyNode(),  # Term-rewriting
+    generics,        # Generic param
+    cleanedParams,
+    pragmas,
+    newEmptyNode(),  # Reserved for future use
+    body
   )
+
+macro implDeprecatedBy*(oldName: untyped, replacement: typed, exported: static bool): untyped =
+  ## Implement a proc that is deprecated
+  if replacement.kind == nnkSym:
+    result = overloadSingleSym(oldName, replacement, exported)
+  else:
+    replacement.expectKind(nnkClosedSymChoice)
+    result = newStmtList()
+    for overload in replacement:
+      result.add overloadSingleSym(oldName, overload, exported)
 
   when false:
     # View proc signature.
-    echo result.toStrLit
+    echo result.treerepr
 
 # Sanity check
 # -----------------------------------------------
 
 when isMainModule:
+  block:
+    proc foo(x: int): int =
+      result = x + 2
 
-  proc foo(x: int): int =
-    result = x + 2
+    implDeprecatedBy(bar, foo, exported = false)
 
-  implDeprecatedBy(bar, foo)
+    let z = bar(10)
+    echo z
 
-  let z = bar(10)
-  echo z
+  block:
+    proc foo[T](x: T): T =
+      result = x + 2
+
+    implDeprecatedBy(bar, foo, exported = false)
+
+    let z = bar(10)
+    echo z
+
+  block:
+    proc foo[T](x, y: T): T =
+      result = x + y + 2
+
+    implDeprecatedBy(bar, foo, exported = false)
+
+    let z = bar(10, 100)
+    echo z

--- a/src/tensor/operators_broadcasted.nim
+++ b/src/tensor/operators_broadcasted.nim
@@ -122,9 +122,9 @@ proc `/.`*[T: SomeNumber|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]
 proc `/.`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
   ## Broadcasted division
   when T is SomeInteger:
-    result = t.map_inline(val div x)
+    result = t.map_inline(x div val)
   else:
-    result = t.map_inline(val / x)
+    result = t.map_inline(x / val)
 
 proc `^.`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T], exponent: T): Tensor[T] {.noInit.} =
   ## Compute element-wise exponentiation

--- a/src/tensor/operators_broadcasted.nim
+++ b/src/tensor/operators_broadcasted.nim
@@ -15,7 +15,8 @@
 import  ./data_structure,
         ./higher_order_applymap,
         ./shapeshifting,
-        ./math
+        ./math,
+        ../private/deprecate
 import complex except Complex64, Complex32
 
 # #########################################################
@@ -27,16 +28,10 @@ proc `+.`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Te
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a + tmp_b
 
-proc `.+`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit,inline,deprecated:"Use `+.` instead".} =
-  a +. b
-
 proc `-.`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit,inline.} =
   ## Broadcasted addition for tensors of incompatible but broadcastable shape.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a - tmp_b
-
-proc `.-`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit,inline,deprecated:"Use `-.` instead".} =
-  a -. b
 
 proc `*.`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Element-wise multiplication (Hadamard product).
@@ -46,28 +41,15 @@ proc `*.`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Te
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = map2_inline(tmp_a, tmp_b, x * y)
 
-proc `.*`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit,inline,deprecated:"Use `*.` instead".} =
-  a *. b
-
-proc `/.`*[T: SomeInteger](a, b: Tensor[T]): Tensor[T] {.noInit.} =
-  ## Tensor element-wise division for integer numbers.
+proc `/.`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit.} =
+  ## Tensor element-wise division
   ##
   ## And broadcasted element-wise division.
   let (tmp_a, tmp_b) = broadcast2(a, b)
-  result = map2_inline(tmp_a, tmp_b, x div y)
-
-proc `/.`*[T: SomeFloat|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit.} =
-  ## Tensor element-wise division for real numbers.
-  ##
-  ## And broadcasted element-wise division.
-  let (tmp_a, tmp_b) = broadcast2(a, b)
-  result = map2_inline(tmp_a, tmp_b, x / y )
-
-proc `./`*[T: SomeInteger](a, b: Tensor[T]): Tensor[T] {.noInit,inline,deprecated:"Use `/.` instead".} =
-  a /. b
-
-proc `./`*[T: SomeFloat|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Tensor[T] {.noInit,inline,deprecated:"Use `/.` instead".} =
-  a /. b
+  when T is SomeInteger:
+    result = map2_inline(tmp_a, tmp_b, x div y )
+  else:
+    result = map2_inline(tmp_a, tmp_b, x / y )
 
 # ##############################################
 # # Broadcasting in-place Tensor-Tensor
@@ -81,9 +63,6 @@ proc `+.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b
   let tmp_b = b.broadcast(a.shape)
   apply2_inline(a, tmp_b, x + y)
 
-proc `.+=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) {.inline,deprecated:"Use `+.=` instead".}=
-  a +.= b
-
 proc `-.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
   ## Tensor broadcasted in-place substraction.
   ##
@@ -92,9 +71,6 @@ proc `-.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b
 
   let tmp_b = b.broadcast(a.shape)
   apply2_inline(a, tmp_b, x - y)
-
-proc `.-=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) {.inline,deprecated:"Use `-.=` instead".}=
-  a -.= b
 
 proc `*.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
   ## Tensor broadcasted in-place multiplication (Hadamard product)
@@ -105,32 +81,17 @@ proc `*.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b
   let tmp_b = b.broadcast(a.shape)
   apply2_inline(a, tmp_b, x * y)
 
-proc `.*=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) {.inline,deprecated:"Use `*.=` instead".}=
-  a *.= b
-
-proc `/.=`*[T: SomeInteger](a: var Tensor[T], b: Tensor[T]) =
-  ## Tensor broadcasted in-place integer division.
+proc `/.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
+  ## Tensor broadcasted in-place division.
   ##
   ## Only the right hand side tensor can be broadcasted.
   # shape check done in apply2 proc
 
   let tmp_b = b.broadcast(a.shape)
-  apply2_inline(a, tmp_b, x div y)
-
-proc `/.=`*[T: SomeFloat|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) =
-  ## Tensor broadcasted in-place float division.
-  ##
-  ## Only the right hand side tensor can be broadcasted.
-  # shape check done in apply2 proc
-
-  let tmp_b = b.broadcast(a.shape)
-  apply2_inline(a, tmp_b, x / y)
-
-proc `./=`*[T: SomeInteger](a: var Tensor[T], b: Tensor[T]) {.inline,deprecated:"Use `/.=` instead".}=
-  a /.= b
-
-proc `./=`*[T: SomeFloat|Complex[float32]|Complex[float64]](a: var Tensor[T], b: Tensor[T]) {.inline,deprecated:"Use `/.=` instead".}=
-  a /.= b
+  when T is SomeInteger:
+    apply2_inline(a, tmp_b, x div y)
+  else:
+    apply2_inline(a, tmp_b, x / y)
 
 # ##############################################
 # # Broadcasting Tensor-Scalar and Scalar-Tensor
@@ -139,69 +100,35 @@ proc `+.`*[T: SomeNumber|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]
   ## Broadcasted addition for tensor + scalar.
   result = t.map_inline(x + val)
 
-proc `.+`*[T: SomeNumber|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noInit, deprecated:"Use `+.` instead".} =
-  val +. t
-
 proc `+.`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
   ## Broadcasted addition for scalar + tensor.
   result = t.map_inline(x + val)
-
-proc `.+`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit, deprecated:"Use `+.` instead".} =
-  t +. val
 
 proc `-.`*[T: SomeNumber|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Broadcasted substraction for tensor - scalar.
   result = t.map_inline(val - x)
 
-proc `.-`*[T: SomeNumber|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noInit, deprecated:"Use `-.` instead".} =
-  val -. t
-
 proc `-.`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
   ## Broadcasted substraction for scalar - tensor.
   result = t.map_inline(x - val)
 
-proc `.-`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit, deprecated:"Use `-.` instead".} =
-  t -. val
+proc `/.`*[T: SomeNumber|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
+  ## Broadcasted division
+  when T is SomeInteger:
+    result = t.map_inline(val div x)
+  else:
+    result = t.map_inline(val / x)
 
-proc `/.`*[T: SomeInteger](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
-  ## Broadcasted division of an integer by a tensor of integers.
-  result = t.map_inline(val div x)
-
-proc `/.`*[T: SomeFloat|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noInit.} =
-  ## Broadcasted division of a float by a tensor of floats.
-  result = t.map_inline(val / x)
-
-proc `/.`*[T: SomeInteger](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
-  ## Broadcasted division of tensor of integers by an integer.
-  result = t.map_inline(x div val)
-
-proc `/.`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
-  ## Broadcasted division of a tensor of floats by a float.
-  result = t.map_inline(x / val)
-
-proc `./`*[T: SomeInteger](val: T, t: Tensor[T]): Tensor[T] {.noInit, deprecated:"Use `/.` instead".} =
-  ## Broadcasted division of an integer by a tensor of integers.
-  val /. t
-
-proc `./`*[T: SomeFloat|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noInit, deprecated:"Use `/.` instead".} =
-  ## Broadcasted division of a float by a tensor of floats.
-  val /. t
-
-proc `./`*[T: SomeInteger](t: Tensor[T], val: T): Tensor[T] {.noInit, deprecated:"Use `/.` instead".} =
-  ## Broadcasted division of tensor of integers by an integer.
-  t /. val
-
-proc `./`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit, deprecated:"Use `/.` instead".} =
-  ## Broadcasted division of a tensor of floats by a float.
-  t /. val
+proc `/.`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noInit.} =
+  ## Broadcasted division
+  when T is SomeInteger:
+    result = t.map_inline(val div x)
+  else:
+    result = t.map_inline(val / x)
 
 proc `^.`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T], exponent: T): Tensor[T] {.noInit.} =
   ## Compute element-wise exponentiation
   result = t.map_inline pow(x, exponent)
-
-proc `.^`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T], exponent: T): Tensor[T] {.noInit, deprecated:"Use `^.` instead".} =
-  ## Compute element-wise exponentiation
-  t ^. exponent
 
 # #####################################
 # # Broadcasting in-place Tensor-Scalar
@@ -210,34 +137,34 @@ proc `+.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], v
   ## Tensor in-place addition with a broadcasted scalar.
   t.apply_inline(x + val)
 
-proc `.+=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) {.deprecated:"Use `+.=` instead".}=
-  t +.= val
-
 proc `-.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
   ## Tensor in-place substraction with a broadcasted scalar.
   t.apply_inline(x - val)
-
-proc `.-=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) {.deprecated:"Use `-.=` instead".}=
-  t -.= val
 
 proc `^.=`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: var Tensor[T], exponent: T) =
   ## Compute in-place element-wise exponentiation
   t.apply_inline pow(x, exponent)
 
-proc `.^=`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: var Tensor[T], exponent: T) {.deprecated:"Use `^.=` instead".}=
-  ## Compute in-place element-wise exponentiation
-  t ^.= exponent
-
 proc `*.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
   ## Tensor in-place multiplication with a broadcasted scalar.
   t.apply_inline(x * val)
-
-proc `.*=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) {.deprecated:"Use `*.=` instead".}=
-  t *.= val
 
 proc `/.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
   ## Tensor in-place division with a broadcasted scalar.
   t.apply_inline(x / val)
 
-proc `./=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) {.deprecated:"Use `/.=` instead".}=
-  t /.= val
+
+# ##############################################
+# Deprecated syntax
+
+implDeprecatedBy(`.+`, `+.`, exported = true)
+implDeprecatedBy(`.-`, `-.`, exported = true)
+implDeprecatedBy(`.*`, `*.`, exported = true)
+implDeprecatedBy(`./`, `/.`, exported = true)
+implDeprecatedBy(`.^`, `^.`, exported = true)
+
+implDeprecatedBy(`.=+`, `+.=`, exported = true)
+implDeprecatedBy(`.=-`, `-.=`, exported = true)
+implDeprecatedBy(`.=*`, `*.=`, exported = true)
+implDeprecatedBy(`.=/`, `/.=`, exported = true)
+implDeprecatedBy(`.^=`, `^.=`, exported = true)

--- a/src/tensor/operators_broadcasted_cuda.nim
+++ b/src/tensor/operators_broadcasted_cuda.nim
@@ -22,6 +22,8 @@ include ./private/incl_accessors_cuda,
         ./private/incl_higher_order_cuda,
         ./private/incl_kernels_cuda
 
+import ../private/deprecate
+
 # #########################################################
 # # Broadcasting Tensor-Tensor
 # # And element-wise multiplication (Hadamard) and division
@@ -33,16 +35,10 @@ proc `+.`*[T: SomeFloat](a, b: CudaTensor[T]): CudaTensor[T] {.noInit,inline.} =
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a + tmp_b
 
-proc `.+`*[T: SomeFloat](a, b: CudaTensor[T]): CudaTensor[T] {.noInit,inline, deprecated: "Use `+.` instead".} =
-  a +. b
-
 proc `-.`*[T: SomeFloat](a, b: CudaTensor[T]): CudaTensor[T] {.noInit,inline.} =
   ## Broadcasted addition for tensors of incompatible but broadcastable shape.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a - tmp_b
-
-proc `.-`*[T: SomeFloat](a, b: CudaTensor[T]): CudaTensor[T] {.noInit,inline, deprecated: "Use `-.` instead".} =
-  a -. b
 
 proc `*.`*[T: SomeFloat](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   ## Element-wise multiplication (Hadamard product).
@@ -54,10 +50,7 @@ proc `*.`*[T: SomeFloat](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   result = newCudaTensor[T](tmp_a.shape)
   cuda_binary_call(cuda_Mul, result, tmp_a, tmp_b)
 
-proc `.*`*[T: SomeFloat](a,b: CudaTensor[T]): CudaTensor[T] {.noInit, inline, deprecated: "Use `*.` instead".} =
-  a *. b
-
-proc `/.`*[T: SomeFloat](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
+proc `/.`*[T: SomeFloat](a, b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   ## CudaTensor substraction
 
   let (tmp_a, tmp_b) = broadcast2(a, b)
@@ -65,8 +58,6 @@ proc `/.`*[T: SomeFloat](a,b: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   result = newCudaTensor[T](tmp_a.shape)
   cuda_binary_call(cuda_Div, result, tmp_a, tmp_b)
 
-proc `./`*[T: SomeFloat](a,b: CudaTensor[T]): CudaTensor[T] {.noInit, inline, deprecated: "Use `/.` instead".} =
-  a /. b
 
 # ##############################################
 # # Broadcasting in-place Tensor-Tensor
@@ -83,9 +74,6 @@ proc `+.=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   let tmp_b = b.broadcast(a.shape)
   a += tmp_b
 
-proc `.+=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) {.inline, deprecated: "Use `+.=` instead".} =
-  a +.= b
-
 proc `-.=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   ## Tensor broadcasted in-place substraction.
   ##
@@ -94,9 +82,6 @@ proc `-.=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
 
   let tmp_b = b.broadcast(a.shape)
   a -= tmp_b
-
-proc `.-=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) {.inline, deprecated: "Use `-.=` instead".} =
-  a -.= b
 
 proc `*.=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   ## Tensor broadcasted in-place multiplication (Hadamard product)
@@ -107,9 +92,6 @@ proc `*.=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   let tmp_b = b.broadcast(a.shape)
   cuda_assign_call(cuda_mMulOp, a, tmp_b)
 
-proc `.*=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) {.inline, deprecated: "Use `*.=` instead".} =
-  a .*= b
-
 proc `/.=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   ## Tensor broadcasted in-place float division.
   ##
@@ -119,8 +101,6 @@ proc `/.=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) =
   let tmp_b = b.broadcast(a.shape)
   cuda_assign_call(cuda_mDivOp, a, tmp_b)
 
-proc `./=`*[T: SomeFloat](a: var CudaTensor[T], b: CudaTensor[T]) {.inline, deprecated: "Use `/.=` instead".} =
-  a /.= b
 
 # ##############################################
 # # Broadcasting Tensor-Scalar and Scalar-Tensor
@@ -133,16 +113,10 @@ proc `+.`*[T: SomeFloat](t: CudaTensor[T], val: T): CudaTensor[T] {.noInit.} =
   result = newCudaTensor[T](t.shape)
   cuda_rscal_call(cuda_rscalAdd, result, t, val)
 
-proc `.+`*[T: SomeFloat](t: CudaTensor[T], val: T): CudaTensor[T] {.noInit, inline, deprecated: "Use `+.` instead".} =
-  t +. val
-
 proc `-.`*[T: SomeFloat](t: CudaTensor[T], val: T): CudaTensor[T] {.noInit.} =
   ## Broadcasted substraction for scalar - tensor.
   result = newCudaTensor[T](t.shape)
   cuda_rscal_call(cuda_rscalSub, result, t, val)
-
-proc `.-`*[T: SomeFloat](t: CudaTensor[T], val: T): CudaTensor[T] {.noInit, inline, deprecated: "Use `-.` instead".} =
-  t -. val
 
 cuda_lscal_glue("cuda_lscalSub","LscalSub", cuda_lscalSub)
 cuda_lscal_glue("cuda_lscalAdd","LscalAdd", cuda_lscalAdd)
@@ -153,24 +127,16 @@ proc `+.`*[T: SomeFloat](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   result = newCudaTensor[T](t.shape)
   cuda_lscal_call(cuda_lscalAdd, result, val, t)
 
-proc `.+`*[T: SomeFloat](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit, inline, deprecated: "Use `+.` instead".} =
-  val +. t
-
 proc `-.`*[T: SomeFloat](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   ## Broadcasted substraction for tensor - scalar.
   result = newCudaTensor[T](t.shape)
   cuda_lscal_call(cuda_lscalSub, result, val, t)
-
-proc `.-`*[T: SomeFloat](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit, inline, deprecated: "Use `-.` instead".} =
-  val -. t
 
 proc `/.`*[T: SomeFloat](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit.} =
   ## Broadcasted division of a float by a tensor of floats.
   result = newCudaTensor[T](t.shape)
   cuda_lscal_call(cuda_lscalDiv, result, val, t)
 
-proc `./`*[T: SomeFloat](val: T, t: CudaTensor[T]): CudaTensor[T] {.noInit, inline, deprecated: "Use `/.` instead".} =
-  val /. t
 
 # ##############################################
 # # Broadcasting in-place Tensor-Scalar
@@ -181,12 +147,19 @@ proc `+.=`*[T: SomeFloat](t: var CudaTensor[T], val: T) =
   ## Broadcasted addition for scalar + tensor.
   cuda_assignscal_call(cuda_mscalAdd, t, val)
 
-proc `.+=`*[T: SomeFloat](t: var CudaTensor[T], val: T) {.inline, deprecated: "Use `+.=` instead".} =
-  t +.= val
-
 proc `-.=`*[T: SomeFloat](t: var CudaTensor[T], val: T) =
   ## Broadcasted substraction for scalar - tensor.
   cuda_assignscal_call(cuda_mscalSub, t, val)
 
-proc `.-=`*[T: SomeFloat](t: var CudaTensor[T], val: T) {.inline, deprecated: "Use `-.=` instead".} =
-  t -.= val
+# ##############################################
+# Deprecated syntax
+
+implDeprecatedBy(`.+`, `+.`, exported = true)
+implDeprecatedBy(`.-`, `-.`, exported = true)
+implDeprecatedBy(`.*`, `*.`, exported = true)
+implDeprecatedBy(`./`, `/.`, exported = true)
+
+implDeprecatedBy(`.=+`, `+.=`, exported = true)
+implDeprecatedBy(`.=-`, `-.=`, exported = true)
+implDeprecatedBy(`.=*`, `*.=`, exported = true)
+implDeprecatedBy(`.=/`, `/.=`, exported = true)

--- a/src/tensor/operators_broadcasted_opencl.nim
+++ b/src/tensor/operators_broadcasted_opencl.nim
@@ -18,7 +18,8 @@ import  ./backend/opencl_backend,
         ./private/p_checks,
         ./data_structure,
         ./shapeshifting_opencl,
-        ./operators_blas_l1_opencl
+        ./operators_blas_l1_opencl,
+        ../private/deprecate
 
 # #########################################################
 # # Broadcasting Tensor-Tensor
@@ -28,16 +29,10 @@ proc `+.`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline.} =
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a + tmp_b
 
-proc `.+`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline, deprecated:"Use `+.` instead".} =
-  a +. b
-
 proc `-.`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline.} =
   ## Broadcasted addition for tensors of incompatible but broadcastable shape.
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = tmp_a - tmp_b
-
-proc `.-`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline, deprecated:"Use `-.` instead".} =
-  a -. b
 
 genClInfixOp(float32, "float", elwise_mul, "clMul", "*", exported = false)
 genClInfixOp(float64, "double", elwise_mul, "clAdd", "*", exported = false)
@@ -51,9 +46,6 @@ proc `*.`*[T: SomeFloat](a,b: ClTensor[T]): ClTensor[T] {.noInit.} =
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = elwise_mul(tmp_a, tmp_b)
 
-proc `.*`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline, deprecated:"Use `*.` instead".} =
-  a *. b
-
 proc `/.`*[T: SomeFloat](a,b: ClTensor[T]): ClTensor[T] {.noInit.} =
   ## Element-wise multiplication (Hadamard product).
   ##
@@ -61,5 +53,11 @@ proc `/.`*[T: SomeFloat](a,b: ClTensor[T]): ClTensor[T] {.noInit.} =
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = elwise_div(tmp_a, tmp_b)
 
-proc `./`*[T: SomeFloat](a, b: ClTensor[T]): ClTensor[T] {.noInit,inline, deprecated:"Use `/.` instead".} =
-  a /. b
+
+# ##############################################
+# Deprecated syntax
+
+implDeprecatedBy(`.+`, `+.`, exported = true)
+implDeprecatedBy(`.-`, `-.`, exported = true)
+implDeprecatedBy(`.*`, `*.`, exported = true)
+implDeprecatedBy(`./`, `/.`, exported = true)

--- a/src/tensor/operators_comparison.nim
+++ b/src/tensor/operators_comparison.nim
@@ -14,7 +14,8 @@
 
 import ./data_structure, ./accessors,
         ./higher_order_applymap,
-        ./shapeshifting
+        ./shapeshifting,
+        ../private/deprecate
 
 proc `==`*[T](a,b: Tensor[T]): bool {.noSideEffect.}=
   ## Tensor comparison
@@ -36,7 +37,7 @@ template gen_broadcasted_comparison(op: untyped): untyped {.dirty.}=
   result = map2_inline(tmp_a, tmp_b):
     op(x, y)
 
-proc `.==`*[T](a, b: Tensor[T]): Tensor[bool] {.noInit.} =
+proc `==.`*[T](a, b: Tensor[T]): Tensor[bool] {.noInit.} =
   ## Tensor element-wise equality.
   ##
   ## And broadcasted element-wise equality.
@@ -46,7 +47,7 @@ proc `.==`*[T](a, b: Tensor[T]): Tensor[bool] {.noInit.} =
   gen_broadcasted_comparison(`==`)
 
 
-proc `.!=`*[T](a, b: Tensor[T]): Tensor[bool] {.noInit.} =
+proc `!=.`*[T](a, b: Tensor[T]): Tensor[bool] {.noInit.} =
   ## Tensor element-wise inequality.
   ##
   ## And broadcasted element-wise inequality.
@@ -55,7 +56,7 @@ proc `.!=`*[T](a, b: Tensor[T]): Tensor[bool] {.noInit.} =
   ##   - A tensor of boolean
   gen_broadcasted_comparison(`!=`)
 
-proc `.<=`*[T](a, b: Tensor[T]): Tensor[bool] {.noInit.} =
+proc `<=.`*[T](a, b: Tensor[T]): Tensor[bool] {.noInit.} =
   ## Tensor element-wise lesser or equal.
   ##
   ## And broadcasted element-wise lesser or equal.
@@ -64,7 +65,7 @@ proc `.<=`*[T](a, b: Tensor[T]): Tensor[bool] {.noInit.} =
   ##   - A tensor of boolean
   gen_broadcasted_comparison(`<=`)
 
-proc `.<`*[T](a, b: Tensor[T]): Tensor[bool] {.noInit.} =
+proc `<.`*[T](a, b: Tensor[T]): Tensor[bool] {.noInit.} =
   ## Tensor element-wise lesser than.
   ##
   ## And broadcasted element-wise lesser than.
@@ -73,7 +74,7 @@ proc `.<`*[T](a, b: Tensor[T]): Tensor[bool] {.noInit.} =
   ##   - A tensor of boolean
   gen_broadcasted_comparison(`<`)
 
-proc `.>=`*[T](a, b: Tensor[T]): Tensor[bool] {.noInit.} =
+proc `>=.`*[T](a, b: Tensor[T]): Tensor[bool] {.noInit.} =
   ## Tensor element-wise greater or equal.
   ##
   ## And broadcasted element-wise greater or equal.
@@ -82,7 +83,7 @@ proc `.>=`*[T](a, b: Tensor[T]): Tensor[bool] {.noInit.} =
   ##   - A tensor of boolean
   gen_broadcasted_comparison(`>=`)
 
-proc `.>`*[T](a, b: Tensor[T]): Tensor[bool] {.noInit.} =
+proc `>.`*[T](a, b: Tensor[T]): Tensor[bool] {.noInit.} =
   ## Tensor element-wise greater than.
   ##
   ## And broadcasted element-wise greater than.
@@ -90,6 +91,13 @@ proc `.>`*[T](a, b: Tensor[T]): Tensor[bool] {.noInit.} =
   ## Returns:
   ##   - A tensor of boolean
   gen_broadcasted_comparison(`>`)
+
+implDeprecatedBy(`.==`, `==.`, exported = true)
+implDeprecatedBy(`.!=`, `!=.`, exported = true)
+implDeprecatedBy(`.<=`, `<=.`, exported = true)
+implDeprecatedBy(`.<`, `<.`, exported = true)
+implDeprecatedBy(`.>=`, `>=.`, exported = true)
+implDeprecatedBy(`.>`, `>.`, exported = true)
 
 # ######################
 # broadcasted scalar ops

--- a/tests/tensor/test_broadcasting_cuda.nim
+++ b/tests/tensor/test_broadcasting_cuda.nim
@@ -24,7 +24,7 @@ suite "CUDA: Shapeshifting - broadcasting and non linear algebra elementwise ope
       let expected_div = @[-2, 0, 3].toTensor().astype(float32)
 
       check: (u *. v).cpu == expected_mul
-      check: (u ./ v).cpu == expected_div
+      check: (u /. v).cpu == expected_div
 
     block:
       let u = @[1.0, 8.0, -3.0].toTensor().astype(float32).cuda
@@ -33,7 +33,7 @@ suite "CUDA: Shapeshifting - broadcasting and non linear algebra elementwise ope
       let expected_div = @[0.25, 4.0, -0.3].toTensor().astype(float32)
 
       check: (u *. v).cpu == expected_mul
-      check: (u ./ v).cpu == expected_div
+      check: (u /. v).cpu == expected_div
 
   test "Implicit tensor-tensor broadcasting - basic operations +., -., *., ./, .^":
     block: # Addition
@@ -67,7 +67,7 @@ suite "CUDA: Shapeshifting - broadcasting and non linear algebra elementwise ope
       let a = [100.0, 10, 20, 30].toTensor().reshape(4,1).cuda
       let b = [2.0, 5, 10].toTensor().reshape(1,3).cuda
 
-      check: (a ./ b).cpu == [[50.0, 20, 10],
+      check: (a /. b).cpu == [[50.0, 20, 10],
                               [5.0, 2, 1],
                               [10.0, 4, 2],
                               [15.0, 6, 3]].toTensor
@@ -165,7 +165,7 @@ suite "CUDA: Shapeshifting - broadcasting and non linear algebra elementwise ope
     block: # Division
       var a = [10, 20, 30].toTensor().reshape(3,1).astype(float32).cuda
 
-      check: (120'f32 ./ a).cpu == [[12],
+      check: (120'f32 /. a).cpu == [[12],
                                     [6],
                                     [4]].toTensor.astype(float32)
 

--- a/tests/tensor/test_broadcasting_opencl.nim
+++ b/tests/tensor/test_broadcasting_opencl.nim
@@ -24,7 +24,7 @@ suite "OpenCL: Shapeshifting - broadcasting and non linear algebra elementwise o
       let expected_div = @[-2, 0, 3].toTensor().astype(float32)
 
       check: (u *. v).cpu == expected_mul
-      check: (u ./ v).cpu == expected_div
+      check: (u /. v).cpu == expected_div
 
     block:
       let u = @[1.0, 8.0, -3.0].toTensor().astype(float32).opencl
@@ -33,7 +33,7 @@ suite "OpenCL: Shapeshifting - broadcasting and non linear algebra elementwise o
       let expected_div = @[0.25, 4.0, -0.3].toTensor().astype(float32)
 
       check: (u *. v).cpu == expected_mul
-      check: (u ./ v).cpu == expected_div
+      check: (u /. v).cpu == expected_div
 
   test "Implicit tensor-tensor broadcasting - basic operations +., -., *., ./, .^":
     block: # Addition
@@ -67,7 +67,7 @@ suite "OpenCL: Shapeshifting - broadcasting and non linear algebra elementwise o
       let a = [100.0, 10, 20, 30].toTensor().reshape(4,1).opencl
       let b = [2.0, 5, 10].toTensor().reshape(1,3).opencl
 
-      check: (a ./ b).cpu == [[50.0, 20, 10],
+      check: (a /. b).cpu == [[50.0, 20, 10],
                               [5.0, 2, 1],
                               [10.0, 4, 2],
                               [15.0, 6, 3]].toTensor

--- a/tests/tensor/test_operators_comparison.nim
+++ b/tests/tensor/test_operators_comparison.nim
@@ -61,6 +61,6 @@ suite "Testing tensor comparison":
       a_complex = a.astype(Complex[float64])
       b_complex = b.astype(Complex[float64])
 
-    check: (a .== b) == [true, false, false, true].toTensor
-    check: (a .> b)  == [false, true, false, false].toTensor
-    check: (a_complex .== b_complex) == [true, false, false, true].toTensor
+    check: (a ==. b) == [true, false, false, true].toTensor
+    check: (a >. b)  == [false, true, false, false].toTensor
+    check: (a_complex ==. b_complex) == [true, false, false, true].toTensor


### PR DESCRIPTION
The implements a macro to ease handling of a large number of deprecated proc as introduced in #410

This also deprecate comparison operators that were forgotten in #410

Limitation, it cannot handle overloads bsed on generic constraints like

https://github.com/mratsim/Arraymancer/blob/b2620e6279a16cf514c4bbe67e5e2f34f1d71291/src/tensor/operators_broadcasted.nim#L111-L127

Instead `when T is SomeInteger` should be used:

https://github.com/mratsim/Arraymancer/blob/93f74ddc707814dc70dd695b68d12e696ab15329/src/tensor/operators_broadcasted.nim#L84-L94
