### PR TITLE
[docs] fix `docs.nim` imports, paramCount/Str are defined again

### DIFF
--- a/docs/docs.nim
+++ b/docs/docs.nim
@@ -2,9 +2,11 @@ import macros, strformat, strutils, sequtils, sets, tables, algorithm
 
 from os import parentDir, getCurrentCompilerExe, DirSep, extractFilename, `/`, setCurrentDir
 
-when (NimMajor, NimMinor, NimPatch) >= (1, 3, 0):
-  from os import paramCount, paramStr
-
+# NOTE:
+# for some time on devel 1.3.x `paramCount` and `paramStr` had to be imported
+# os, because they were removed for nimscript. This was reverted in:
+# https://github.com/nim-lang/Nim/pull/14658
+# For `nimdoc` we still have to import those from `os`!
 when defined(nimdoc):
   from os import getCurrentDir, paramCount, paramStr
 


### PR DESCRIPTION
This fixes a regression introduced after the merge of:
https://github.com/nim-lang/Nim/pull/14658/
which resulted in our favorite "Invalid section: ." nimble error.

Should work fine again. This however means it's now broken for those Nim versions between the original change that required the `pramCount`/`paramStr` imports from `os` and the above. Both was version `1.3` though, if I'm not misremembering.