### PR TITLE
fix regression due to paramCount not in nimscript anymore

### DIFF
--- a/docs/docs.nim
+++ b/docs/docs.nim
@@ -2,6 +2,9 @@ import macros, strformat, strutils, sequtils, sets, tables, algorithm
 
 from os import parentDir, getCurrentCompilerExe, DirSep, extractFilename, `/`, setCurrentDir
 
+when (NimMajor, NimMinor, NimPatch) >= (1, 3, 0):
+  from os import paramCount, paramStr
+
 when defined(nimdoc):
   from os import getCurrentDir, paramCount, paramStr
 


### PR DESCRIPTION
Fixes the issue mentioned by @brentp in https://github.com/mratsim/Arraymancer/issues/441#issuecomment-620954758.

*Really* confusing error message once again by nimble. 