### PR TITLE
further tensor `pretty` improvements

### DIFF
--- a/src/arraymancer/tensor/display.nim
+++ b/src/arraymancer/tensor/display.nim
@@ -22,8 +22,8 @@ proc pretty*[T](t: Tensor[T], precision = -1): string =
   let desc = t.type.name & " of shape \"" & $t.shape & "\" on backend \"" & "Cpu" & "\""
   if t.size() == 0:
     return desc & "\n    [] (empty)"
-  elif t.rank <= 2:
-    return desc & "\n" & t.disp2d(precision = precision)
+  elif t.rank == 1: # for rank 1 we want an indentation, because we have no `|`
+    return desc & "\n    " & t.prettyImpl(precision = precision)
   else:
     return desc & "\n" & t.prettyImpl(precision = precision)
 

--- a/src/arraymancer/tensor/display_cuda.nim
+++ b/src/arraymancer/tensor/display_cuda.nim
@@ -23,7 +23,7 @@ proc pretty*[T](t: CudaTensor[T], precision = -1): string =
   let cpu_t = t.cpu()
   if cpu_t.size() == 0:
     return desc & "\n    [] (empty)"
-  elif t.rank == 1: # for rank 1 we want an indentation, because we have no `|`
+  elif cpu_t.rank == 1: # for rank 1 we want an indentation, because we have no `|`
     return desc & "\n    " & cpu_t.prettyImpl(precision = precision)
   else:
     return desc & "\n" & cpu_t.prettyImpl(precision = precision)

--- a/src/arraymancer/tensor/display_cuda.nim
+++ b/src/arraymancer/tensor/display_cuda.nim
@@ -23,8 +23,8 @@ proc pretty*[T](t: CudaTensor[T], precision = -1): string =
   let cpu_t = t.cpu()
   if cpu_t.size() == 0:
     return desc & "\n    [] (empty)"
-  elif cpu_t.rank <= 2:
-    return desc & "\n" & cpu_t.disp2d(precision = precision)
+  elif t.rank == 1: # for rank 1 we want an indentation, because we have no `|`
+    return desc & "\n    " & cpu_t.prettyImpl(precision = precision)
   else:
     return desc & "\n" & cpu_t.prettyImpl(precision = precision)
 


### PR DESCRIPTION
The implementation had the problem that for long floats we could run
into overlapping issues, as `disp2d` by itself didn't contain enough
alignment by itself.

In addition we didn't have any 1D tensor printing tests, which could
have caught this.

In addition I'm surprised the vandermonde 2D printing test case passed before. The spacing was wrong.

In that particular case it looks a bit funny, because the first column has so much more space. But this is just an illusion (it has less space than the other columns), but due to the left space of the second column it appears as such. The large spacing comes from the large difference between smallest and largest numbers in the tensor.

This alignment is important though for a pretty output for larger tensors so that all rows keep proper alignment.