### PR TITLE
Fix memory leak introduced by cursor notation

### DIFF
--- a/src/arraymancer/laser/tensor/datatypes.nim
+++ b/src/arraymancer/laser/tensor/datatypes.nim
@@ -32,7 +32,7 @@ type
     shape*: Metadata                     # 56 bytes
     strides*: Metadata                   # 56 bytes
     offset*: int                         # 8 bytes
-    storage* {.cursor.}: CpuStorage[T]   # 8 bytes
+    storage*: CpuStorage[T]              # 8 bytes
 
   CpuStorage*[T] {.shallow.} = ref CpuStorageObj[T] # Total heap: 25 bytes = 1 cache-line
   CpuStorageObj[T] {.shallow.} = object

--- a/src/arraymancer/tensor/backend/openmp.nim
+++ b/src/arraymancer/tensor/backend/openmp.nim
@@ -92,7 +92,7 @@ template omp_parallel_reduce_blocks*[T](reduced: T, block_offset, block_size: un
           let num_blocks = min(min(ompsize, omp_get_max_threads()), OMP_MAX_REDUCE_BLOCKS)
           if num_blocks > 1:
             withMemoryOptimHints()
-            var results {.align64.}: array[OMP_MAX_REDUCE_BLOCKS * maxItemsPerCacheLine, type(reduced)]
+            var results {.align64, noInit.}: array[OMP_MAX_REDUCE_BLOCKS * maxItemsPerCacheLine, type(reduced)]
             let bsize = ompsize div num_blocks
 
             if bsize > 1:


### PR DESCRIPTION
* The cursor notation fixed a crash in openmp but caused a memory leak on some cases due to cursor notation on cycle
*  The actual segfault seemed linked to a memory allocation inside an openmp loop ( ``results`` array in ``backend/openmp.nim``).

Many tests later the easiest solution was to disable openmp for omp_parallel_reduce_blocks with ``when defined(gcDestructors)``. Since the goal is to eventually move away from openmp this shouldn't be a problem (an it's better to slow some fold / reduce loop than to cras h I guess ? ) 

@mratsim If you have an actual solution to avoid disabling it entirely I'd be glad to implement it.