### PR TITLE
fix warnings & deprecated functions

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,16 +5,16 @@ matrix:
 
 environment:
   matrix:
-    - NIM_ARCHIVE: nim-1.2.0_x64.zip
-      NIM_DIR: nim-1.2.0
-      NIM_URL: https://nim-lang.org/download/nim-1.2.0_x64.zip
+    - NIM_ARCHIVE: nim-1.4.0_x64.zip
+      NIM_DIR: nim-1.4.0
+      NIM_URL: https://nim-lang.org/download/nim-1.4.0_x64.zip
       MINGW_PATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
       LAPACK_URL: http://icl.cs.utk.edu/lapack-for-windows/libraries/VisualStudio/3.7.0/Dynamic-MINGW/Win64/liblapack.dll
       BLAS_PLATFORM: x64
       platform: x64
 
-    - NIM_ARCHIVE: nim-1.2.0_x32.zip
-      NIM_DIR: nim-1.2.0
+    - NIM_ARCHIVE: nim-1.4.0_x32.zip
+      NIM_DIR: nim-1.4.0
       NIM_URL: https://nim-lang.org/download/nim-1.4.0_x32.zip
       MINGW_PATH: C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin
       LAPACK_URL: http://icl.cs.utk.edu/lapack-for-windows/libraries/VisualStudio/3.7.0/Dynamic-MINGW/Win32/liblapack.dll

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,17 +5,17 @@ matrix:
 
 environment:
   matrix:
-    - NIM_ARCHIVE: nim-1.0.6_x64.zip
-      NIM_DIR: nim-1.0.6
-      NIM_URL: https://nim-lang.org/download/nim-1.0.6_x64.zip
+    - NIM_ARCHIVE: nim-1.2.0_x64.zip
+      NIM_DIR: nim-1.2.0
+      NIM_URL: https://nim-lang.org/download/nim-1.2.0_x64.zip
       MINGW_PATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
       LAPACK_URL: http://icl.cs.utk.edu/lapack-for-windows/libraries/VisualStudio/3.7.0/Dynamic-MINGW/Win64/liblapack.dll
       BLAS_PLATFORM: x64
       platform: x64
 
-    - NIM_ARCHIVE: nim-1.0.6_x32.zip
-      NIM_DIR: nim-1.0.6
-      NIM_URL: https://nim-lang.org/download/nim-1.0.6_x32.zip
+    - NIM_ARCHIVE: nim-1.2.0_x32.zip
+      NIM_DIR: nim-1.2.0
+      NIM_URL: https://nim-lang.org/download/nim-1.4.0_x32.zip
       MINGW_PATH: C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin
       LAPACK_URL: http://icl.cs.utk.edu/lapack-for-windows/libraries/VisualStudio/3.7.0/Dynamic-MINGW/Win32/liblapack.dll
       BLAS_PLATFORM: win32

--- a/arraymancer.nimble
+++ b/arraymancer.nimble
@@ -1,11 +1,11 @@
 ### Package
-version       = "0.6.1"
+version       = "0.6.2"
 author        = "Mamy André-Ratsimbazafy"
 description   = "A n-dimensional tensor (ndarray) library"
 license       = "Apache License 2.0"
 
 ### Dependencies
-requires "nim >= 1.0.0",
+requires "nim >= 1.2.0",
   "nimblas >= 0.2.2",
   "nimlapack >= 0.1.1",
   "nimcuda >= 0.1.4",

--- a/arraymancer.nimble
+++ b/arraymancer.nimble
@@ -5,7 +5,7 @@ description   = "A n-dimensional tensor (ndarray) library"
 license       = "Apache License 2.0"
 
 ### Dependencies
-requires "nim >= 1.2.0",
+requires "nim >= 1.4.0",
   "nimblas >= 0.2.2",
   "nimlapack >= 0.1.1",
   "nimcuda >= 0.1.4",

--- a/src/arraymancer/datasets/mnist.nim
+++ b/src/arraymancer/datasets/mnist.nim
@@ -101,7 +101,7 @@ proc read_mnist_images*(imgsPath: string): Tensor[uint8] {.noInit.}=
   ##     - W, width
   ##
   ## MNIST data can be downloaded here: http://yann.lecun.com/exdb/mnist/
-  if not existsFile(imgsPath):
+  if not fileExists(imgsPath):
     raise newException(IOError, "MNIST images file \"" & imgsPath & "\" does not exist")
 
   let stream = newGzFileStream(imgsPath, mode = fmRead)
@@ -135,7 +135,7 @@ proc read_mnist_labels*(labelsPath: string): Tensor[uint8] {.noInit.}=
   ##   - A tensor of labels with shape (N)
   ##     - N, number of images
   ## MNIST data can be downloaded here: http://yann.lecun.com/exdb/mnist/
