### PR TITLE
Fix examples & compile in CI to avoid regressions

### DIFF
--- a/arraymancer.nimble
+++ b/arraymancer.nimble
@@ -143,6 +143,15 @@ proc test(name, switches = "", split = false, lang = "c") =
     exec "nim " & lang & " -o:build/" & name & switches & " -r tests/" & name & ".nim"
   else:
     exec "nim " & lang & " -o:build/" & name & switches & " -r tests/_split_tests/" & name & ".nim"
+  # try to compile (not run) all examples to avoid regressions
+  let examples = @["ex01_xor_perceptron_from_scratch.nim",
+                   "ex02_handwritten_digits_recognition.nim",
+                   "ex03_simple_two_layers.nim",
+                   "ex04_fizzbuzz_interview_cheatsheet.nim",
+                   "ex05_sequence_classification_GRU.nim",
+                   "ex06_shakespeare_generator.nim"]
+  for ex in examples:
+    exec "nim " & lang & " -o:build/" & name & switches & " examples/" & $ex
 
 task all_tests, "Run all tests - Intel MKL + Cuda + OpenCL + OpenMP":
   var switches = " -d:cuda -d:opencl -d:openmp"

--- a/examples/ex04_fizzbuzz_interview_cheatsheet.nim
+++ b/examples/ex04_fizzbuzz_interview_cheatsheet.nim
@@ -13,7 +13,7 @@ import ../src/arraymancer, math, strformat
 # We want to input a number and output the correct "fizzbuzz" representation
 # ideally the input is a represented by a vector of real values between 0 and 1
 # One way to do that is by using the binary representation of number
-func binary_encode(i: int, num_digits: int): Tensor[float32] =
+proc binary_encode(i: int, num_digits: int): Tensor[float32] =
   result = newTensor[float32](1, num_digits)
   for d in 0 ..< num_digits:
     result[0, d] = float32(i shr d and 1)

--- a/examples/ex05_sequence_classification_GRU.nim
+++ b/examples/ex05_sequence_classification_GRU.nim
@@ -23,7 +23,7 @@ func classify(input: Tensor[float32], id: int): SeqKind =
 proc gen3(): array[3, float32] =
   # Generate monotonic sequence with more than 25% probability
   # Note that if NonMonotonic is drawn, it's just plain random
-  let kind = rand([Increasing, Decreasing, NonMonotonic, NonMonotonic])
+  let kind = sample([Increasing, Decreasing, NonMonotonic, NonMonotonic])
 
   result[0] = rand(1.0)
   for i in 1..2:

--- a/src/arraymancer/datasets/imdb.nim
+++ b/src/arraymancer/datasets/imdb.nim
@@ -87,7 +87,7 @@ proc read_imdb(path: string): Imdb =
 
 
 proc load_imdb*(cache: static bool = true): Imdb =
-  let cache_dir = get_cache_dir()
+  let cache_dir = util.get_cache_dir()
 
   if not dirExists( cache_dir / folder_name):
     create_cache_dirs_if_necessary()

--- a/src/arraymancer/datasets/mnist.nim
+++ b/src/arraymancer/datasets/mnist.nim
@@ -180,7 +180,7 @@ proc load_mnist*(cache: static bool = true): Mnist =
   ## - delete the downloaded files if cache is false
 
   let
-    cache_dir = get_cache_dir()
+    cache_dir = util.get_cache_dir()
     files = cache_dir.mnistFilesPath
 
   if not files.all(x => x.fileExists):

--- a/src/arraymancer/nn/optimizers/optimizers.nim
+++ b/src/arraymancer/nn/optimizers/optimizers.nim
@@ -224,7 +224,7 @@ proc update*(self: var Adam) =
       # Zero the gradient
       v.grad = v.value.zeros_like # TODO "setZero" instead of a new allocation
 
-func optimizerAdam*[M, T](
+proc optimizerAdam*[M, T](
         model: M,
         learning_rate: T = T(0.001),
         beta1 = T(0.9), beta2 = T(0.999),


### PR DESCRIPTION
This fixes all examples to make them compile on current devel. Let's hope this doesn't break the CI for old Nim versions (but who are we kidding). 

Fixes #514 if it all works.