### PR TITLE
Clarify numerical gradient signature

### DIFF
--- a/arraymancer.nimble
+++ b/arraymancer.nimble
@@ -1,5 +1,5 @@
 ### Package
-version       = "0.7.18"
+version       = "0.7.19"
 author        = "Mamy André-Ratsimbazafy"
 description   = "A n-dimensional tensor (ndarray) library"
 license       = "Apache License 2.0"

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,12 @@
 Arraymancer v0.7.x
 =====================================================
 
+Arraymancer v0.7.19 Dec. 10 2022
+=====================================================
+
+- change the signature of `numerical_gradient` for scalars to
+  explicitly reject `Tensor` arguments. See discussion in PR #580.
+
 Arraymancer v0.7.18 Dec. 10 2022
 =====================================================
 

--- a/src/arraymancer/nn_primitives/nnp_numerical_gradient.nim
+++ b/src/arraymancer/nn_primitives/nnp_numerical_gradient.nim
@@ -14,7 +14,7 @@
 
 import ../tensor
 
-proc numerical_gradient*[T](input: T, f: (proc(x: T): T), h = T(1e-5)): T {.inline.} =
+proc numerical_gradient*[T: not Tensor](input: T, f: (proc(x: T): T), h = T(1e-5)): T {.inline.} =
   ## Compute numerical gradient for any function w.r.t. to an input value,
   ## useful for gradient checking, recommend using float64 types to assure
   ## numerical precision. The gradient is calculated as:

--- a/tests/nn_primitives/test_nnp_convolution.nim
+++ b/tests/nn_primitives/test_nnp_convolution.nim
@@ -14,7 +14,7 @@
 
 
 import ../../src/arraymancer
-import unittest, sugar, math
+import unittest, sugar
 
 proc main() =
   suite "Convolution 2D":


### PR DESCRIPTION
Changes the signature of `numerical_gradient` intended for scalars as discussed in #580.