### PR TITLE
Fix wrong usage of `newSeqUninit`

### DIFF
--- a/src/arraymancer/autograd/autograd_common.nim
+++ b/src/arraymancer/autograd/autograd_common.nim
@@ -241,7 +241,7 @@ proc backprop*[TT](v: Variable[TT]) =
         parent_i.grad += diff
 
 func newParents*[TT](num: Natural): Parents[TT] {.inline.} =
-  newSeqUninit[Variable[TT]](num)
+  newSeq[Variable[TT]](num)
 
 func newDiffs*[TT](num: Natural): SmallDiffs[TT] {.inline.} =
-  newSeqUninit[TT](num)
+  newSeq[TT](num)

--- a/src/arraymancer/autograd/gates_shapeshifting_concat_split.nim
+++ b/src/arraymancer/autograd/gates_shapeshifting_concat_split.nim
@@ -67,7 +67,7 @@ proc stack*[TT](variables: varargs[Variable[TT]], axis = 0): Variable[TT] =
 
   # Resulting var
   new result
-  var ts = newSeqUninit[TT](variables.len)
+  var ts = newSeq[TT](variables.len)
   for i in 0 ..< variables.len:
     # TODO: avoid the intermediate seq alloc to extract varargs Tensors from varargs variables
     ts[i] = variables[i].value

--- a/src/arraymancer/laser/private/memory.nim
+++ b/src/arraymancer/laser/private/memory.nim
@@ -3,7 +3,7 @@
 # Distributed under the Apache v2 License (license terms are at http://www.apache.org/licenses/LICENSE-2.0).
 # This file may not be copied, modified, or distributed except according to those terms.
 
-import ../compiler_optim_hints
+import ../compiler_optim_hints, ../tensor/datatypes
 
 func align_raw_data*(T: typedesc, p: pointer): ptr UncheckedArray[T] =
   static: assert T is KnownSupportsCopyMem

--- a/src/arraymancer/nn/layers/gru.nim
+++ b/src/arraymancer/nn/layers/gru.nim
@@ -81,7 +81,7 @@ proc gru_forward[TT](
   let batch_size = input.value.shape[1]
   let hidden_size = hidden0.value.shape[2]
 
-  gate.cached_inputs = newSeqUninit[TT](layers)
+  gate.cached_inputs = newSeq[TT](layers)
   gate.cached_hiddens = newSeqWith(layers) do: newSeq[TT](seq_len)
 
   gate.rs = newTensorUninit[TT.T](layers, seq_len, batch_size, hidden_size)

--- a/src/arraymancer/tensor/higher_order_applymap.nim
+++ b/src/arraymancer/tensor/higher_order_applymap.nim
@@ -235,7 +235,7 @@ proc map2*[T, U; V: KnownSupportsCopyMem](t1: Tensor[T],
   ##     # Or
   ##     map2(a, `**`, b)
   ## ``map2`` is especially useful to do multiple element-wise operations on a two tensors in a single loop over the data.
-  ## for example ```alpha * sin(A) + B```
+  ## for example ``alpha * sin(A) + B``
   ##
   ## For OpenMP compatibility, this ``map2`` doesn't allow ref types as result like seq or string
   when compileOption("boundChecks"):


### PR DESCRIPTION
Fixes the remaining case of `newSeqUninit` being used wrongly.

Also addresses a minor issue I encountered with `nim doc` locally.