### PR TITLE
Allow `CustomMetric` in distances

### DIFF
--- a/src/arraymancer/spatial/distances.nim
+++ b/src/arraymancer/spatial/distances.nim
@@ -9,8 +9,9 @@ type
   Manhattan* = object
   Minkowski* = object
   Jaccard* = object
+  CustomMetric* = object
 
-  AnyMetric* = Euclidean | Manhattan | Minkowski | Jaccard
+  AnyMetric* = Euclidean | Manhattan | Minkowski | Jaccard | CustomMetric
 
 when (NimMajor, NimMinor, NimPatch) < (1, 4, 0):
   # have to export sets for 1.0, because `bind` didn't exist apparently

--- a/tests/spatial/test_distances.nim
+++ b/tests/spatial/test_distances.nim
@@ -104,3 +104,17 @@ suite "Distances: Jaccard distance":
     let t = [[3.0, 4.0], [3.0, 5.0]].toTensor
     let u = [[3.0, 4.0], [3.0, 4.0]].toTensor
     Jaccard.pairwiseDistances(t, u) =~= [0.0, 2.0 / 3.0].toTensor
+
+suite "Distances: `CustomMetric`":
+  let a = [1,2,3].toTensor
+  let b = [4,5,6].toTensor
+  test "CustomMetric of a constant value":
+    proc distance(_: typedesc[CustomMetric], v, w: Tensor[int]): int =
+      result = 100
+    check CustomMetric.distance(a, b) == 100
+
+  test "CustomMetric that is euclidean":
+    proc distance(_: typedesc[CustomMetric], v, w: Tensor[int]): float =
+      result = Euclidean.distance(v.asType(float), w.asType(float))
+
+    check CustomMetric.distance(a, b) == Euclidean.distance(a.asType(float), b.asType(float))


### PR DESCRIPTION
This adds a new type `CustomMetric` to the known metrics, which is part of the `AnyMetric` class. 

It can be used to supply a user defined metric for any procedure that needs allows an `AnyMetric` argument.
Be wary though when using it for this purpose, as to what the procedure actually does with the metric! For example the k-d tree implementation takes the squared distance! 