### PR TITLE
fix arraymancer for https://github.com/nim-lang/Nim/pull/18050

### DIFF
--- a/src/arraymancer/laser/tensor/initialization.nim
+++ b/src/arraymancer/laser/tensor/initialization.nim
@@ -134,6 +134,10 @@ proc copyFromRaw*[T](dst: var Tensor[T], buffer: ptr T, len: Natural) =
   ## Destination tensor size and buffer length should be the same
   when T is KnownSupportsCopyMem:
     withCompilerOptimHints()
+    mixin size
+      # either this or `from ../../tensor/data_structure import size` is needed
+      # as can be seen with: `type tmp = typeof(Tensor[int].default.size)` which
+      # would fail at top-level
     doAssert dst.size == len, "Tensor size and buffer length should be the same"
     let buf{.restrict.} = cast[ptr UncheckedArray[T]](buffer)
     omp_parallel_chunks(
@@ -167,6 +171,7 @@ proc setZero*[T](t: var Tensor[T], check_contiguous: static bool = true) =
     t.storage.raw_buffer.reset()
     t.storage.raw_buffer.setLen(t.size)
   else:
+    mixin size
     omp_parallel_chunks(
           t.size, chunk_offset, chunk_size,
           OMP_MEMORY_BOUND_GRAIN_SIZE * 4):


### PR DESCRIPTION
unblocks https://github.com/nim-lang/Nim/pull/18050 which fixes the long-standing generic sandwich problem in nim (nim CI in that nim PR fails for 2 packages which depend on arraymancer; this arraymancer PR fixes it)

this is forward and backward compatible.

I can change the PR to `from ../../tensor/data_structure import size` above copyFromRaw if needed (either works)

size isn't defined in this the scope where `copyFromRaw` uses it, and only works currently in nim devel because of the generic sandwich problem; but after https://github.com/nim-lang/Nim/pull/18050 it won't work unless either mixin is used or `from ../../tensor/data_structure import size` is used.