-  if not existsFile(labelsPath):
+  if not fileExists(labelsPath):
     raise newException(IOError, "MNIST labels file \"" & labelsPath & "\" does not exist")
 
   let stream = newGzFileStream(labelsPath, mode = fmRead)
@@ -183,7 +183,7 @@ proc load_mnist*(cache: static bool = true): Mnist =
     cache_dir = get_cache_dir()
     files = cache_dir.mnistFilesPath
 
-  if not files.all(x => x.existsFile):
+  if not files.all(x => x.fileExists):
     create_cache_dirs_if_necessary()
     download_mnist_files(files)
 

--- a/src/arraymancer/io/io_npy.nim
+++ b/src/arraymancer/io/io_npy.nim
@@ -74,7 +74,7 @@ proc read_npy*[T: SomeNumber](npyPath: string): Tensor[T] {.noInit.} =
   ##
   ## Only integer, unsigned integer and float ndarrays are supported at the moment.
 
-  if unlikely(not existsFile(npyPath)):
+  if unlikely(not fileExists(npyPath)):
     raise newException(IOError, &".npy file \"{npyPath}\" does not exist")
 
   let stream = newFileStream(npyPath, mode = fmRead)

--- a/src/arraymancer/laser/compiler_optim_hints.nim
+++ b/src/arraymancer/laser/compiler_optim_hints.nim
@@ -43,7 +43,7 @@ type
     # 3 - L1 and L2 cache eviction level
 
 when withBuiltins:
-  proc builtin_assume_aligned(data: pointer, alignment: csize): pointer {.importc: "__builtin_assume_aligned", noDecl.}
+  proc builtin_assume_aligned(data: pointer, alignment: csize_t): pointer {.importc: "__builtin_assume_aligned", noDecl.}
   proc builtin_prefetch(data: pointer, rw: PrefetchRW, locality: PrefetchLocality) {.importc: "__builtin_prefetch", noDecl.}
 
 when defined(cpp):

--- a/src/arraymancer/ml/metrics/accuracy_score.nim
+++ b/src/arraymancer/ml/metrics/accuracy_score.nim
@@ -23,4 +23,4 @@ proc accuracy_score*[T](y_pred, y_true: Tensor[T]): float =
   ## Returns:
   ##   - The proportion of correctly classified samples (as float).
 
-  result = (y_true .== y_pred).astype(float).mean
+  result = (y_true ==. y_pred).astype(float).mean

--- a/src/arraymancer/nn_dsl/dsl_topology.nim
+++ b/src/arraymancer/nn_dsl/dsl_topology.nim
@@ -104,7 +104,7 @@ proc topoFromInput(self: var TopoTable, ident: NimNode, desc: NimNode) =
   if desc.len != 2:
     incorrect(desc) ## Placeholder to specify padding stride in the future
 
