### PR TITLE
Don't import x86 SIMD at all on ARM

### DIFF
--- a/src/laser/primitives/matrix_multiplication/gemm_ukernel_avx.nim
+++ b/src/laser/primitives/matrix_multiplication/gemm_ukernel_avx.nim
@@ -7,6 +7,8 @@ import
   ./gemm_ukernel_generator, ./gemm_tiling,
   ../../simd
 
+x86only()
+
 template float32x8_muladd_unfused(a, b, c: m256): m256 =
   mm256_add_ps(mm256_mul_ps(a, b), c)
 

--- a/src/laser/primitives/matrix_multiplication/gemm_ukernel_avx2.nim
+++ b/src/laser/primitives/matrix_multiplication/gemm_ukernel_avx2.nim
@@ -7,6 +7,8 @@ import
   ./gemm_ukernel_generator, ./gemm_tiling,
   ../../simd
 
+x86only()
+
 template int32x8_muladd_unfused_avx2(a, b, c: m256i): m256i =
   mm256_add_epi32(mm256_mullo_epi32(a, b), c)
 

--- a/src/laser/primitives/matrix_multiplication/gemm_ukernel_avx512.nim
+++ b/src/laser/primitives/matrix_multiplication/gemm_ukernel_avx512.nim
@@ -6,7 +6,9 @@
 import
     ./gemm_ukernel_generator, ./gemm_tiling,
     ../../simd
-  
+
+x86only()
+
 ukernel_generator(
     x86_AVX512,
     typ = float32,

--- a/src/laser/primitives/matrix_multiplication/gemm_ukernel_avx_fma.nim
+++ b/src/laser/primitives/matrix_multiplication/gemm_ukernel_avx_fma.nim
@@ -7,6 +7,8 @@ import
   ./gemm_ukernel_generator, ./gemm_tiling,
   ../../simd
 
+x86only()
+
 ukernel_generator(
       x86_AVX_FMA,
       typ = float32,

--- a/src/laser/primitives/matrix_multiplication/gemm_ukernel_dispatch.nim
+++ b/src/laser/primitives/matrix_multiplication/gemm_ukernel_dispatch.nim
@@ -7,14 +7,17 @@ import
   macros,
   ../../compiler_optim_hints,
   ./gemm_tiling, ./gemm_utils,
-  ./gemm_ukernel_generic,
-  ./gemm_ukernel_sse,
-  ./gemm_ukernel_sse2,
-  ./gemm_ukernel_sse4_1,
-  ./gemm_ukernel_avx,
-  ./gemm_ukernel_avx_fma,
-  ./gemm_ukernel_avx2,
-  ./gemm_ukernel_avx512
+  ./gemm_ukernel_generic
+
+when defined(i386) or defined(amd64):
+  import
+    ./gemm_ukernel_sse,
+    ./gemm_ukernel_sse2,
+    ./gemm_ukernel_sse4_1,
+    ./gemm_ukernel_avx,
+    ./gemm_ukernel_avx_fma,
+    ./gemm_ukernel_avx2,
+    ./gemm_ukernel_avx512
 
 {.experimental: "dynamicBindSym".}
 

--- a/src/laser/primitives/matrix_multiplication/gemm_ukernel_generator.nim
+++ b/src/laser/primitives/matrix_multiplication/gemm_ukernel_generator.nim
@@ -22,7 +22,7 @@ import
 # #############################################################
 
 template x86only*(): untyped =
-  when not defined(i386) or not defined(amd64):
+  when not (defined(i386) or defined(amd64)):
     {.error: "This file is x86-only, there should be a fallback path for other architectures.".}
 
 template ukernel_simd_proc(ukernel_name, epilogue_name: NimNode, edge: bool) {.dirty.} =

--- a/src/laser/primitives/matrix_multiplication/gemm_ukernel_generator.nim
+++ b/src/laser/primitives/matrix_multiplication/gemm_ukernel_generator.nim
@@ -21,6 +21,10 @@ import
 
 # #############################################################
 
+template x86only*(): untyped =
+  when not defined(i386) or not defined(amd64):
+    {.error: "This file is x86-only, there should be a fallback path for other architectures.".}
+
 template ukernel_simd_proc(ukernel_name, epilogue_name: NimNode, edge: bool) {.dirty.} =
   if edge:
     result.add quote do:

--- a/src/laser/primitives/matrix_multiplication/gemm_ukernel_sse.nim
+++ b/src/laser/primitives/matrix_multiplication/gemm_ukernel_sse.nim
@@ -7,6 +7,8 @@ import
   ./gemm_ukernel_generator, ./gemm_tiling,
   ../../simd
 
+x86only()
+
 template float32x4_muladd_unfused(a, b, c: m128): m128 =
   mm_add_ps(mm_mul_ps(a, b), c)
 

--- a/src/laser/primitives/matrix_multiplication/gemm_ukernel_sse2.nim
+++ b/src/laser/primitives/matrix_multiplication/gemm_ukernel_sse2.nim
@@ -7,6 +7,8 @@ import
   ./gemm_ukernel_generator, ./gemm_tiling,
   ../../simd
 
+x86only()
+
 template float64x2_muladd_unfused(a, b, c: m128d): m128d =
   mm_add_pd(mm_mul_pd(a, b), c)
 

--- a/src/laser/primitives/matrix_multiplication/gemm_ukernel_sse4_1.nim
+++ b/src/laser/primitives/matrix_multiplication/gemm_ukernel_sse4_1.nim
@@ -8,6 +8,8 @@ import
   ./gemm_ukernel_generator, ./gemm_tiling,
   ../../simd
 
+x86only()
+
 template int32x4_muladd_unfused_sse4_1(a, b, c: m128i): m128i =
   mm_add_epi32(mm_mullo_epi32(a, b), c)
 


### PR DESCRIPTION
Fix #449

The code had proper fallback for non supported SIMD but the x86-files were still imported

https://github.com/mratsim/Arraymancer/blob/fd26e16ff0d1d623c749c57a2e3df6fd9d2a431c/src/laser/primitives/matrix_multiplication/gemm.nim#L229-L248