### PR TITLE
misc k-d tree fixes & fixes `deepCopy` for tensor

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 Arraymancer v0.7.x
 =====================================================
 
+- add `clone` operation for k-d tree
+- remove `TensorHelper` type in k-d tree implementation, instead
+  `bind` a custom `<`
+- fix `deepCopy` for tensors
+
 Arraymancer v0.7.15 Jul. 28 2022
 =====================================================
 

--- a/src/arraymancer/laser/strided_iteration/foreach.nim
+++ b/src/arraymancer/laser/strided_iteration/foreach.nim
@@ -52,7 +52,6 @@ proc forEachContiguousImpl(
                   replacements = elems_contiguous,
                   to_replace = values
                   )
-
   if use_openmp:
     result = quote do:
       omp_parallel_for_default(`index`, `size`):
@@ -188,7 +187,6 @@ template forEachTemplate(use_openmp: static bool) {.dirty.} =
         `contiguous_body`
       else:
         `strided_body`
-
 
 macro forEachContiguous*(args: varargs[untyped]): untyped =
   ## Parallel iteration over one or more **contiguous** tensors.

--- a/src/arraymancer/laser/tensor/initialization.nim
+++ b/src/arraymancer/laser/tensor/initialization.nim
@@ -70,10 +70,9 @@ proc deepCopy*[T](dst: var Tensor[T], src: Tensor[T]) =
   ## Note that if x was already initialized with a ``storage``,
   ## the storage will be detached from x. This does not write
   ## into existing storage.
-
   var size: int
   initTensorMetadata(dst, size, src.shape)
-  dst.storage = allocCpuStorage(T, size)
+  allocCpuStorage(dst.storage, size)
 
   when T is KnownSupportsCopyMem:
     # We use memcpy, due to SIMD optimizations in memcpy,
@@ -83,8 +82,8 @@ proc deepCopy*[T](dst: var Tensor[T], src: Tensor[T]) =
             size, chunk_offset, chunk_size,
             OMP_MEMORY_BOUND_GRAIN_SIZE * 4):
         copyMem(
-          dst.unsafe_raw_offset[chunk_offset],
-          src.unsafe_raw_offset[chunk_offset],
+          dst.unsafe_raw_offset[chunk_offset].addr,
+          src.unsafe_raw_offset[chunk_offset].unsafeAddr,
           chunk_size * sizeof(T)
           )
     else:

--- a/src/arraymancer/spatial/kdtree.nim
+++ b/src/arraymancer/spatial/kdtree.nim
@@ -43,6 +43,29 @@ type
     tree*: Node[T]           ## the root node of the tree
     size*: int               ## number of nodes in the tree
 
+proc clone*[T](n: Node[T]): Node[T] =
+  result = Node[T](level: n.level,
+                   id: n.id,
+                   kind: n.kind)
+  case n.kind
+  of tnInner:
+    result.lesser = n.lesser.clone()
+    result.greater = n.greater.clone()
+    result.split_dim = n.split_dim
+    result.split = n.split
+  of tnLeaf:
+    result.children = n.children
+    result.idx = n.idx.clone()
+
+proc clone*[T](kd: KDTree[T]): KDTree[T] =
+  result = KDTree[T](data: kd.data.clone(),
+                     leafSize: kd.leafSize,
+                     k: kd.k, n: kd.n,
+                     maxes: kd.maxes.clone(),
+                     mins: kd.mins.clone(),
+                     tree: kd.tree.clone(),
+                     size: kd.size)
+
 proc `<`[T](n1, n2: Node[T]): bool =
   ## Comparison of two nodes is done by comparing their `id`. The `id` tells us the
   ## order in which the node was constructed. This is sensible, as we *first* construct

--- a/src/arraymancer/spatial/kdtree.nim
+++ b/src/arraymancer/spatial/kdtree.nim
@@ -296,10 +296,8 @@ proc queryImpl[T](
     distanceUpperBound = pow(distanceUpperBound, p)
 
   var node: Node[T]
-  var sdt: Tensor[T] # stupid helper
   while q.len > 0:
-    (min_distance, sdt, node) = pop q
-    side_distances = sdt
+    (min_distance, side_distances, node) = pop q
     case node.kind
     of tnLeaf:
       # brute force for remaining elements in leaf node

--- a/src/arraymancer/spatial/tensor_compare_helper.nim
+++ b/src/arraymancer/spatial/tensor_compare_helper.nim
@@ -1,0 +1,16 @@
+import ../tensor
+proc `<`*[T](s1, s2: Tensor[T]): bool =
+  ## just an internal comparison of two Tensors, which assumes that the order of two
+  ## seqs matters.
+  #let s1 = s1C.toTensorNormal
+  #let s2 = s2C.toTensorNormal
+  doAssert s1.size == s2.size
+  result = false
+  for i in 0 ..< s1.size:
+    if s1[i] == s2[i]:
+      # may still be decided, equal up to here
+      continue
+    elif s1[i] < s2[i]:
+      return true
+    elif s1[i] > s2[i]:
+      return false

--- a/src/arraymancer/spatial/tensor_compare_helper.nim
+++ b/src/arraymancer/spatial/tensor_compare_helper.nim
@@ -1,9 +1,11 @@
 import ../tensor
 proc `<`*[T](s1, s2: Tensor[T]): bool =
   ## just an internal comparison of two Tensors, which assumes that the order of two
-  ## seqs matters.
-  #let s1 = s1C.toTensorNormal
-  #let s2 = s2C.toTensorNormal
+  ## seqs matters. This proc is in an extra file, because the proc using it (`queryImpl`)
+  ## is generic and we need to call `bind` for this. If it was defined in the same
+  ## file, we can't `bind` it for some reason. Further we do not want to export such
+  ## a procedure as obviously in the general context this comparison doesn't make sense.
+  ## But as we use a HeapQueue of tensors, we *need* a `<` comparison operator.
   doAssert s1.size == s2.size
   result = false
   for i in 0 ..< s1.size:


### PR DESCRIPTION
This is based on #564. I'll rebase it onto master once that is merged.

It's just a few small fixes to the k-d tree module. The `TensorHelper` hacky type is removed and replaced by a custom `<` proc that is bound in the generic scope.

Further it fixes the `deepCopy` implementation of `Tensor`, as that was outdated I think.