### PR TITLE
[WIP] Laser forEach iterators

### DIFF
--- a/benchmarks/ex01_xor.nim
+++ b/benchmarks/ex01_xor.nim
@@ -1,50 +1,52 @@
 import ../src/arraymancer
 
 # Learning XOR function with a neural network.
+proc main() =
+  # Autograd context / neuralnet graph
+  let ctx = newContext Tensor[float32]
+  let bsz = 32 # batch size
 
-# Autograd context / neuralnet graph
-let ctx = newContext Tensor[float32]
-let bsz = 32 # batch size
+  let x_train_bool = randomTensor([bsz * 100, 2], 1).astype(bool)
+  let y_bool = x_train_bool[_,0] xor x_train_bool[_,1]
+  let x_train = ctx.variable(x_train_bool.astype(float32))
+  let y = y_bool.astype(float32)
 
-let x_train_bool = randomTensor([bsz * 100, 2], 1).astype(bool)
-let y_bool = x_train_bool[_,0] xor x_train_bool[_,1]
-let x_train = ctx.variable(x_train_bool.astype(float32))
-let y = y_bool.astype(float32)
+  # We will build the following network:
+  # Input --> Linear(out_features = 3) --> relu --> Linear(out_features = 1) --> Sigmoid --> Cross-Entropy Loss
 
-# We will build the following network:
-# Input --> Linear(out_features = 3) --> relu --> Linear(out_features = 1) --> Sigmoid --> Cross-Entropy Loss
+  let layer_3neurons = ctx.variable(
+                        randomTensor(3, 2, 2.0f) -. 1.0f,
+                        requires_grad = true
+                      )
 
-let layer_3neurons = ctx.variable(
-                       randomTensor(3, 2, 2.0f) -. 1.0f,
-                       requires_grad = true
-                     )
+  let classifier_layer = ctx.variable(
+                          randomTensor(1, 3, 2.0f) -. 1.0f,
+                          requires_grad = true
+                        )
 
-let classifier_layer = ctx.variable(
-                         randomTensor(1, 3, 2.0f) -. 1.0f,
-                         requires_grad = true
-                       )
+  # Stochastic Gradient Descent
+  let optim = newSGD[float32](
+      layer_3neurons, classifier_layer, 0.01f
+    )
 
-# Stochastic Gradient Descent
-let optim = newSGD[float32](
-    layer_3neurons, classifier_layer, 0.01f
-  )
+  # Learning loop
+  for epoch in 0..10000:
+    for batch_id in 0..<100:
 
-# Learning loop
-for epoch in 0..10000:
-  for batch_id in 0..<100:
+      # minibatch offset in the Tensor
+      let offset = batch_id * 32
+      let x = x_train[offset ..< offset + 32, _]
+      let target = y[offset ..< offset + 32, _]
 
-    # minibatch offset in the Tensor
-    let offset = batch_id * 32
-    let x = x_train[offset ..< offset + 32, _]
-    let target = y[offset ..< offset + 32, _]
+      # Building the network
+      let n1 = relu linear(x, layer_3neurons)
+      let n2 = linear(n1, classifier_layer)
+      let loss = n2.sigmoid_cross_entropy(target)
 
-    # Building the network
-    let n1 = relu linear(x, layer_3neurons)
-    let n2 = linear(n1, classifier_layer)
-    let loss = n2.sigmoid_cross_entropy(target)
+      # Compute the gradient (i.e. contribution of each parameter to the loss)
+      loss.backprop()
 
-    # Compute the gradient (i.e. contribution of each parameter to the loss)
-    loss.backprop()
+      # Correct the weights now that we have the gradient information
+      optim.update()
 
-    # Correct the weights now that we have the gradient information
-    optim.update()
+main()

