### PR TITLE
Add unsafe_raw_data

### DIFF
--- a/arraymancer.nimble
+++ b/arraymancer.nimble
@@ -1,5 +1,5 @@
 ### Package
-version       = "0.6.2"
+version       = "0.6.3"
 author        = "Mamy André-Ratsimbazafy"
 description   = "A n-dimensional tensor (ndarray) library"
 license       = "Apache License 2.0"

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 Arraymancer v0.6.X
 =====================================================
 Changes :
-  - Add ``unsafe_raw_data`` as replacement of ``dataArray`` to return a ``ptr UncheckedArray`` 
+  - Add ``toUnsafeView`` as replacement of ``dataArray`` to return a ``ptr UncheckedArray``
 
 
 Arraymancer v0.6.2 Dec. 22 2020

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,13 @@
-Arraymancer v0.x.x
+Arraymancer v0.6.X
+=====================================================
+Changes :
+  - Add ``unsafe_raw_data`` as replacement of ``dataArray`` to return a ``ptr UncheckedArray`` 
+
+
+Arraymancer v0.6.2 Dec. 22 2020
 =====================================================
 
-Changes (TODO):
+Changes :
   - Fancy Indexing (#434)
   - ``argmax_max`` obsolete assert to 1D/2D removed. It refered to issues #183 and merged PR #171
 

--- a/src/arraymancer/laser/tensor/datatypes.nim
+++ b/src/arraymancer/laser/tensor/datatypes.nim
@@ -177,6 +177,17 @@ func unsafe_raw_offset*[T: KnownSupportsCopyMem](t: var Tensor[T], aligned: stat
   ## and that the data is aligned by LASER_MEM_ALIGN (default 64).
   unsafe_raw_offset_impl(t.offset)
 
+func unsafe_raw_data*[T: KnownSupportsCopyMem](t: Tensor[T], aligned: static bool = true): UncheckedArray[T] {.inline.} =
+  ## Returns a ``ptr UncheckedArray`` to the start of the valid data.
+  ## Avoid writing to the returned pointer. Use ``fromBuffer`` instead to write Tensor data from a pointer.
+  ##
+  ##
+  ## Unsafe: the pointer can outlive the input tensor
+  ## For optimization purposes, Laser will hint the compiler that
+  ## while the pointer is valid, all data accesses will be through it (no aliasing)
+  ## and that the data is aligned by LASER_MEM_ALIGN (default 64).
+  unsafe_raw_offset(t, aligned).distinctBase()
+
 func unsafe_raw_buf*[T: not KnownSupportsCopyMem](t: Tensor[T], aligned: static bool = true): ptr UncheckedArray[T]  {.error: "Access via raw pointer forbidden for non mem copyable types!".}
 
 func unsafe_raw_offset*[T: not KnownSupportsCopyMem](t: Tensor[T], aligned: static bool = true): ptr UncheckedArray[T] {.error: "Access via raw pointer forbidden for non mem copyable types!".}

--- a/src/arraymancer/laser/tensor/datatypes.nim
+++ b/src/arraymancer/laser/tensor/datatypes.nim
@@ -177,7 +177,7 @@ func unsafe_raw_offset*[T: KnownSupportsCopyMem](t: var Tensor[T], aligned: stat
   ## and that the data is aligned by LASER_MEM_ALIGN (default 64).
   unsafe_raw_offset_impl(t.offset)
 
-func unsafe_raw_data*[T: KnownSupportsCopyMem](t: Tensor[T], aligned: static bool = true): UncheckedArray[T] {.inline.} =
+func unsafe_raw_data*[T: KnownSupportsCopyMem](t: Tensor[T], aligned: static bool = true): ptr UncheckedArray[T] {.inline.} =
   ## Returns a ``ptr UncheckedArray`` to the start of the valid data.
   ## Avoid writing to the returned pointer. Use ``fromBuffer`` instead to write Tensor data from a pointer.
   ##

--- a/src/arraymancer/laser/tensor/datatypes.nim
+++ b/src/arraymancer/laser/tensor/datatypes.nim
@@ -177,17 +177,6 @@ func unsafe_raw_offset*[T: KnownSupportsCopyMem](t: var Tensor[T], aligned: stat
   ## and that the data is aligned by LASER_MEM_ALIGN (default 64).
   unsafe_raw_offset_impl(t.offset)
 
-func unsafe_raw_data*[T: KnownSupportsCopyMem](t: Tensor[T], aligned: static bool = true): ptr UncheckedArray[T] {.inline.} =
-  ## Returns a ``ptr UncheckedArray`` to the start of the valid data.
-  ## Avoid writing to the returned pointer. Use ``fromBuffer`` instead to write Tensor data from a pointer.
-  ##
-  ##
-  ## Unsafe: the pointer can outlive the input tensor
-  ## For optimization purposes, Laser will hint the compiler that
-  ## while the pointer is valid, all data accesses will be through it (no aliasing)
-  ## and that the data is aligned by LASER_MEM_ALIGN (default 64).
-  unsafe_raw_offset(t, aligned).distinctBase()
-
 func unsafe_raw_buf*[T: not KnownSupportsCopyMem](t: Tensor[T], aligned: static bool = true): ptr UncheckedArray[T]  {.error: "Access via raw pointer forbidden for non mem copyable types!".}
 
 func unsafe_raw_offset*[T: not KnownSupportsCopyMem](t: Tensor[T], aligned: static bool = true): ptr UncheckedArray[T] {.error: "Access via raw pointer forbidden for non mem copyable types!".}

--- a/src/arraymancer/laser/tensor/initialization.nim
+++ b/src/arraymancer/laser/tensor/initialization.nim
@@ -234,6 +234,8 @@ proc fromBuffer*[T](rawBuffer: ptr UncheckedArray[T], shape: varargs[int]): Tens
   ## If you type cast a raw `pointer` to `ptr UncheckedArray[T]` before handing it to this
   ## proc, make sure to cast to the correct type as we cannot check the validity of
   ## the type!
+  ##
+  ## Its counterpart ``toUnsafeView`` can be used to obtain ``ptr UncheckedArray`` from a Tensor.
   var size: int
   initTensorMetadata(result, size, shape)
   cpuStorageFromBuffer(result.storage, rawBuffer, size)
@@ -242,6 +244,16 @@ proc fromBuffer*[T](rawBuffer: pointer, shape: varargs[int]): Tensor[T] =
   ## Creates a `Tensor[T]` from a raw `pointer`. Make sure that the explicit type
   ## given to this proc actually matches the data stored behind the pointer!
   ## The size derived from the given shape must match the size of the buffer!
+  ##
+  ## Its counterpart ``toUnsafeView`` can be used to obtain ``ptr UncheckedArray`` from a Tensor.
   var size: int
   initTensorMetadata(result, size, shape)
   cpuStorageFromBuffer(result.storage, rawBuffer, size)
+
+func toUnsafeView*[T: KnownSupportsCopyMem](t: Tensor[T], aligned: static bool = true): ptr UncheckedArray[T] {.inline.} =
+  ## Returns an unsafe view of the valid data as a ``ptr UncheckedArray``.
+  ## Its counterpart ``fromBuffer`` can be used to create a Tensor from``ptr UncheckedArray``.
+  ##
+  ## Unsafe: the pointer can outlive the input tensor.
+  unsafe_raw_offset(t, aligned).distinctBase()
+

--- a/src/arraymancer/tensor/data_structure.nim
+++ b/src/arraymancer/tensor/data_structure.nim
@@ -185,7 +185,7 @@ proc get_offset_ptr*[T](t: CudaTensor[T] or ClTensor[T]): ptr T {.noSideEffect, 
   ##     - A pointer to the offset start of its data
   t.storage.Fdata[t.offset].unsafeAddr
 
-proc dataArray*[T: KnownSupportsCopyMem](t: Tensor[T]): ptr UncheckedArray[T] {.noSideEffect, inline, deprecated: "Use unsafe_raw_data instead".}=
+proc dataArray*[T: KnownSupportsCopyMem](t: Tensor[T]): ptr UncheckedArray[T] {.noSideEffect, inline, deprecated: "Use toUnsafeView instead".}=
   ## Input:
   ##     - A tensor
   ## Returns:

--- a/src/arraymancer/tensor/data_structure.nim
+++ b/src/arraymancer/tensor/data_structure.nim
@@ -185,7 +185,7 @@ proc get_offset_ptr*[T](t: CudaTensor[T] or ClTensor[T]): ptr T {.noSideEffect, 
   ##     - A pointer to the offset start of its data
   t.storage.Fdata[t.offset].unsafeAddr
 
-proc dataArray*[T: KnownSupportsCopyMem](t: Tensor[T]): ptr UncheckedArray[T] {.noSideEffect, inline, deprecated: "Use unsafe_raw_offset instead".}=
+proc dataArray*[T: KnownSupportsCopyMem](t: Tensor[T]): ptr UncheckedArray[T] {.noSideEffect, inline, deprecated: "Use unsafe_raw_data instead".}=
   ## Input:
   ##     - A tensor
   ## Returns:


### PR DESCRIPTION
This PR add a simple unsafe_raw_data access function to get a ``ptr UncheckedArray[T]`` based on unsafe_raw_offset.

No distinction is made so far on Immutable vs Mutable (since this is not intended to write to this ptr anyway, there is ``fromBuffer`` for that). 
Other possibility would be:  
* forbid this func for non-var Tensor 
* define 2 func :

```nim
func unsafe_raw_data*[T: KnownSupportsCopyMem](t: Tensor[T], aligned: static bool = true): UncheckedArray[T] {.inline.} 

func unsafe_raw_mut_data*[T: KnownSupportsCopyMem](t: var Tensor[T], aligned: static bool = true): UncheckedArray[T] {.inline.} 
```

Since ``unsafe_raw_data`` directly use ``unsafe_raw_offset().distinctBase()`` I didn't see the need to add another unit test; but if It's a wrong assumption, I'll add one .

I added the 0.6.2 release date in the changelog, but if you want in another PR i can just revert the commit and open a new one 
