### PR TITLE
Linear Algebra fixes and additions

### DIFF
--- a/src/arraymancer/linear_algebra/helpers/least_squares_lapack.nim
+++ b/src/arraymancer/linear_algebra/helpers/least_squares_lapack.nim
@@ -54,7 +54,7 @@ proc gelsd*[T: SomeFloat](
   var b2: Tensor[T]
   b2.newMatrixUninitColMajor(ldb.int, nrhs.int)
 
-  var b2_slice = b2[0 ..< b.shape[0], 0 ..< nrhs] # Workaround because slicing does no produce a var at the moment
+  var b2_slice = b2[0 ..< b.shape[0], 0 ..< nrhs] # Workaround because slicing does not produce a var at the moment
   apply2_inline(b2_slice, b):
     # paste b in b2.
     # if b2 is larger, the rest is zeros

--- a/src/arraymancer/linear_algebra/helpers/least_squares_lapack.nim
+++ b/src/arraymancer/linear_algebra/helpers/least_squares_lapack.nim
@@ -71,8 +71,8 @@ proc gelsd*[T: SomeFloat](
   singular_values = newTensorUninit[T](minmn) # will hold the singular values of A
 
   var # Temporary parameter values
-    # Condition for a float to be considered 0
-    rcond = epsilon(T) * a.shape.max.T * a.max
+    # Condition for singular values considered to be zero, s(i) <= rcond * s(i) are treated as zero
+    rcond = epsilon(T)
     lwork = max(1, 12 * m + 2 * m * smlsiz + 8 * m * nlvl + m * nrhs + (smlsiz + 1) ^ 2)
     work = newSeqUninit[T](lwork)
     iwork = newSeqUninit[cint](liwork)

--- a/src/arraymancer/linear_algebra/special_matrices.nim
+++ b/src/arraymancer/linear_algebra/special_matrices.nim
@@ -31,3 +31,19 @@ proc hilbert*(n: int, T: typedesc[SomeFloat]): Tensor[T] =
 
   # TODO: scipy has a very fast hilbert matrix generation
   #       via Hankel Matrix and fancy 2D indexing
+
+proc vandermonde*[T](x: Tensor[T], order: int): Tensor[float] =
+  ## Returns a Vandermonde matrix of the input `x` up to the given `order`.
+  ##
+  ## A vandermonde matrix consists of the input `x` split into multiple
+  ## rows where each row contains all powers from 0 to `order` of `x_i`.
+  ##
+  ## `V_ij = x_i ^ order_j`
+  ##
+  ## where `order_j` runs from 0 to `order`.
+  assert x.squeeze.rank == 1
+  let x = x.squeeze.asType(float)
+  result = newTensorUninit[float]([x.size.int, order.int])
+  let orders = arange(order.float)
+  for i, ax in enumerateAxis(result, axis = 1):
+    result[_, i] = (x ^. orders[i]).unsqueeze(axis = 1)

--- a/tests/linear_algebra/test_linear_algebra.nim
+++ b/tests/linear_algebra/test_linear_algebra.nim
@@ -22,6 +22,17 @@ proc main() =
             check:
               a[i-1, j-1] == 1 / (i.float64 + j.float64 - 1)
 
+    test "Vandermonde matrix":
+      let x = [1, 2, 3, 4].toTensor
+      let A = vandermonde(x, 3)
+      for i, ax in enumerateAxis(A, axis = 0):
+        var order = 0
+        var el = x[i]
+        let axSq = ax.squeeze
+        for j in 0 ..< axSq.size:
+          check axSq[j] == pow(el.float, order.float)
+          inc order
+
     test "Linear equation solver using least squares":
       block: # "Single equation"
             # Example from Numpy documentation


### PR DESCRIPTION
Adds a constructor for Vandermonde matrices and fixes the `rcond` argument to `gelsd` to the raw epsilon of floats. The existing numbers caused problems for me (this seems stable and is the same `scipy.lstsq` uses). 