### PR TITLE
k-d tree performance improvements & KDE `adjust` fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,14 @@
 Arraymancer v0.7.x
 =====================================================
 
+Arraymancer v0.7.22 Sep. 12 2023
+=====================================================
+
+- performance improvements to the k-d tree implementation by avoiding
+  `pow` and `sqrt` calls if unnecessary and providing a custom code
+  path for euclidean distances
+- fix an issue in `kde` such that the `adjust` argument actually takes effect
+
 Arraymancer v0.7.21 Aug. 31 2023
 =====================================================
 

--- a/src/arraymancer/laser/openmp.nim
+++ b/src/arraymancer/laser/openmp.nim
@@ -7,7 +7,7 @@
 # Compile-time name mangling for OpenMP thresholds
 # Workaround https://github.com/nim-lang/Nim/issues/9365
 # and https://github.com/nim-lang/Nim/issues/9366
-import random
+import std / random
 from strutils import toHex
 
 var mangling_rng {.compileTime.} = initRand(0x1337DEADBEEF)

--- a/src/arraymancer/ml/clustering/kmeans.nim
+++ b/src/arraymancer/ml/clustering/kmeans.nim
@@ -1,7 +1,7 @@
 # Copyright (c) 2018 Mamy André-Ratsimbazafy and the Arraymancer contributors
 # Distributed under the Apache v2 License (license terms are at http://www.apache.org/licenses/LICENSE-2.0).
 # This file may not be copied, modified, or distributed except according to those terms.
-import math, random, tables
+import std / [math, random, tables]
 
 import ../../tensor
 import ../../spatial/distances

