### PR TITLE
Reshape with explicit memory layout and transpose with explicit permutation

### DIFF
--- a/src/arraymancer/tensor/private/p_shapeshifting.nim
+++ b/src/arraymancer/tensor/private/p_shapeshifting.nim
@@ -49,10 +49,20 @@ proc reshapeImpl*(t: AnyTensor, new_shape: varargs[int]|MetadataArray, result: v
     reshape_no_copy(t, new_shape, result, rowMajor)
     result.storage = t.storage
   elif t.is_F_contiguous:
-    reshape_no_copy(t, new_shape, result, colMajor)
+    reshape_no_copy(t, new_shape, result, rowMajor)
     result.storage = t.storage
   else:
     reshape_with_copy(t, new_shape, result)
+
+proc reshapeImplWithContig*(t : AnyTensor, new_shape: varargs[int]|MetadataArray, result: var AnyTensor, layout: OrderType) {.noSideEffect.}=
+  when compileOption("boundChecks"):
+    when new_shape is MetadataArray:
+      check_reshape(t, new_shape)
+    else:
+      check_reshape(t, new_shape.toMetadataArray)
+
+  reshapeImpl(t.asContiguous(layout, force=true), new_shape, result)
+
 
 proc broadcastImpl*(t: var AnyTensor, shape: varargs[int]|MetadataArray) {.noSideEffect.}=
   when compileOption("boundChecks"):

--- a/src/arraymancer/tensor/private/p_shapeshifting.nim
+++ b/src/arraymancer/tensor/private/p_shapeshifting.nim
@@ -49,7 +49,7 @@ proc reshapeImpl*(t: AnyTensor, new_shape: varargs[int]|MetadataArray, result: v
     reshape_no_copy(t, new_shape, result, rowMajor)
     result.storage = t.storage
   elif t.is_F_contiguous:
-    reshape_no_copy(t, new_shape, result, rowMajor)
+    reshape_no_copy(t, new_shape, result, colMajor)
     result.storage = t.storage
   else:
     reshape_with_copy(t, new_shape, result)

--- a/tests/tensor/test_shapeshifting.nim
+++ b/tests/tensor/test_shapeshifting.nim
@@ -75,6 +75,22 @@ testSuite "Shapeshifting":
     check: a.reshape(6, 2, colMajor) == b.reshape(6, 2)
     check: a.reshape(6, 2) == b.reshape(6, 2, rowMajor)
 
+  test "Transpose with explicit permutation":
+    let a = toSeq(1..6).toTensor().reshape(1, 2, 3)
+    let b = a.transpose(@[0, 2, 1])
+    let c = a.transpose(@[2, 0, 1])
+    # Check different permutations other than a full transpose
+
+    let expected_b = @[1, 4, 2, 5, 3, 6].toTensor().reshape(1, 3, 2)
+    check: b == expected_b
+    check: b.shape == [1, 3, 2]
+    check: b.strides == [6, 1, 3]
+
+    let expected_c = @[1, 4, 2, 5, 3, 6].toTensor().reshape(3, 1, 2)
+    check: c == expected_c
+    check: c.shape == [3, 1, 2]
+    check: c.strides == [1, 6, 3]
+
   test "Unsafe reshape":
     block:
       let a = toSeq(1..4).toTensor()

--- a/tests/tensor/test_shapeshifting.nim
+++ b/tests/tensor/test_shapeshifting.nim
@@ -64,6 +64,17 @@ testSuite "Shapeshifting":
     check: a == [[1,2],
                  [3,4]].toTensor()
 
+  test "Reshape with explicit order":
+    let a = toSeq(1..12).toTensor().reshape(3, 2, 2).asContiguous(rowMajor, force = true)
+    let b = toSeq(1..12).toTensor().reshape(3, 2, 2).asContiguous(colMajor, force = true)
+    check: a == b
+    # Default behavior is respecting memory layouts when reshaping
+    check: a.reshape(6, 2) != b.reshape(6, 2)
+
+    # Explicit ordering will reshape using the same memory layout
+    check: a.reshape(6, 2, colMajor) == b.reshape(6, 2)
+    check: a.reshape(6, 2) == b.reshape(6, 2, rowMajor)
+
   test "Unsafe reshape":
     block:
       let a = toSeq(1..4).toTensor()


### PR DESCRIPTION
Currently, reshaping respects existing memory layout, so two tensors with different contiguity can often differ after reshaping:

```nim
let
  a = toSeq(1..12).toTensor().reshape(3, 2, 2).asContiguous(rowMajor, force=true)
  b = toSeq(1..12).toTensor().reshape(3, 2, 2).asContiguous(colMajor, force=true)

echo a == b
echo a.reshape(2, 6)
echo b.reshape(2, 6)

# true
# Tensor[system.int] of shape [2, 6]" on backend "Cpu"
# |1	2	3	4	5	6|
# |7	8	9	10	11	12|
#
# Tensor[system.int] of shape [2, 6]" on backend "Cpu"
# |1	9	7	2	10	8|
# |5	3	11	6	4	12|
```

This PR adds another `reshape` method which allows reshaping to be done w.r.t. a provided memory layout.

```nim
echo a.reshape(2, 6, colMajor) == b.reshape(2, 6, colMajor)
# true
```

It also adds the ability to transpose a tensor using a provided permutation of axes, rather than just simply reversing axes and strides.

```nim
let
  a = toSeq(1..12).toTensor().reshape(3, 2, 2)

echo a.transpose()
echo a.transpose(@[2, 0, 1])

# Tensor[system.int] of shape [2, 2, 3]" on backend "Cpu"
# | | 	1	5	9 | 	2	6	10|
# | | 	3	7	11 | 	4	8	12|
# 
# Tensor[system.int] of shape [2, 3, 2]" on backend "Cpu"
# | | 	1	3 | 	2	4|
# | | 	5	7 | 	6	8|
# | | 	9	11 | 	10	12|
```
