### PR TITLE
make `asType` a no-op if `T` is `U`

### DIFF
--- a/src/tensor/ufunc.nim
+++ b/src/tensor/ufunc.nim
@@ -17,8 +17,12 @@ import  ./data_structure,
         sugar, math, complex
 
 proc astype*[T; U: not Complex](t: Tensor[T], typ: typedesc[U]): Tensor[U] {.noInit.} =
-  ## Apply type conversion on the whole tensor
-  result = t.map(x => x.U)
+  ## Apply type conversion on the whole tensor. This is a no-op if `T` is the same
+  ## as `U`.
+  when T is U:
+    result = t
+  else:
+    result = t.map(x => x.U)
 
 proc astype*[T: SomeNumber, U: Complex](t: Tensor[T], typ: typedesc[U]): Tensor[U] {.noInit.} =
   ## Apply type conversion on the whole tensor


### PR DESCRIPTION
I just wanted to make some changes in ggplotnim's DF to allow handing tensors of other numeric types than float and int by applying an `asType` automatically.

However, it seemed like a bad idea to apply the map even if the input already is a float or int. Seemed like a useful optimization to do this here.