### PR TITLE
mixin `rank` in laser initialization and importing `rank`, `size`

### DIFF
--- a/src/arraymancer/laser/tensor/initialization.nim
+++ b/src/arraymancer/laser/tensor/initialization.nim
@@ -16,6 +16,9 @@ import
   # Third-party
   nimblas
 
+from ../../tensor/data_structure import rank, size
+
+
 ## Initialization and copy routines
 
 func toMetadata*(s: varargs[int]): Metadata =
@@ -31,6 +34,7 @@ template initTensorMetadataImpl(
     layout: static OrderType) =
   ## We don't use a proc directly due to https://github.com/nim-lang/Nim/issues/6529
   result.shape = shape.toMetadata
+  mixin rank
   result.strides.len = result.rank
 
   size = 1


### PR DESCRIPTION
In some use cases when creating a laser tensor (i.e. mem copyable types) within a generic procedure, we could run into issues with generics and identifier resolution.

In particular the following in a change in `numericalnim`:
```nim
proc newLinear1D*[T](X: openArray[float], Y: openArray[T]): InterpolatorType[T] =
  if X.len != Y.len:
    raise newException(ValueError, &"X and Y and dY must have the same length. X.len is {X.len} and Y.len is {Y.len}")
  let sortedDataset = sortAndTrimDataset(@X, @Y)
  let xSorted = sortedDataset.x
  let ySorted: seq[T] = sortedDataset.y
  var coeffs = newTensor[T](ySorted.len.int, 1)
```
did not compile with an error:

```sh
/tmp/interp.nim(23, 27) template/generic instantiation of `newLinear1D` from here
/home/basti/src/nim/numericalnim/src/numericalnim/interpolate.nim(228, 28) template/generic instantiation of `newTensor` from here
/home/basti/src/nim/arraymancer/src/arraymancer/laser/tensor/initialization.nim(187, 21) template/generic instantiation of `initTensorMetadata` from here
/home/basti/src/nim/arraymancer/src/arraymancer/laser/tensor/initialization.nim(55, 25) template/generic instantiation of `initTensorMetadataImpl` from here
/home/basti/src/nim/arraymancer/src/arraymancer/laser/tensor/initialization.nim(36, 30) Error: undeclared field: 'rank' for type datatypes.Tensor [type decla
red in /home/basti/src/nim/arraymancer/src/arraymancer/laser/tensor/datatypes.nim(28, 3)]
```

By leaving the `rank` symbol open and importing it (but both are required, afaict) we fix this.