### PR TITLE
do not confuse `sugar.enumerate` macro with arraymancer's iterator of the same name

### DIFF
--- a/src/arraymancer/tensor/higher_order_applymap.nim
+++ b/src/arraymancer/tensor/higher_order_applymap.nim
@@ -15,8 +15,9 @@
 import  ./backend/openmp,
         ./backend/memory_optimization_hints,
         ./private/p_checks,
-        ./data_structure, ./init_cpu, ./accessors,
-        sugar
+        ./data_structure, ./init_cpu, ./accessors
+
+import sugar except enumerate
 
 # ####################################################################
 # Mapping over tensors


### PR DESCRIPTION
This change is needed if we want https://github.com/nim-lang/Nim/pull/15297 to be merged.