--- a/benchmarks/implementation/softmax_cross_entropy_bench_batch_first.nim
+++ b/benchmarks/implementation/softmax_cross_entropy_bench_batch_first.nim
@@ -176,6 +176,7 @@ proc softmax_cross_entropy_backward1[T](
 
   result = zeros_like(cached_tensor)
 
+  # TODO: nested parallelism has suspect performance
   for i in 0||(batch_size-1):
     let (max, sumexp) = cached_tensor[i,_].streaming_max_sumexp
 

--- a/benchmarks/implementation/softmax_cross_entropy_bench_batch_last.nim
+++ b/benchmarks/implementation/softmax_cross_entropy_bench_batch_last.nim
@@ -176,6 +176,7 @@ proc softmax_cross_entropy_backward1[T](
 
   result = zeros_like(cached_tensor)
 
+  # TODO: nested parallelism has suspect performance
   for i in 0||(batch_size-1): # Can't use OpenMP - SIGSEGV Illegal Address
     let (max, sumexp) = cached_tensor[_,i].streaming_max_sumexp
 

--- a/examples/ex06_shakespeare_generator.nim
+++ b/examples/ex06_shakespeare_generator.nim
@@ -56,7 +56,7 @@ const
 #
 # ################################################################
 
-func strToTensor(str: string|TaintedString): Tensor[PrintableIdx] =
+proc strToTensor(str: string|TaintedString): Tensor[PrintableIdx] =
   result = newTensor[PrintableIdx](str.len)
 
   # For each x in result, map the corresponding char index

--- a/src/arraymancer/io/io_image.nim
+++ b/src/arraymancer/io/io_image.nim
@@ -27,7 +27,7 @@ proc read_image*(filepath: string): Tensor[uint8] =
   ## Usage example with conversion to [0..1] float:
   ## .. code:: nim
   ##   let raw_img = read_image('path/to/image.png')
-  ##   let img = raw_img.map_inline:
+  ##   let img = forEach x in raw_img:
   ##     x.float32 / 255.0
 
   var width, height, channels: int

--- a/src/arraymancer/linear_algebra/helpers/least_squares_lapack.nim
+++ b/src/arraymancer/linear_algebra/helpers/least_squares_lapack.nim
@@ -6,8 +6,7 @@ import
   nimlapack, fenv,
   ./overload, ./init_colmajor,
   ../../private/sequninit,
-  ../../tensor,
-  ../../laser/strided_iteration/foreach
+  ../../tensor
 
 # Least Squares using Recursive Divide & Conquer
 # --------------------------------------------------------------------------------------

--- a/src/arraymancer/ml/dimensionality_reduction/pca.nim
+++ b/src/arraymancer/ml/dimensionality_reduction/pca.nim
@@ -3,7 +3,8 @@
 # This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  ../../tensor, ../../linear_algebra
+  ../../tensor, ../../linear_algebra,
+  ../../laser/strided_iteration/foreach
 
 proc pca*[T: SomeFloat](
        X: Tensor[T], n_components = 2, center: static bool = true,
@@ -187,8 +188,10 @@ proc pca_detailed*[T: SomeFloat](
 
   # Variance explained by Singular Values
   let bessel_correction = T(result.n_observations - 1)
-  result.explained_variance = map_inline(S):
-    x * x / bessel_correction
+  result.explained_variance = newTensorUninit[T](S.shape)
+  forEach ev in result.explained_variance,
+          s in S:
+    ev = s*s / bessel_correction
 
   # Since we are using SVD truncated to `n_components` we need to
   # refer back to the original matrix for total variance

--- a/src/arraymancer/ml/dimensionality_reduction/pca.nim
+++ b/src/arraymancer/ml/dimensionality_reduction/pca.nim
@@ -3,8 +3,7 @@
 # This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  ../../tensor, ../../linear_algebra,
-  ../../laser/strided_iteration/foreach
+  ../../tensor, ../../linear_algebra
 
 proc pca*[T: SomeFloat](
        X: Tensor[T], n_components = 2, center: static bool = true,

--- a/src/arraymancer/ml/metrics/common_error_functions.nim
+++ b/src/arraymancer/ml/metrics/common_error_functions.nim
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ../../tensor, ../../laser/strided_iteration/foreach
+import ../../tensor
 
 # ####################################################
 

--- a/src/arraymancer/ml/metrics/common_error_functions.nim
+++ b/src/arraymancer/ml/metrics/common_error_functions.nim
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ../../tensor
+import ../../tensor, ../../laser/strided_iteration/foreach
 
 # ####################################################
 
@@ -22,7 +22,11 @@ proc squared_error*[T](y, y_true: T): T {.inline.} =
 
 proc squared_error*[T](y, y_true: Tensor[T]): Tensor[T] {.noInit.} =
   ## Element-wise squared error for a tensor, |y_true - y| ^2
-  result = map2_inline(y_true, y, squared_error(x,y))
+  result = newTensorUninit[T](y.shape)
+  forEach r in result,
+          testval in y,
+          truthval in y_true:
+    r = squared_error(testval,truthval)
 
 proc mean_squared_error*[T](y, y_true: Tensor[T]): T =
   ## Also known as MSE or L2 loss, mean squared error between elements:
@@ -48,7 +52,11 @@ proc relative_error*[T](y, y_true: Tensor[T]): Tensor[T] {.noInit.} =
   ## Normally the relative error is defined as |y_true - x| / |y_true|,
   ## but here max is used to make it symmetric and to prevent dividing by zero,
   ## guaranteed to return zero in the case when both values are zero.
-  result = map2_inline(y, y_true, relative_error(x,y))
+  result = newTensorUninit[T](y.shape)
+  forEach r in result,
+          testval in y,
+          truthval in y_true:
+    r = relative_error(testval,truthval)
 
 proc mean_relative_error*[T](y, y_true: Tensor[T]): T =
   ## Mean relative error for Tensor, mean of the element-wise
@@ -67,10 +75,14 @@ proc absolute_error*[T: SomeFloat](y, y_true: T): T {.inline.} =
 
 proc absolute_error*[T](y, y_true: Tensor[T]): Tensor[T] {.noInit.} =
   ## Element-wise absolute error for a tensor
-  result = map2_inline(y, y_true, y.absolute_error(x))
+  result = newTensorUninit[T](y.shape)
+  forEach r in result,
+          testval in y,
+          truthval in y_true:
+    r = absolute_error(testval,truthval)
 
 proc mean_absolute_error*[T](y, y_true: Tensor[T]): T =
   ## Also known as L1 loss, absolute error between elements:
   ## sum(|y_true - y|)/m
   ## where m is the number of elements
-  result = map2_inline(y, y_true, y.absolute_error(x)).mean()
+  result = y.absolute_error(y_true).mean()

--- a/src/arraymancer/nn/loss/mean_square_error_loss.nim
+++ b/src/arraymancer/nn/loss/mean_square_error_loss.nim
@@ -30,8 +30,10 @@ proc mse_backward_ag[TT](self: MSELoss[TT], payload: Payload[TT]): SmallDiffs[TT
                                                   # See also Stanford course: http://theory.stanford.edu/~tim/s15/l/l15.pdf
 
   result = newDiffs[TT](1)
-  result[0] = map2_inline(self.cache.value, self.target):
-    norm * (x - y)
+  forEach r0 in result[0],
+          v in self.cache.value,
+          t in self.target:
+    r0 = norm * (v - t)
 
 proc mse_cache[TT](result: Variable[TT], input: Variable[TT], target: TT) =
   ## We expect input with shape [batch_size, features]

--- a/src/arraymancer/nn_primitives/nnp_activation.nim
+++ b/src/arraymancer/nn_primitives/nnp_activation.nim
@@ -56,7 +56,7 @@ proc msigmoid*[T: SomeFloat](t: var Tensor[T]) =
 
 proc mrelu*[T](t: var Tensor[T]) =
   forEach x in t:
-    x = t.apply_inline max(0.T, x)
+    x = max(0.T, x)
 
 proc mtanh*[T: SomeFloat](t: var Tensor[T]) =
   forEach x in t:

--- a/src/arraymancer/nn_primitives/nnp_gru.nim
+++ b/src/arraymancer/nn_primitives/nnp_gru.nim
@@ -375,10 +375,6 @@ proc gru_forward*[T: SomeFloat](
         n_lts = ns[layer, timestep, _, _].squeeze(0).squeeze(0)
         Uh_lts = Uhs[layer, timestep, _, _].squeeze(0).squeeze(0)
 
-      # TODO: gru_cell_forward will detach `nl``
-      # due to a missing apply4/loop-fusion operation
-      var n_tmp = n_lts
-
       let input_ts = block:
             if layer == 0:
               input[timestep, _, _].squeeze(0)
@@ -388,14 +384,10 @@ proc gru_forward*[T: SomeFloat](
       gru_cell_forward(
         input_ts,
         W3l, U3l, bW3l, bU3l,
-        r_lts, z_lts, n_tmp, Uh_lts,
+        r_lts, z_lts, n_lts, Uh_lts,
         hiddenl
       )
       output[timestep, _, _] = hiddenl.unsqueeze(0)
-      # TODO: apply/loop-fusion
-      # copy n_tmpl back to nl
-      apply2_inline(n_lts, n_tmp):
-        y
 
 proc gru_backward*[T: SomeFloat](
   dInput, dHidden0,                    # Input and starting hidden state gradient

--- a/src/arraymancer/nn_primitives/nnp_gru.nim
+++ b/src/arraymancer/nn_primitives/nnp_gru.nim
@@ -212,8 +212,8 @@ proc gru_cell_backward*[T: SomeFloat](
   linear_backward(h, U3, dU3h, dh, dU3, dbU3)
 
   # Backprop of step 4 - h part
-  apply3_inline(dh, dnext, z):
-    x + y * z
+  forEach dhi in dh, dni in dnext, zi in z:
+    dhi += dni * zi
 
 proc gru_inference*[T: SomeFloat](
   input: Tensor[T],

--- a/src/arraymancer/nn_primitives/nnp_linear.nim
+++ b/src/arraymancer/nn_primitives/nnp_linear.nim
@@ -24,7 +24,6 @@ proc linear*[T](input, weight: Tensor[T], bias: Tensor[T], output: var Tensor[T]
   #   - bias tensor shape [1, out_features]
   # Output does not need to be initialized to 0 or the proper shape, data will be overwritten
   # Output is: Y = x * W.transpose + b
-
   output = input * weight.transpose # TODO: with the transpose the non-matching rows and cols is confusing
   output +.= bias
 

--- a/src/arraymancer/nn_primitives/nnp_softmax_cross_entropy.nim
+++ b/src/arraymancer/nn_primitives/nnp_softmax_cross_entropy.nim
@@ -146,13 +146,14 @@ proc softmax_cross_entropy_backward*[T](
 
   result = zeros_like(cached_tensor)
 
+  # TODO: nested parallelism has suspect performance
   for i in 0||(batch_size-1):
     let (max, sumexp) = cached_tensor[i,_].streaming_max_sumexp
 
     var res_slice = result[i,_]
 
-    apply3_inline(res_slice, cached_tensor[i,_], target[i,_]):
-      grad * (stable_softmax(y, max, sumexp) - z) / T(batch_size)
+    forEachSerial r in res_slice, ci in cached_tensor[i,_], ti in target[i,_]:
+      r = grad * (stable_softmax(ci, max, sumexp) - ti) / T(batch_size)
 
 
 proc sparse_softmax_cross_entropy_backward*[T; Idx: SomeNumber or byte or char or enum](

--- a/src/arraymancer/stats/kde.nim
+++ b/src/arraymancer/stats/kde.nim
@@ -179,7 +179,8 @@ proc kde*[T: SomeNumber; U: int | Tensor[SomeNumber] | openArray[SomeNumber]](
 
   if normalize:
     let normFactor = 1.0 / (result.sum * (maxT - minT) / nsamples.float)
-    result.apply_inline(normFactor * x)
+    forEach x in result:
+      x *= normFactor
 
 proc kde*[T: SomeNumber; U: KernelKind | string; V: int | Tensor[SomeNumber] | openArray[SomeNumber]](
     t: Tensor[T],

--- a/src/arraymancer/tensor.nim
+++ b/src/arraymancer/tensor.nim
@@ -17,6 +17,7 @@ import nimblas
 export OrderType
 
 import  ./laser/dynamic_stack_arrays,
+        ./laser/strided_iteration/foreach,
         ./tensor/data_structure,
         ./tensor/init_cpu,
         ./tensor/init_copy_cpu,
@@ -45,6 +46,7 @@ import  ./laser/dynamic_stack_arrays,
         ./tensor/exporting
 
 export  dynamic_stack_arrays,
+        foreach,
         data_structure,
         init_cpu,
         init_copy_cpu,

--- a/src/arraymancer/tensor/higher_order_applymap.nim
+++ b/src/arraymancer/tensor/higher_order_applymap.nim
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import  ./backend/openmp,
+import  ../laser/strided_iteration/foreach,
+        ./backend/openmp,
         ./private/p_checks,
         ./data_structure, ./init_cpu, ./accessors, ./accessors_macros_write
 
+export foreach
 import sugar except enumerate
 
 # ####################################################################
@@ -206,10 +208,8 @@ proc apply*[T: KnownSupportsCopyMem](t: var Tensor[T], f: proc(x:var T)) =
   ##       x += 1
   ##     a.apply(pluseqone) # Apply the in-place function pluseqone
   ## ``apply`` is especially useful to do multiple element-wise operations on a tensor in a single loop over the data.
-
-  omp_parallel_blocks(block_offset, block_size, t.size):
-    for x in t.mitems(block_offset, block_size):
-      f(x)
+  forEach x in t:
+    f(x)
 
 proc map2*[T, U; V: KnownSupportsCopyMem](t1: Tensor[T],
                                           f: (T,U) -> V,

--- a/src/arraymancer/tensor/higher_order_applymap.nim
+++ b/src/arraymancer/tensor/higher_order_applymap.nim
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import  ../laser/strided_iteration/foreach,
+import  ../laser/strided_iteration/[foreach, foreach_staged],
         ./backend/openmp,
         ./private/p_checks,
         ./data_structure, ./init_cpu, ./accessors, ./accessors_macros_write
 
-export foreach
+export foreach, foreach_staged
 import sugar except enumerate
 
 # ####################################################################

--- a/src/arraymancer/tensor/math_functions.nim
+++ b/src/arraymancer/tensor/math_functions.nim
@@ -26,7 +26,9 @@ proc elwise_mul*[T](a, b: Tensor[T]): Tensor[T] {.noInit.} =
 
 proc melwise_mul*[T](a: var Tensor[T], b: Tensor[T]) =
   ## Element-wise multiply
-  a.apply2_inline(b, x * y)
+  forEach x in a,
+          y in b:
+    x *= y
 
 proc elwise_div*[T: Someinteger](a, b: Tensor[T]): Tensor[T] {.noInit.} =
   ## Element-wise division
@@ -38,11 +40,15 @@ proc elwise_div*[T: SomeFloat](a, b: Tensor[T]): Tensor[T] {.noInit.} =
 
 proc melwise_div*[T: Someinteger](a: var Tensor[T], b: Tensor[T]) =
   ## Element-wise division (in-place)
-  a.apply2_inline(b, x div y)
+  forEach x in a,
+          y in b:
+    x = x div y
 
 proc melwise_div*[T: SomeFloat](a: var Tensor[T], b: Tensor[T]) =
   ## Element-wise division (in-place)
-  a.apply2_inline(b, x / y)
+  forEach x in a,
+          y in b:
+    x /= y
 
 proc reciprocal*[T: SomeFloat](t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Return a tensor with the reciprocal 1/x of all elements
@@ -50,17 +56,21 @@ proc reciprocal*[T: SomeFloat](t: Tensor[T]): Tensor[T] {.noInit.} =
 
 proc mreciprocal*[T: SomeFloat](t: var Tensor[T]) =
   ## Apply the reciprocal 1/x in-place to all elements of the Tensor
-  t.apply_inline(1.T/x)
+  forEach x in t:
+    x = 1.T/x
 
 proc reciprocal*[T: Complex[float32] or Complex[float64]](t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Return a tensor with the reciprocal 1/x of all elements
   type F = T.T # Get float subtype of Complex[T]
-  t.map_inline(complex(1.F, 0.F)/x)
+  result = newTensorUninit[T](t.shape)
+  forEach x in t, r in result:
+    r = complex(1.F, 0.F)/x
 
 proc mreciprocal*[T: Complex[float32] or Complex[float64]](t: var Tensor[T]) =
   ## Apply the reciprocal 1/x in-place to all elements of the Tensor
   type F = T.T # Get float subtype of Complex[T]
-  t.apply_inline(complex(1.F, 0.F)/x)
+  forEach x in t:
+    x = complex(1.F, 0.F)/x
 
 proc negate*[T: SomeSignedInt|SomeFloat](t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Return a tensor with all elements negated (10 -> -10)
@@ -68,7 +78,8 @@ proc negate*[T: SomeSignedInt|SomeFloat](t: Tensor[T]): Tensor[T] {.noInit.} =
 
 proc mnegate*[T: SomeSignedInt|SomeFloat](t: var Tensor[T]) =
   ## Negate in-place all elements of the tensor (10 -> -10)
-  t.apply_inline(-x)
+  forEach x in t:
+    x = -x
 
 proc `-`*[T: SomeNumber](t: Tensor[T]): Tensor[T] {.noInit.} =
   ## Negate all values of a Tensor
@@ -91,13 +102,15 @@ proc abs*(t: Tensor[Complex[float32]]): Tensor[float32] {.noInit.} =
 proc mabs*[T](t: var Tensor[T]) =
   ## Return a Tensor with absolute values of all elements
   # FIXME: how to inplace convert Tensor[Complex] to Tensor[float]
-  t.apply_inline(abs(x))
+  forEach x in t:
+    x = abs(x)
 
 proc clamp*[T](t: Tensor[T], min, max: T): Tensor[T] {.noInit.} =
   t.map_inline(clamp(x, min, max))
 
 proc mclamp*[T](t: var Tensor[T], min, max: T) =
-  t.apply_inline(clamp(x, min, max))
+  forEach x in t:
+    x = clamp(x, min, max)
 
 proc square*[T](x: T): T {.inline.} =
   ## Return x*x

--- a/src/arraymancer/tensor/operators_blas_l1.nim
+++ b/src/arraymancer/tensor/operators_blas_l1.nim
@@ -90,16 +90,19 @@ proc `*=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], a:
   ## Element-wise multiplication by a scalar (in-place)
   if t.size == 0:
     return
-  t.apply_inline(x * a)
+  forEach x in t:
+    x *= a
 
 proc `/=`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: var Tensor[T], a: T) =
   ## Element-wise division by a scalar (in-place)
   if t.size == 0:
     return
-  t.apply_inline(x / a)
+  forEach x in t:
+    x /= a
 
 proc `/=`*[T: SomeInteger](t: var Tensor[T], a: T) =
   ## Element-wise division by a scalar (in-place)
   if t.size == 0:
     return
-  t.apply_inline(x div a)
+  forEach x in t:
+    x = x div a

--- a/src/arraymancer/tensor/operators_broadcasted.nim
+++ b/src/arraymancer/tensor/operators_broadcasted.nim
@@ -145,31 +145,36 @@ proc `+.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], v
   ## Tensor in-place addition with a broadcasted scalar.
   if t.size == 0:
     return
-  t.apply_inline(x + val)
+  forEach x in t:
+    x += val
 
 proc `-.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
   ## Tensor in-place substraction with a broadcasted scalar.
   if t.size == 0:
     return
-  t.apply_inline(x - val)
+  forEach x in t:
+    x -= val
 
 proc `^.=`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: var Tensor[T], exponent: T) =
   ## Compute in-place element-wise exponentiation
   if t.size == 0:
     return
-  t.apply_inline pow(x, exponent)
+  forEach x in t:
+    x = x.pow(exponent)
 
 proc `*.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
   ## Tensor in-place multiplication with a broadcasted scalar.
   if t.size == 0:
     return
-  t.apply_inline(x * val)
+  forEach x in t:
+    x *= val
 
 proc `/.=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], val: T) =
   ## Tensor in-place division with a broadcasted scalar.
   if t.size == 0:
     return
-  t.apply_inline(x / val)
+  forEach x in t:
+    x /= val
 
 
 # ##############################################

--- a/tests/manual_checks/optimizers/test_optimizers.nim
+++ b/tests/manual_checks/optimizers/test_optimizers.nim
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import
-  ../../src/arraymancer, ../testutils,
+  ../../../src/arraymancer, ../../testutils,
   unittest, random, strformat
 
 # ############################################################
@@ -25,14 +25,14 @@ import
 # We use the Rosenbrock function for testing optimizers
 # https://en.wikipedia.org/wiki/Rosenbrock_function
 
-func rosenbrock[T](x, y: Tensor[T], a: static T = 1, b: static T = 100): Tensor[T] =
+proc rosenbrock[T](x, y: Tensor[T], a: static T = 1, b: static T = 100): Tensor[T] =
   # f(x, y) = (a - x)² + b(y - x²)²
   result = map2_inline(x, y):
     let u = a - x
     let v = y - x*x
     u * u + b * v * v
 
-func drosenbrock[T](x, y: Tensor[T], a: static T = 1, b: static T = 100): tuple[dx, dy: Tensor[T]] =
+proc drosenbrock[T](x, y: Tensor[T], a: static T = 1, b: static T = 100): tuple[dx, dy: Tensor[T]] =
   result.dx = map2_inline(x, y):
     2.T*x - 2.T*a + 4*b*x*x*x - 4*b*x*y
   result.dy = map2_inline(x, y):


### PR DESCRIPTION
This replaces the use of `mapX_inline` and `applyX_inline` by the forEach / forEachContiguous / forEachParallel / forEachSerial laser iterators.

This is particularly valuable for recurrent neural network like GRU because we can implement the equation in a straightforward manner with meaning ful variable name instead of magic `x`, `y`, `z` and we would have needed an `apply11_inline` anyway (with the correct var/non-var parameters).

TODO:
-  There is a significant parallel performance regression on GRU when running test_nnp_gru. While before this PR the parallel version was "only" 2x slower than serial, now it's 13x slower than serial which probably signals a false sharing issue.
  Even then RNN are a type of iterative stencil application that require special care and often used for polyhedral benchmarking so another approach using tiling is probably needed to properly speed those up. (see https://github.com/numforge/laser/blob/master/research/automatic_loop_nest_scheduling.md#polyhedral-approaches)

Not in scope:
- using forEach for backward propagation in GRU: this is a headache inducing refactoring