### PR TITLE
better least squares docs, make `rcond` an argument, fix workspace calculation

### DIFF
--- a/src/arraymancer/linear_algebra/least_squares.nim
+++ b/src/arraymancer/linear_algebra/least_squares.nim
@@ -5,14 +5,29 @@
 import  ../tensor,
         ./helpers/least_squares_lapack
 
-proc least_squares_solver*[T: SomeFloat](a, b: Tensor[T]):
+proc least_squares_solver*[T: SomeFloat](a, b: Tensor[T],
+                                         rcond = -1.T):
   tuple[
     solution: Tensor[T],
     residuals:  Tensor[T],
     matrix_rank: int,
     singular_values: Tensor[T]
-  ] {.noInit.}=
-
+  ] {.noInit.} =
+  ## Solves the given linear least squares problem:
+  ##
+  ## `minimize | Ax - y | `
+  ##
+  ## where the matrix `A` is our input tensor `a` and the resulting vector `y` is
+  ## given by our input tensor `b`.
+  ##
+  ## `a` needs to be of shape `N x M`. `b` may either be of shape `N` or `N x K`, where
+  ## `K` represents the number of solutions to search for. One solution for each `k_i` is
+  ## returned.
+  ##
+  ## `rcond` is the condition for singular values to be considered zero,
+  ## `s(i) <= rcond * s(i)` are treated as zero.
+  ##
+  ## If `rcond = -1` is used, it determines the size automatically (to the machine precision).
   gelsd(a, b,
         result.solution,
         result.residuals,


### PR DESCRIPTION
The workspace calculation was flawed. For certain large arguments the
used 25 as the max size for the smallest subproblems was not enough, resulting in
errors on calls (error code 10).

Also make `rcond` changeable by user. It's a tricky input, because it
may result in wrong results if not set correctly. The previous value
yielded wrong results for certain problems (Savitzky-Golay filter in
scinim / ggplotnim). Letting it sit at `-1` (meaning let it be determined by LAPACK) is the most stable in my experience so far.