--- a/src/arraymancer/spatial/distances.nim
+++ b/src/arraymancer/spatial/distances.nim
@@ -130,6 +130,7 @@ proc pairwiseDistances*(metric: typedesc[AnyMetric],
   ## `[1, n_dimensions]`. In this case all distances between this point and
   ## all in the other input will be computed so that the result is always of
   ## shape `[n_observations]`.
+  ## If one input has only shape `[n_dimensions]` it is unsqueezed to `[1, n_dimensions]`.
   ##
   ## The first argument is the metric to compute the distance under. If the Minkowski metric
   ## is selected the power `p` is used.
@@ -154,9 +155,10 @@ proc pairwiseDistances*(metric: typedesc[AnyMetric],
   else:
     # determine which is one is 1 along n_observations
     let nx = if x.rank == 2 and x.shape[0] == n_obs: x else: y
-    let ny = if x.rank == 2 and x.shape[0] == n_obs: y else: x
+    var ny = if x.rank == 2 and x.shape[0] == n_obs: y else: x
     # in this case compute distance between all `nx` and single `ny`
-
+    if ny.rank == 1: # unsqueeze to have both rank 2
+      ny = ny.unsqueeze(0)
     var idx = 0
     for ax in axis(nx, 0):
       when metric is Minkowski:

--- a/src/arraymancer/spatial/kdtree.nim
+++ b/src/arraymancer/spatial/kdtree.nim
@@ -43,6 +43,8 @@ type
     tree*: Node[T]           ## the root node of the tree
     size*: int               ## number of nodes in the tree
 
+proc isSquared(p: float): bool = abs(p - 2.0) < 1e-6
+
 proc clone*[T](n: Node[T]): Node[T] =
   result = Node[T](level: n.level,
                    id: n.id,
@@ -227,6 +229,7 @@ proc toTensorTuple[T, U](q: var HeapQueue[T],
   var vals = newTensorUninit[U](q.len)
   var idxs = newTensorUninit[int](q.len)
   var i = 0
+  let squared = isSquared(p)
   if classify(p) == fcInf:
     while q.len > 0:
       let (val, idx) = q.pop
@@ -234,11 +237,18 @@ proc toTensorTuple[T, U](q: var HeapQueue[T],
       idxs[i] = idx
       inc i
   else:
-    while q.len > 0:
-      let (val, idx) = q.pop
-      vals[i] = pow(-val, 1.0 / p)
-      idxs[i] = idx
-      inc i
+    if squared:
+      while q.len > 0:
+        let (val, idx) = q.pop
+        vals[i] = sqrt(-val)
+        idxs[i] = idx
+        inc i
+    else:
+      while q.len > 0:
+        let (val, idx) = q.pop
+        vals[i] = pow(-val, 1.0 / p)
+        idxs[i] = idx
+        inc i
   result = (vals, idxs)
 
 import ./tensor_compare_helper
@@ -257,6 +267,8 @@ proc queryImpl[T](
   ## and the static `yieldNumber` arguments it returns:
   ## - the `k` neighbors around `x` within a maximum `radius` (`yieldNumber = true`)
   ## - all points around `x` within `radius` (`yieldNumber = false`)
+  let squared = isSquared(p)
+
   var side_distances = map2_inline(x -. tree.maxes,
                                     tree.mins -. x):
     max(0, max(x, y))
@@ -264,7 +276,10 @@ proc queryImpl[T](
   var min_distance: T
   var distanceUpperBound = radius
   if classify(p) != fcInf:
-    side_distances = side_distances.map_inline(pow(x, p))
+    if squared:
+      side_distances = side_distances.map_inline(x*x)
+    else:
+      side_distances = side_distances.map_inline(pow(x, p))
     min_distance = sum(side_distances)
   else:
     min_distance = max(side_distances)
@@ -288,12 +303,18 @@ proc queryImpl[T](
     epsfac = 1.T
   elif classify(p) == fcInf:
     epsfac = T(1 / (1 + eps))
+  elif squared:
+    let tmp = 1 + eps
+    epsfac = T(1 / (tmp*tmp))
   else:
     epsfac = T(1 / pow(1 + eps, p))
 
   # normalize the radius to the correct power
   if classify(p) != fcInf and classify(distanceUpperBound) != fcInf:
-    distanceUpperBound = pow(distanceUpperBound, p)
+    if squared:
+      distanceUpperBound = distanceUpperBound*distanceUpperBound
+    else:
+      distanceUpperBound = pow(distanceUpperBound, p)
 
   var node: Node[T]
   while q.len > 0:
@@ -334,7 +355,11 @@ proc queryImpl[T](
         sd[node.split_dim] = abs(node.split - x[node.split_dim])
         min_distance = min_distance - side_distances[node.split_dim] + sd[node.split_dim]
       else:
-        sd[node.split_dim] = pow(abs(node.split - x[node.split_dim]), p)
+        if squared:
+          let tmp = node.split - x[node.split_dim]
+          sd[node.split_dim] = tmp*tmp
+        else:
+          sd[node.split_dim] = pow(abs(node.split - x[node.split_dim]), p)
         min_distance = min_distance - side_distances[node.split_dim] + sd[node.split_dim]
 
       if min_distance <= distanceUpperBound * epsfac:

--- a/src/arraymancer/spatial/kdtree.nim
+++ b/src/arraymancer/spatial/kdtree.nim
@@ -3,7 +3,7 @@ import math, typetraits
 import ../tensor
 import ./distances
 
-import sorted_seq
+import std / heapqueue
 
 #[
 
@@ -216,11 +216,11 @@ proc kdTree*[T](data: Tensor[T],
   result.buildKdTree(arange[int](result.n),
                      useMedian = balancedTree)
 
-proc toTensorTuple[T, U](q: var SortedSeq[T],
+proc toTensorTuple[T, U](q: var HeapQueue[T],
                          retType: typedesc[U],
                          p = Inf): tuple[dist: Tensor[U],
                                          idx: Tensor[int]] =
-  ## Helper proc to convert the contents of the SortedSeq to a tuple of
+  ## Helper proc to convert the contents of the `HeapQueue` to a tuple of
   ## two tensors.
   ##
   ## The heap queue here is used to accumulate neighbors in the `query` proc. It
@@ -291,12 +291,12 @@ proc queryImpl[T](
   # - distance between nearest side of cell and target
   # - head node of cell
   bind tensor_compare_helper.`<`
-  var q = initSortedSeq[(T, Tensor[T], Node[T])](128)
+  var q = initHeapQueue[(T, Tensor[T], Node[T])]()
   q.push (min_distance, side_distances.clone, tree.tree)
   # priority queue for nearest neighbors, i.e. our result
   # - (- distance ** p) from input `x` to current point
   # - index of point in `KDTree's` data
-  var neighbors = initSortedSeq[(T, int)](128)
+  var neighbors = initHeapQueue[(T, int)]()
 
   # compute a sensible epsilon
   var epsfac: T

--- a/src/arraymancer/spatial/kdtree.nim
+++ b/src/arraymancer/spatial/kdtree.nim
@@ -1,7 +1,9 @@
-import math, heapqueue, typetraits
+import math, typetraits
 
 import ../tensor
 import ./distances
+
+import sorted_seq
 
 #[
 
@@ -214,11 +216,11 @@ proc kdTree*[T](data: Tensor[T],
   result.buildKdTree(arange[int](result.n),
                      useMedian = balancedTree)
 
-proc toTensorTuple[T, U](q: var HeapQueue[T],
+proc toTensorTuple[T, U](q: var SortedSeq[T],
                          retType: typedesc[U],
                          p = Inf): tuple[dist: Tensor[U],
                                          idx: Tensor[int]] =
-  ## Helper proc to convert the contents of the HeapQueue to a tuple of
+  ## Helper proc to convert the contents of the SortedSeq to a tuple of
   ## two tensors.
   ##
   ## The heap queue here is used to accumulate neighbors in the `query` proc. It
@@ -289,13 +291,12 @@ proc queryImpl[T](
   # - distance between nearest side of cell and target
   # - head node of cell
   bind tensor_compare_helper.`<`
-  var q = initHeapQueue[(T, Tensor[T], Node[T])]()
+  var q = initSortedSeq[(T, Tensor[T], Node[T])](128)
   q.push (min_distance, side_distances.clone, tree.tree)
-
   # priority queue for nearest neighbors, i.e. our result
   # - (- distance ** p) from input `x` to current point
   # - index of point in `KDTree's` data
-  var neighbors = initHeapQueue[(T, int)]()
+  var neighbors = initSortedSeq[(T, int)](128)
 
   # compute a sensible epsilon
   var epsfac: T

--- a/src/arraymancer/spatial/neighbors.nim
+++ b/src/arraymancer/spatial/neighbors.nim
@@ -30,8 +30,8 @@ proc nearestNeighbors*[T](X: Tensor[T], eps: float, metric: typedesc[AnyMetric],
     let kd = kdTree(X)
     result = newSeq[Tensor[int]](X.shape[0])
     var idx = 0
-    for v in axis(X, 0):
-      let (dist, idxs) = kd.query_ball_point(v.squeeze, radius = eps, metric = metric)
+    for i in 0 ..< X.shape[0]:
+      let (dist, idxs) = kd.query_ball_point(X[i, _].squeeze, radius = eps, metric = metric)
       result[idx] = idxs
       inc idx
   else:

--- a/src/arraymancer/stats/kde.nim
+++ b/src/arraymancer/stats/kde.nim
@@ -123,9 +123,8 @@ proc kde*[T: SomeNumber; U: int | Tensor[SomeNumber] | openArray[SomeNumber]](
   var t = t.asType(float)
   let A = min(std(t),
               iqr(t) / 1.34)
-  let bwAct = if classify(bw) != fcNan: bw
-              else: 0.9 * A * pow(N.float, -1.0/5.0)
-
+  var bwAct = if classify(bw) == fcNormal: bw
+              else: adjust * (0.9 * A * pow(N.float, -1.0/5.0))
   var weights = weights.asType(float)
   if weights.size > 0:
     doAssert weights.size == t.size
@@ -142,10 +141,10 @@ proc kde*[T: SomeNumber; U: int | Tensor[SomeNumber] | openArray[SomeNumber]](
     let nsamples = samples
   elif U is seq | array:
     let x = toTensor(@samples).asType(float)
-    let nsamples = x.size
+    let nsamples = x.size.int
   else:
     let x = samples.asType(float)
-    let nsamples = x.size
+    let nsamples = x.size.int
   result = newTensor[float](nsamples)
   let norm = 1.0 / (N.float * bwAct)
   var

--- a/src/arraymancer/tensor/init_cpu.nim
+++ b/src/arraymancer/tensor/init_cpu.nim
@@ -18,7 +18,7 @@ import
   ../laser/strided_iteration/foreach,
   ./data_structure,
   # Standard library
-  random,
+  std / random,
   math
 
 export initialization


### PR DESCRIPTION
Improves the performance of the k-d tree significantly in certain use cases in which we can avoid expensive `pow` and `sqrt` calls. 

Fixes the `adjust` argument of the KDE procedure so that it is actually taken into account to adjust the bandwidth.

NOTE: 
Right now the code contains an experimental commit that replaces the HeapQueue of the k-d tree by a sorted sequence. This will likely not remain (or if it does the sorted seq impl will be added as a private module). 