### PR TITLE
fix #496 by importing math

### DIFF
--- a/src/arraymancer/linear_algebra/helpers/least_squares_lapack.nim
+++ b/src/arraymancer/linear_algebra/helpers/least_squares_lapack.nim
@@ -6,7 +6,8 @@ import
   nimlapack, fenv,
   ./overload, ./init_colmajor,
   ../../private/sequninit,
-  ../../tensor
+  ../../tensor,
+  math
 
 # Least Squares using Recursive Divide & Conquer
 # --------------------------------------------------------------------------------------


### PR DESCRIPTION
The math module (at least nowadays) defines ^ for `Natural` second arguments.