-  self.add ident, LayerTopology(kind: lkInput,
+  self[ident] = LayerTopology(kind: lkInput,
                                 in_shape: desc[1],
                                 out_shape: desc[1])
 
@@ -144,7 +144,7 @@ proc topoFromConv2D(self: var TopoTable, ident: NimNode, desc: NimNode) =
   let out_shape = quote do:
     out_shape_conv2d(`in_shape`, `kernel`, `padding`, `strides`)
 
-  self.add ident, LayerTopology(kind: lkConv2D,
+  self[ident] = LayerTopology(kind: lkConv2D,
                                 in_shape: in_shape,
                                 out_shape: out_shape,
                                 c2d_kernel_shape: kernel,
@@ -182,7 +182,7 @@ proc topoFromMaxPool2D(self: var TopoTable, ident: NimNode, desc: NimNode) =
   let out_shape = quote do:
     out_shape_maxpool2d(`in_shape`, `kernel`, `padding`, `strides`)
 
-  self.add ident, LayerTopology(kind: lkMaxPool2D,
+  self[ident] = LayerTopology(kind: lkMaxPool2D,
                                 in_shape: in_shape,
                                 out_shape: out_shape,
                                 m2d_kernel: kernel,
@@ -202,7 +202,7 @@ proc topoFromLinear(self: var TopoTable, ident: NimNode, desc: NimNode) =
   var in_shape = self.replaceInputNodes(desc[1])
   in_shape = quote do: `in_shape`
 
-  self.add ident, LayerTopology(kind: lkLinear,
+  self[ident] = LayerTopology(kind: lkLinear,
                                 in_shape: in_shape,
                                 out_shape: desc[2])
 
@@ -223,7 +223,7 @@ proc topoFromFlatten(self: var TopoTable, ident: NimNode, desc: NimNode) =
   let out_shape = quote do:
     out_shape_flatten(`in_shape`)
 
-  self.add ident, LayerTopology(kind: lkFlatten,
+  self[ident] = LayerTopology(kind: lkFlatten,
                                 in_shape: in_shape,
                                 out_shape: out_shape)
 
@@ -253,7 +253,7 @@ proc topoFromGRU(self: var TopoTable, ident: NimNode, desc: NimNode) =
       hidden_size
     )
 
-  self.add ident, LayerTopology(kind: lkGRU,
+  self[ident] = LayerTopology(kind: lkGRU,
                                 in_shape: in_shape,
                                 out_shape: out_shape,
                                 gru_hidden_size: hidden_size,

--- a/src/arraymancer/nn_primitives/backend/cudnn_conv_interface.nim
+++ b/src/arraymancer/nn_primitives/backend/cudnn_conv_interface.nim
@@ -38,7 +38,7 @@ type Algo = cudnnConvolutionFwdAlgo_t or cudnnConvolutionBwdFilterAlgo_t or cudn
 type ConvAlgoSpace*[T: SomeFloat, Algo] = object
   algo*: Algo
   workspace*: ref[ptr T]
-  sizeInBytes*: csize
+  sizeInBytes*: csize_t
 
 # #####################################################################
 # Convolution descriptor

--- a/src/arraymancer/nn_primitives/backend/nnpack.nim
+++ b/src/arraymancer/nn_primitives/backend/nnpack.nim
@@ -110,9 +110,9 @@ const
 
 type
   nnp_size* {.bycopy.} = object
-    width*: csize              ## * Width (horizontal size) of an image, kernel, or pooling filter.
+    width*: csize_t              ## * Width (horizontal size) of an image, kernel, or pooling filter.
     ## * Height (vertical size) of an image, kernel, or pooling filter.
-    height*: csize
+    height*: csize_t
 
 ## *
 ##  @brief Padding of images in NNPACK.
@@ -120,11 +120,11 @@ type
 
 type
   nnp_padding* {.bycopy.} = object
-    top*: csize                ## * Padding above the image data
+    top*: csize_t                ## * Padding above the image data
     ## * Padding on the right of image data
-    right*: csize              ## * Padding below the image data
-    bottom*: csize             ## * Padding on the left of image data
-    left*: csize
+    right*: csize_t              ## * Padding below the image data
+    bottom*: csize_t             ## * Padding on the left of image data
+    left*: csize_t
 
 ## *
 ##  @brief Profiling information about time spent in different phases of a function call.
@@ -178,12 +178,12 @@ proc nnp_deinitialize*(): nnp_status {.cdecl, importc: "nnp_deinitialize".}
 ##
 
 proc nnp_convolution_output*(algorithm: nnp_convolution_algorithm;
-                            batch_size: csize; input_channels: csize;
-                            output_channels: csize; input_size: nnp_size;
+                            batch_size: csize_t; input_channels: csize_t;
+                            output_channels: csize_t; input_size: nnp_size;
                             input_padding: nnp_padding; kernel_size: nnp_size;
                             input: ptr cfloat; kernel: ptr cfloat; bias: ptr cfloat;
                             output: ptr cfloat; workspace_buffer: pointer=nil;
-                            workspace_size: ptr csize=nil; activation: nnp_activation=nnp_activation_identity;
+                            workspace_size: ptr csize_t=nil; activation: nnp_activation=nnp_activation_identity;
                             activation_parameters: pointer=nil;
                             threadpool: pthreadpool_t=nil; profile: ptr nnp_profile=nil): nnp_status {.
     cdecl, importc: "nnp_convolution_output".}
@@ -222,14 +222,14 @@ proc nnp_convolution_output*(algorithm: nnp_convolution_algorithm;
 ##
 
 proc nnp_convolution_input_gradient*(algorithm: nnp_convolution_algorithm;
-                                    batch_size: csize; input_channels: csize;
-                                    output_channels: csize; input_size: nnp_size;
+                                    batch_size: csize_t; input_channels: csize_t;
+                                    output_channels: csize_t; input_size: nnp_size;
                                     input_padding: nnp_padding;
                                     kernel_size: nnp_size;
                                     grad_output: ptr cfloat; kernel: ptr cfloat;
                                     grad_input: ptr cfloat;
                                     workspace_buffer: pointer = nil;
-                                    workspace_size: ptr csize = nil;
+                                    workspace_size: ptr csize_t = nil;
                                     activation: nnp_activation = nnp_activation_identity;
                                     activation_parameters: pointer = nil;
                                     threadpool: pthreadpool_t = nil;
@@ -269,14 +269,14 @@ proc nnp_convolution_input_gradient*(algorithm: nnp_convolution_algorithm;
 ##
 
 proc nnp_convolution_kernel_gradient*(algorithm: nnp_convolution_algorithm;
-                                     batch_size: csize; input_channels: csize;
-                                     output_channels: csize; input_size: nnp_size;
+                                     batch_size: csize_t; input_channels: csize_t;
+                                     output_channels: csize_t; input_size: nnp_size;
                                      input_padding: nnp_padding;
                                      kernel_size: nnp_size; input: ptr cfloat;
                                      grad_output: ptr cfloat;
                                      grad_kernel: ptr cfloat;
                                      workspace_buffer: pointer = nil;
-                                     workspace_size: ptr csize = nil;
+                                     workspace_size: ptr csize_t = nil;
                                      activation: nnp_activation = nnp_activation_identity;
                                      activation_parameters: pointer = nil;
                                      threadpool: pthreadpool_t = nil;
@@ -338,13 +338,13 @@ proc nnp_convolution_kernel_gradient*(algorithm: nnp_convolution_algorithm;
 ##
 
 proc nnp_convolution_inference*(algorithm: nnp_convolution_algorithm;
-    transform_strategy: nnp_convolution_transform_strategy; input_channels: csize;
-                               output_channels: csize; input_size: nnp_size;
+    transform_strategy: nnp_convolution_transform_strategy; input_channels: csize_t;
+                               output_channels: csize_t; input_size: nnp_size;
                                input_padding: nnp_padding; kernel_size: nnp_size;
                                output_subsampling: nnp_size; input: ptr cfloat;
                                kernel: ptr cfloat; bias: ptr cfloat;
                                output: ptr cfloat; workspace_buffer: pointer;
-                               workspace_size: ptr csize;
+                               workspace_size: ptr csize_t;
                                activation: nnp_activation;
                                activation_parameters: pointer;
                                threadpool: pthreadpool_t; profile: ptr nnp_profile): nnp_status {.
@@ -364,8 +364,8 @@ proc nnp_convolution_inference*(algorithm: nnp_convolution_algorithm;
 ##                    If threadpool is NULL, the computation would run on the caller thread without parallelization.
 ##
 
-proc nnp_fully_connected_output*(batch_size: csize; input_channels: csize;
-                                output_channels: csize; input: ptr cfloat;
+proc nnp_fully_connected_output*(batch_size: csize_t; input_channels: csize_t;
+                                output_channels: csize_t; input: ptr cfloat;
                                 kernel: ptr cfloat; output: ptr cfloat;
                                 threadpool: pthreadpool_t;
                                 profile: ptr nnp_profile): nnp_status {.cdecl,
@@ -382,7 +382,7 @@ proc nnp_fully_connected_output*(batch_size: csize; input_channels: csize;
 ##                    If threadpool is NULL, the computation would run on the caller thread without parallelization.
 ##
 
-proc nnp_fully_connected_inference*(input_channels: csize; output_channels: csize;
+proc nnp_fully_connected_inference*(input_channels: csize_t; output_channels: csize_t;
                                    input: ptr cfloat; kernel: ptr cfloat;
                                    output: ptr cfloat; threadpool: pthreadpool_t): nnp_status {.
     cdecl, importc: "nnp_fully_connected_inference".}
@@ -398,8 +398,8 @@ proc nnp_fully_connected_inference*(input_channels: csize; output_channels: csiz
 ##                    If threadpool is NULL, the computation would run on the caller thread without parallelization.
 ##
 
-proc nnp_fully_connected_inference_f16f32*(input_channels: csize;
-    output_channels: csize; input: ptr cfloat; kernel: pointer; output: ptr cfloat;
+proc nnp_fully_connected_inference_f16f32*(input_channels: csize_t;
+    output_channels: csize_t; input: ptr cfloat; kernel: pointer; output: ptr cfloat;
     threadpool: pthreadpool_t): nnp_status {.cdecl,
     importc: "nnp_fully_connected_inference_f16f32".}
 ## *
@@ -425,7 +425,7 @@ proc nnp_fully_connected_inference_f16f32*(input_channels: csize;
 ##                    If threadpool is NULL, the computation would run on the caller thread without parallelization.
 ##
 
-proc nnp_max_pooling_output*(batch_size: csize; channels: csize;
+proc nnp_max_pooling_output*(batch_size: csize_t; channels: csize_t;
                             input_size: nnp_size; input_padding: nnp_padding;
                             pooling_size: nnp_size; pooling_stride: nnp_size;
                             input: ptr cfloat; output: ptr cfloat;
@@ -443,7 +443,7 @@ proc nnp_max_pooling_output*(batch_size: csize; channels: csize;
 ##                    If threadpool is NULL, the computation would run on the caller thread without parallelization.
 ##
 
-proc nnp_softmax_output*(batch_size: csize; channels: csize; input: ptr cfloat;
+proc nnp_softmax_output*(batch_size: csize_t; channels: csize_t; input: ptr cfloat;
                         output: ptr cfloat; threadpool: pthreadpool_t): nnp_status {.
     cdecl, importc: "nnp_softmax_output".}
 ## *
@@ -458,7 +458,7 @@ proc nnp_softmax_output*(batch_size: csize; channels: csize; input: ptr cfloat;
 ##                    If threadpool is NULL, the computation would run on the caller thread without parallelization.
 ##
 
-proc nnp_relu_output*(batch_size: csize; channels: csize; input: ptr cfloat;
+proc nnp_relu_output*(batch_size: csize_t; channels: csize_t; input: ptr cfloat;
                      output: ptr cfloat; negative_slope: cfloat;
                      threadpool: pthreadpool_t): nnp_status {.cdecl,
     importc: "nnp_relu_output".}
@@ -474,7 +474,7 @@ proc nnp_relu_output*(batch_size: csize; channels: csize; input: ptr cfloat;
 ##                    If threadpool is NULL, the computation would run on the caller thread without parallelization.
 ##
 
-proc nnp_relu_input_gradient*(batch_size: csize; channels: csize;
+proc nnp_relu_input_gradient*(batch_size: csize_t; channels: csize_t;
                              grad_output: ptr cfloat; input: ptr cfloat;
                              grad_input: ptr cfloat; negative_slope: cfloat;
                              threadpool: pthreadpool_t): nnp_status {.cdecl,

--- a/src/arraymancer/tensor/aggregate.nim
+++ b/src/arraymancer/tensor/aggregate.nim
@@ -21,7 +21,7 @@ import  ./backend/memory_optimization_hints,
         ./algorithms,
         ./private/p_empty_tensors,
         math
-        
+
 import complex except Complex64, Complex32
 
 # ### Standard aggregate functions
@@ -174,7 +174,7 @@ proc argmax_max*[T](t: Tensor[T], axis: int): tuple[indices: Tensor[int], maxes:
   ##                                     [1],
   ##                                     [1]].toTensor
 
-  assert axis in {0, 1}, "Only 1D and 2D tensors are supported at the moment for argmax"
+  # assert axis in {0, 1}, "Only 1D and 2D tensors are supported at the moment for argmax"
   # TODO: Reimplement parallel Argmax (introduced by https://github.com/mratsim/Arraymancer/pull/171)
   #       must be done with care: https://github.com/mratsim/Arraymancer/issues/183
 

--- a/src/arraymancer/tensor/backend/memory_optimization_hints.nim
+++ b/src/arraymancer/tensor/backend/memory_optimization_hints.nim
@@ -30,13 +30,13 @@ template withMemoryOptimHints*() =
 const withBuiltins = defined(gcc) or defined(clang)
 
 when withBuiltins:
-  proc builtin_assume_aligned[T](data: ptr T, n: csize): ptr T {.importc: "__builtin_assume_aligned",noDecl.}
+  proc builtin_assume_aligned[T](data: ptr T, n: csize_t): ptr T {.importc: "__builtin_assume_aligned",noDecl.}
 
 when defined(cpp):
   proc static_cast[T](input: T): T
     {.importcpp: "static_cast<'0>(@)".}
 
-template assume_aligned*[T](data: ptr T, n: csize): ptr T =
+template assume_aligned*[T](data: ptr T, n: csize_t): ptr T =
   when defined(cpp) and withBuiltins: # builtin_assume_aligned returns void pointers, this does not compile in C++, they must all be typed
     static_cast builtin_assume_aligned(data, n)
   elif withBuiltins:

--- a/src/arraymancer/tensor/fallback/legacy/blas_l3_gemm_data_structure.nim
+++ b/src/arraymancer/tensor/fallback/legacy/blas_l3_gemm_data_structure.nim
@@ -44,7 +44,7 @@ proc newBlasBuffer[T](size: int): BlasBufferArray[T] =
 
 proc check_index(a: BlasBufferArray, idx: int) {.inline, noSideEffect.}=
   if idx < 0 or idx >= a.len:
-    raise newException(IndexError,  "Index out of bounds, index was " & $idx &
+    raise newException(IndexDefect,  "Index out of bounds, index was " & $idx &
                                       " while length of the array is " & $a)
 
 proc `[]`[T](a: BlasBufferArray[T], idx: int): T {.inline, noSideEffect.} =

--- a/src/arraymancer/tensor/init_cuda.nim
+++ b/src/arraymancer/tensor/init_cuda.nim
@@ -28,7 +28,7 @@ proc cuda*[T:SomeFloat](t: Tensor[T]): CudaTensor[T] {.noInit.}=
 
   # TODO: avoid reordering rowMajor tensors. This is only needed for inplace operation in CUBLAS.
   let contig_t = t.asContiguous(colMajor, force = true)
-  let size = csize(result.size * sizeof(T))
+  let size = csize_t(result.size * sizeof(T))
 
   # For host to device we use non-blocking copy
   # Host can proceed with computation.
@@ -49,7 +49,7 @@ proc cpu*[T:SomeFloat](t: CudaTensor[T]): Tensor[T] {.noSideEffect, noInit.}=
   result.offset = t.offset
   result.data = newSeqUninit[T](t.storage.Flen) # We copy over all the memory allocated
 
-  let size = csize(t.storage.Flen * sizeof(T))
+  let size = csize_t(t.storage.Flen * sizeof(T))
 
   check cudaMemCpy( result.get_data_ptr,
                     t.get_data_ptr,

--- a/src/arraymancer/tensor/init_opencl.nim
+++ b/src/arraymancer/tensor/init_opencl.nim
@@ -24,7 +24,7 @@ proc opencl*[T:SomeFloat](t: Tensor[T]): ClTensor[T] {.noInit.}=
   result = newClTensor[T](t.shape)
 
   let contig_t = t.asContiguous(rowMajor, force = true)
-  let size = csize(result.size * sizeof(T))
+  let size = csize_t(result.size * sizeof(T))
 
   # TODO error checking in Nim opencl is broken
   # See https://github.com/nim-lang/opencl/pull/3

--- a/src/arraymancer/tensor/private/p_accessors_macros_desugar.nim
+++ b/src/arraymancer/tensor/private/p_accessors_macros_desugar.nim
@@ -24,7 +24,7 @@ const Span = SteppedSlice(b: 1, step: 1, b_from_end: true)
 # #########################################################################
 # Slicing macros - desugaring AST
 
-macro desugar*(args: untyped): typed =
+macro desugar*(args: untyped): void =
   ## Transform all syntactic sugar in arguments to integer or SteppedSlices
   ## It will then be dispatched to "atIndex" (if specific integers)
   ## or "slicer" if there are SteppedSlices
@@ -143,7 +143,7 @@ macro desugar*(args: untyped): typed =
       r.add(infix(nnk[1], "..^", infix(newIntLitNode(1), "|", nnk[2][2])))
     elif nnk0_inf_dotdot and nnk20_bar_min and nnk21_joker:
       ## Raise error on [5.._|-1, 3]
-      raise newException(IndexError, "Please use explicit end of range " &
+      raise newException(IndexDefect, "Please use explicit end of range " &
                        "instead of `_` " &
                        "when the steps are negative")
     elif nnk0_inf_dotdot_all and nnk10_hat and nnk20_bar_all:

--- a/src/arraymancer/tensor/private/p_accessors_macros_read.nim
+++ b/src/arraymancer/tensor/private/p_accessors_macros_read.nim
@@ -29,7 +29,7 @@ template slicerImpl*[T](result: AnyTensor[T]|var AnyTensor[T], slices: ArrayOfSl
   when compileOption("boundChecks"):
     if unlikely(slices.len > result.rank):
       raise newException(
-        IndexError,
+        IndexDefect,
         "Rank of slice expression (" & $slices.len &
           ") is larger than the tensor rank. Tensor shape" & $result.shape & "."
       )

--- a/src/arraymancer/tensor/private/p_checks.nim
+++ b/src/arraymancer/tensor/private/p_checks.nim
@@ -24,18 +24,18 @@ func check_nested_elements*(shape: MetadataArray, len: int) {.inline.}=
   ##   -- A shape (sequence of int)
   ##   -- A length (int)
   if unlikely(shape.product != len):
-    raise newException(IndexError, "Each nested sequence at the same level must have the same number of elements")
+    raise newException(IndexDefect, "Each nested sequence at the same level must have the same number of elements")
 
 func check_index*(t: Tensor, idx: varargs[int]) {.inline.}=
   if unlikely(idx.len != t.rank):
-    raise newException(IndexError, "Number of arguments: " &
+    raise newException(IndexDefect, "Number of arguments: " &
                     $(idx.len) &
                     ", is different from tensor rank: " &
                     $(t.rank))
 
 func check_contiguous_index*(t: Tensor, idx: int) {.inline.}=
   if unlikely(idx < 0 or idx >= t.size):
-    raise newException(IndexError, "Invalid contigous index: " &
+    raise newException(IndexDefect, "Invalid contigous index: " &
                     $idx &
                     " while tensor size is" &
                     $(t.size))
@@ -64,7 +64,7 @@ func check_steps*(a,b, step:int) {.inline.}=
   #   # like shape of (3, 0)
   #   return
   if unlikely((b-a) * step < 0):
-    raise newException(IndexError, "Your slice start: " &
+    raise newException(IndexDefect, "Your slice start: " &
                 $a & ", and stop: " &
                 $b & ", or your step: " &
                 $step &
@@ -74,7 +74,7 @@ func check_steps*(a,b, step:int) {.inline.}=
 
 func check_start_end*(a, b: int, dim_size: int) {.inline.} =
   if unlikely(a < 0 or a >= dim_size or b < 0 or b >= dim_size):
-    raise newException(IndexError, "Your slice start: " &
+    raise newException(IndexDefect, "Your slice start: " &
                 $a & ", or stop: " &
                 $b & " cannot slice a dimension of size " &
                 $dim_size &
@@ -87,7 +87,7 @@ func check_shape*(a: Tensor; b: Tensor|openarray) {.inline.}=
   let b_shape = b.shape # There is a shape proc that converts openarray to MetadataArray
 
   if unlikely(a.shape != b_shape):
-    raise newException(IndexError, "Your tensors or openarrays do not have the same shape: " &
+    raise newException(IndexDefect, "Your tensors or openarrays do not have the same shape: " &
                                    $a.shape &
                                    " and " & $b_shape)
 
@@ -123,7 +123,7 @@ func check_matmat*(a, b: AnyTensor) {.inline.}=
   let rowB = b.shape[0]
 
   if unlikely(colA != rowB):
-    raise newException(IndexError, "Number of columns in the first matrix: " &
+    raise newException(IndexDefect, "Number of columns in the first matrix: " &
                     $(colA) &
                     ", must be the same as the number of rows in the second matrix: " &
                     $(rowB))
@@ -133,14 +133,14 @@ func check_matvec*(a, b: AnyTensor) {.inline.}=
   let rowB = b.shape[0]
 
   if unlikely(colA != rowB):
-    raise newException(IndexError, "Number of columns in the matrix: " &
+    raise newException(IndexDefect, "Number of columns in the matrix: " &
                     $(colA) &
                     ", must be the same as the number of rows in the vector: " &
                     $(rowB))
 
 func check_axis_index*(t: AnyTensor, axis, index, len: Natural) {.inline.}=
   if unlikely(not (axis < t.rank and index+len <= t.shape[axis])):
-    raise newException(IndexError, "The axis is out of range, axis requested is " &
+    raise newException(IndexDefect, "The axis is out of range, axis requested is " &
                                     $axis &
                                     " and (index, length) requested (" & $index & ", " & $len &
                                     ") while tensor shape is " & $(t.shape))

--- a/tests/tensor/test_accessors.nim
+++ b/tests/tensor/test_accessors.nim
@@ -38,14 +38,14 @@ testSuite "Accessing and setting tensor values":
   when compileOption("boundChecks") and not defined(openmp):
     test "Out of bounds checking":
       var a = newTensor[int](@[2,3,4])
-      expect(IndexError):
+      expect(IndexDefect):
         a[2,0,0] = 200
       var b = newTensor[int](@[3,4])
-      expect(IndexError):
+      expect(IndexDefect):
         b[3,4] = 999
-      expect(IndexError):
+      expect(IndexDefect):
         echo b[-1,0] # We don't use discard here because with the C++ backend it is optimized away.
-      expect(IndexError):
+      expect(IndexDefect):
         echo b[0,-2]
   else:
     echo "Bound-checking is disabled or OpenMP is used. The out-of-bounds checking test has been skipped."

--- a/tests/tensor/test_accessors_slicer.nim
+++ b/tests/tensor/test_accessors_slicer.nim
@@ -134,7 +134,7 @@ testSuite "Testing indexing and slice syntax":
 
   when compileOption("boundChecks") and not defined(openmp):
     test "Slice from the end - expect non-negative step error - foo[^1..0, 3]":
-      expect(IndexError):
+      expect(IndexDefect):
         discard t_van[^1..0, 3]
   else:
     echo "Bound-checking is disabled or OpenMP is used. The Slice from end, non-negative step error test has been skipped."
@@ -233,13 +233,13 @@ testSuite "Slice mutations":
   when compileOption("boundChecks") and not defined(openmp):
     test "Bounds checking":
       var t_van = t_van_immut.clone
-      expect(IndexError):
+      expect(IndexDefect):
         t_van[0..1,0..1] = [111, 222, 333, 444, 555]
-      expect(IndexError):
+      expect(IndexDefect):
         t_van[0..1,0..1] = [111, 222, 333]
-      expect(IndexError):
+      expect(IndexDefect):
         t_van[^2..^1,2..4] = t_van[1, 4..2|-1]
-      expect(IndexError):
+      expect(IndexDefect):
         t_van[^2..^1,2..4] = t_van[^1..^3|-1, 4..2|-1]
   else:
     echo "Bound-checking is disabled or OpenMP is used. The Out of bound checking test has been skipped."
@@ -285,7 +285,7 @@ testSuite "Axis slicing":
 
   when compileOption("boundChecks") and not defined(openmp):
     test "atAxisIndex bounds checking":
-      expect(IndexError):
+      expect(IndexDefect):
         echo a.atAxisIndex(0, 3)
-      expect(IndexError):
+      expect(IndexDefect):
         echo a.atAxisIndex(1, 3, 6)

--- a/tests/tensor/test_accessors_slicer_cuda.nim
+++ b/tests/tensor/test_accessors_slicer_cuda.nim
@@ -134,7 +134,7 @@ testSuite "CUDA: Testing indexing and slice syntax":
 
   when compileOption("boundChecks") and not defined(openmp):
     test "Slice from the end - expect non-negative step error - foo[^1..0, 3]":
-      expect(IndexError):
+      expect(IndexDefect):
         discard t_van[^1..0, 3]
   else:
     echo "Bound-checking is disabled or OpenMP is used. The non-negative step test has been skipped."

--- a/tests/tensor/test_fancy_indexing.nim
+++ b/tests/tensor/test_fancy_indexing.nim
@@ -148,7 +148,7 @@ testSuite "Fancy indexing":
     block: # y[:, y.sum(axis = 0) > 50] = np.array([10, 20, 30, 40])
       var y = x.clone()
 
-      expect(IndexError):
+      expect(IndexDefect):
         y[_, y.sum(axis = 0) >. 50] = [10, 20, 30, 40].toTensor()
 
   test "Masked axis assign broadcastable 1d tensor via fancy indexing":

--- a/tests/tensor/test_init.nim
+++ b/tests/tensor/test_init.nim
@@ -72,7 +72,7 @@ testSuite "Creating a new Tensor":
     let u = @[@[1.0, -1, 2],@[0.0, -1]]
 
     when compileOption("boundChecks") and not defined(openmp):
-      expect(IndexError):
+      expect(IndexDefect):
         discard u.toTensor()
     else:
       echo "Bound-checking is disabled or OpenMP is used. The incorrect seq shape test has been skipped."

--- a/tests/tensor/test_operators_blas.nim
+++ b/tests/tensor/test_operators_blas.nim
@@ -111,7 +111,7 @@ testSuite "BLAS (Basic Linear Algebra Subprograms)":
     test "GEMM - Bounds checking":
       let c = @[@[1'f32,2,3],@[4'f32,5,6]].toTensor()
 
-      expect(IndexError):
+      expect(IndexDefect):
         discard c * c
   else:
     echo "Bound-checking is disabled or OpenMP is used. The out-of-bounds checking test has been skipped."

--- a/tests/tensor/test_operators_blas_cuda.nim
+++ b/tests/tensor/test_operators_blas_cuda.nim
@@ -100,7 +100,7 @@ testSuite "CUDA CuBLAS backend (Basic Linear Algebra Subprograms)":
   test "GEMM - Bounds checking":
     let c = @[@[1'f32,2,3],@[4'f32,5,6]].toTensor().cuda()
 
-    expect(IndexError):
+    expect(IndexDefect):
       discard c * c
 
   test "GEMV - General Matrix to Vector Multiplication":

--- a/tests/tensor/test_operators_blas_opencl.nim
+++ b/tests/tensor/test_operators_blas_opencl.nim
@@ -100,7 +100,7 @@ testSuite "OpenCL BLAS operations (Basic Linear Algebra Subprograms)":
   test "GEMM - Bounds checking":
     let c = @[@[1'f32,2,3],@[4'f32,5,6]].toTensor().opencl()
 
-    expect(IndexError):
+    expect(IndexDefect):
       discard c * c
 
   test "GEMV - General Matrix to Vector Multiplication - float32":

--- a/tests/tensor/test_ufunc.nim
+++ b/tests/tensor/test_ufunc.nim
@@ -80,7 +80,7 @@ testSuite "Universal functions":
     check: td.map(stringify)[0,1] == "4"
 
     when compileOption("boundChecks") and not defined(openmp):
-      expect(IndexError):
+      expect(IndexDefect):
         discard td.map(stringify)[1,3]
     else:
       echo "Bound-checking is disabled or OpenMP is used. The incorrect seq shape test has been skipped."

--- a/tests/test_bugtracker.nim
+++ b/tests/test_bugtracker.nim
@@ -45,7 +45,7 @@ testSuite "Testing specific issues from bug tracker":
 
   test "#307 3D slicing with same shape: offset is off":
     let x = zeros[int]([1, 2, 3])
-    expect(IndexError):
+    expect(IndexDefect):
       let y{.used.} = x[1, _, _]
 
   test "#386 Reshaping a contiguous permuted tensor":


### PR DESCRIPTION
This PR aims at fixing deprecated warnings when compiling.

* ``existsFIle`` -> ``fileExists``
* ``IndexError`` -> ``IndexDefect`` 
* ``csize`` -> ``csize_t``
* replace ``add`` for table by ``[]``

* Removed assert for 1D/2D Tensor on argmax