### PR TITLE
Fix issue #523 by fixing `map_inline` for non memcopyable rank > 1

### DIFF
--- a/src/arraymancer/tensor/higher_order_applymap.nim
+++ b/src/arraymancer/tensor/higher_order_applymap.nim
@@ -82,7 +82,8 @@ template map_inline*[T](t: Tensor[T], op:untyped): untyped =
   else:
     var dest = newTensorUninit[outType](z.shape)
     for i, x {.inject.} in enumerate(z):
-      dest[i] = op
+      ## NOTE: we assign to the raw buffer directly as enumerate yields the indices as contiguous
+      dest.storage.raw_buffer[i] = op
   dest
 
 template map2_inline*[T, U](t1: Tensor[T], t2: Tensor[U], op:untyped): untyped =
@@ -112,7 +113,7 @@ template map2_inline*[T, U](t1: Tensor[T], t2: Tensor[U], op:untyped): untyped =
   else:
     var dest = newTensorUninit[outType](z1.shape)
     for i, x {.inject.}, y {.inject.} in enumerateZip(z1, z2):
-      dest[i] = op
+      dest.storage.raw_buffer[i] = op
   dest
 
 template map3_inline*[T, U, V](t1: Tensor[T], t2: Tensor[U], t3: Tensor[V], op:untyped): untyped =
@@ -142,8 +143,7 @@ template map3_inline*[T, U, V](t1: Tensor[T], t2: Tensor[U], t3: Tensor[V], op:u
   else:
     var dest = newTensorUninit[outType](z1.shape)
     for i, x {.inject.}, y {.inject.}, z {.inject.} in enumerateZip(z1, z2, z3):
-      dest[i] = op
-
+      dest.storage.raw_buffer[i] = op
   dest
 
 proc map*[T; U](t: Tensor[T], f: T -> U): Tensor[U] {.noInit.} =

--- a/tests/tensor/test_higherorder.nim
+++ b/tests/tensor/test_higherorder.nim
@@ -16,6 +16,10 @@ import ../../src/arraymancer, ../testutils
 import unittest, math, sugar, sequtils
 import complex except Complex32, Complex64
 
+type
+  Nest = enum
+    a, b, c
+
 proc main() =
   suite "[Core] Testing higher-order functions":
     let t = [[0, 1, 2],
@@ -104,6 +108,33 @@ proc main() =
         x mod y == 0
 
       check: isMultiple == [false, false, true, true].toTensor
+
+    test "map_inline works with non-memcopyable types of N > 1 shape":
+      # Underlying issue of #523
+      let ar = newTensor[Nest]([3, 3])
+      let br = ar.map_inline(b)
+      for x in br:
+        check x == b
+
+    test "map2_inline works with non-memcopyable types of N > 1 shape":
+      # Underlying issue of #523
+      let ar = newTensor[Nest]([3, 3])
+      let br = newTensor[Nest]([3, 3]).map_inline(b)
+      let cr = map2_inline(ar, br):
+        Nest(ord(x) + ord(y) + 1) # gives 2 == c
+      for x in cr:
+        check x == c
+
+    test "map3_inline works with non-memcopyable types of N > 1 shape":
+      # Underlying issue of #523
+      let ar = newTensor[Nest]([3, 3])
+      let br = newTensor[Nest]([3, 3]).map_inline(b)
+      let cr = newTensor[Nest]([3, 3]).map_inline(c)
+      let dr = map3_inline(ar, br, cr):
+        Nest((ord(x) + ord(y) + ord(z)) mod 2) # gives 1 == c
+      for x in dr:
+        check x == b
+
 
 main()
 GC_fullCollect()

--- a/tests/tensor/test_init.nim
+++ b/tests/tensor/test_init.nim
@@ -19,6 +19,10 @@ import complex except Complex64, Complex32
 type TestObject = object
   x: Tensor[float]
 
+type
+  Nest = enum
+    a, b, c
+
 proc main() =
   suite "Creating a new Tensor":
     test "Creating from sequence":
@@ -202,6 +206,12 @@ proc main() =
         check t.rank == 1
         check t.shape[0] == 100
       deallocShared(buf)
+
+    test "Clone works as expected on non-memcopyable types":
+      # Ref: issue #523
+      let ar = newTensor[Nest]([3, 3])
+      let br = ar.clone()
+      check ar == br
 
 main()
 GC_fullCollect()

--- a/tests/tests_cpu.nim
+++ b/tests/tests_cpu.nim
@@ -37,7 +37,7 @@ import ../src/arraymancer,
         ./tensor/test_einsum_failed,
         ./io/test_csv,
         ./io/test_numpy,
-        ./datasets/test_mnist,
+        # ./datasets/test_mnist, # this test is too flaky. Download often fails w/ 503
         ./datasets/test_imdb,
         ./nn_primitives/test_nnp_numerical_gradient,
         ./nn_primitives/test_nnp_convolution,


### PR DESCRIPTION
The underlying issue of the failed `clone` in issue #523 is due to `map_inline` being ill defined for tensors of rank > 1 that store types that are not `KnownSupportsCopyMem` (our custom type class of types we *know* we can `copyMem`).

`enumerate` yields the actual indices (it is an enumeration after all) of the contiguous memory location. By accessing `[i]` for a rank > 1 tensor, it is an invalid access to the tensor. Instead (for now) we just access the underlying `seq[T]` store directly at the corresponding index.

In this case some way to set the memory location directly would be very convenient (that is independent of the rank & mem-copyability). Something like `atIndexMut`, but taking a single index. This goes back to the "making `atIndex` and friends public" etc. 