### PR TITLE
allocate memory without zero initialization

### DIFF
--- a/src/arraymancer/laser/tensor/datatypes.nim
+++ b/src/arraymancer/laser/tensor/datatypes.nim
@@ -80,7 +80,7 @@ proc allocCpuStorage*[T](storage: var CpuStorage[T], size: int) =
       new(storage, finalizer[T])
     else:
       new(storage)
-    storage.memalloc = allocShared0(sizeof(T) * size + LASER_MEM_ALIGN - 1)
+    storage.memalloc = allocShared(sizeof(T) * size + LASER_MEM_ALIGN - 1)
     storage.isMemOwner = true
     storage.raw_buffer = align_raw_data(T, storage.memalloc)
   else: # Always 0-initialize Tensors of seq, strings, ref types and types with non-trivial destructors


### PR DESCRIPTION
Currently during tensor initialization we call `allocShared0`. This causes zero initialization in every case, rendering the existence of `newTensorUninit` moot. 

In tensor construction procs like `newTensor`, `zeros` etc. we zero initialize manually afterwards using `setZero` anyway.

This causes big performance issues in code that depends on `newTensorUninit` to not run over the data.