### PR TITLE
remove the overload of slicer with multiple varargs 

### DIFF
--- a/src/arraymancer/tensor/private/p_accessors_macros_read.nim
+++ b/src/arraymancer/tensor/private/p_accessors_macros_read.nim
@@ -101,7 +101,7 @@ proc slicer*[T](t: AnyTensor[T],
 
   result = t
   let full_slices = concat(slices1.toArrayOfSlices,
-                            initSpanSlices(t.rank - slices1.len - slices2.len),
+                            initSpanSlices(t.rank - 1 - 1),
                             slices2.toArrayOfSlices)
   slicerImpl(result, full_slices)
 

--- a/src/arraymancer/tensor/private/p_accessors_macros_read.nim
+++ b/src/arraymancer/tensor/private/p_accessors_macros_read.nim
@@ -89,6 +89,22 @@ proc slicer*[T](t: AnyTensor[T],
   let full_slices = initSpanSlices(t.rank - slices.len) & slices.toArrayOfSlices
   slicerImpl(result, full_slices)
 
+proc slicer*[T](t: AnyTensor[T],
+                slices1: SteppedSlice,
+                ellipsis: Ellipsis,
+                slices2: SteppedSlice
+                ): AnyTensor[T] {.noInit,noSideEffect.}=
+  ## Take a Tensor, Ellipsis and SteppedSlices
+  ## Returns:
+  ##    A copy of the original Tensor
+  ##    Offset and strides are changed to achieve the desired effect.
+
+  result = t
+  let full_slices = concat(slices1.toArrayOfSlices,
+                            initSpanSlices(t.rank - slices1.len - slices2.len),
+                            slices2.toArrayOfSlices)
+  slicerImpl(result, full_slices)
+
 proc slicer*[T](t: Tensor[T], slices: ArrayOfSlices): Tensor[T] {.noInit,noSideEffect.}=
   ## Take a Tensor and SteppedSlices
   ## Returns:

--- a/src/arraymancer/tensor/private/p_accessors_macros_read.nim
+++ b/src/arraymancer/tensor/private/p_accessors_macros_read.nim
@@ -89,22 +89,6 @@ proc slicer*[T](t: AnyTensor[T],
   let full_slices = initSpanSlices(t.rank - slices.len) & slices.toArrayOfSlices
   slicerImpl(result, full_slices)
 
-proc slicer*[T](t: AnyTensor[T],
-                slices1: varargs[SteppedSlice],
-                ellipsis: Ellipsis,
-                slices2: varargs[SteppedSlice]
-                ): AnyTensor[T] {.noInit,noSideEffect.}=
-  ## Take a Tensor, Ellipsis and SteppedSlices
-  ## Returns:
-  ##    A copy of the original Tensor
-  ##    Offset and strides are changed to achieve the desired effect.
-
-  result = t
-  let full_slices = concat(slices1.toArrayOfSlices,
-                            initSpanSlices(t.rank - slices1.len - slices2.len),
-                            slices2.toArrayOfSlices)
-  slicerImpl(result, full_slices)
-
 proc slicer*[T](t: Tensor[T], slices: ArrayOfSlices): Tensor[T] {.noInit,noSideEffect.}=
   ## Take a Tensor and SteppedSlices
   ## Returns:


### PR DESCRIPTION
multiple varargs never worked well, even a simple case breaks

```nim
proc thing(a: varargs[string], m: int, b: varargs[float]) = 
  discard

thing("1.0", "2.0", 0, 1.0) # compiles
thing("1.0", 0, 1.0, 2.0) # broken
thing("1.0", "2.0", 0, 1.0, 2.0) # broken
```

It is about to become a compilation error => https://github.com/nim-lang/Nim/pull/20266

 `slicer` seems to be a function in a private module and not used internally. I suppose it can be safely modified.