### PR TITLE
Add support for combining span slices with negative steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Arraymancer tutorial is available [here](https://mratsim.github.io/Arraymancer/t
 Here is a preview of Arraymancer syntax.
 
 ### Tensor creation and slicing
+
 ```Nim
 import math, arraymancer
 
@@ -80,9 +81,19 @@ echo foo[1..2, 3..4] # slice
 # Tensor of shape 2x2 of type "int" on backend "Cpu"
 # |16     32|
 # |81     243|
+
+echo foo[_|-1, _] # reverse the order of the rows
+
+# Tensor[int] of shape "[5, 5]" on backend "Cpu"
+# |5      25      125     625     3125|
+# |4      16       64     256     1024|
+# |3       9       27      81      243|
+# |2       4        8      16       32|
+# |1       1        1       1        1|
 ```
 
 ### Reshaping and concatenation
+
 ```Nim
 import arraymancer, sequtils
 

--- a/README.md
+++ b/README.md
@@ -19,26 +19,22 @@ Reminder of supported compilation flags:
 
 - `-d:release`: Nim release mode (no stacktraces and debugging information)
 - `-d:danger`: No runtime checks like array bound checking
+- `-d:blas=blaslibname`: Customize the BLAS library used by Arraymancer. By default (i.e. if you don't define this setting) Arraymancer will try to automatically find a BLAS library (e.g. `blas.so/blas.dll` or `libopenblas.dll`) on your path. You should only set this setting if for some reason you want to use a specific BLAS library. See [nimblas](https://github.com/SciNim/nimblas) for further information
+- `-d:lapack=lapacklibname`: Customize the LAPACK library used by Arraymancer. By default (i.e. if you don't define this setting) Arraymancer will try to automatically find a LAPACK library (e.g. `lapack.so/lapack.dll` or `libopenblas.dll`) on your path. You should only set this setting if for some reason you want to use a specific LAPACK library. See [nimlapack](https://github.com/SciNim/nimlapack) for further information
 - `-d:openmp`: Multithreaded compilation
-- `-d:mkl`: Use MKL, implies `openmp`
-- `-d:openblas`: Use OpenBLAS
-- by default Arraymancer will try to use your default `blas.so/blas.dll`
-  Archlinux users may have to specify `-d:blas=cblas`.
-  Windows users may have to download `libopenblas.dll` from the binary releases
-  section of [openblas](https://www.openblas.net), extract it to the compilation
-  output folder and specify `-d:blas=libopenblas -d:lapack=libopenblas` when compiling
-  (or set those options on your `nim.cfg` file).
-  See [nimblas](https://github.com/unicredit/nimblas) for further configuration.
+- `-d:mkl`: Deprecated flag which forces the use of MKL. Implies `-d:openmp`. Use `-d:blas=mkl -d:lapack=mkl` instead, but _only_ if you want to force Arraymancer to use MKL, instead of looking for the available BLAS / LAPACK libraries
+- `-d:openblas`: Deprecated flag which forces the use of OpenBLAS. Use `-d:blas=openblas -d:lapack=openblas` instead, but _only_ if you want to force Arraymancer to use OpenBLAS, instead of looking for the available BLAS / LAPACK libraries
 - `-d:cuda`: Build with Cuda support
-- `-d:cudnn`: Build with CuDNN support, implies `cuda`.
-- `-d:avx512`: Build with AVX512 support by supplying the
-  `-mavx512dq` flag to gcc / clang. Without this flag the
-  resulting binary does not use AVX512 even on CPUs that support
-  it. Handing this flag however, makes the binary incompatible with
-  CPUs that do *not* support it. See the comments in #505 for a
-  discussion (from `v0.7.9`).
+- `-d:cudnn`: Build with CuDNN support, implies `-d:cuda`
+- `-d:avx512`: Build with AVX512 support by supplying the `-mavx512dq` flag
+  to gcc / clang. Without this flag the resulting binary does not use AVX512
+  even on CPUs that support it. Setting this flag, however, makes the binary
+  incompatible with CPUs that do _not_ support AVX512. See the comments in #505
+  for a discussion (from `v0.7.9`)
 - You might want to tune library paths in [nim.cfg](nim.cfg) after installation for OpenBLAS, MKL and Cuda compilation.
-  The current defaults should work on Mac and Linux.
+  The current defaults should work on Mac and Linux; and on Windows after downloading `libopenblas.dll` or another
+  BLAS / LAPACK DLL (see the [Installation](#installation) section for more information) and copying it into a folder
+  in your path or into the compilation output folder.
 
 ## Show me some code
 
@@ -260,11 +256,14 @@ I however recommend installing Nim in your user profile via [``choosenim``](http
 
 To install Arraymancer development version you can use `nimble install arraymancer@#head`.
 
-Arraymancer requires a BLAS and Lapack library.
+Arraymancer requires a BLAS and a LAPACK library.
 
-- On Windows you can get [OpenBLAS ](https://github.com/xianyi/OpenBLAS/wiki/Precompiled-installation-packages)and [Lapack](https://icl.cs.utk.edu/lapack-for-windows/lapack/) for Windows.
+- On Windows you can get the [OpenBLAS](https://www.openblas.net) library, which combines BLAS and LAPACK into a single DLL (`libopenblas.dll`), from the binary packages section of the OpenBLAS web page. Alternatively you can download separate BLAS and LAPACK libraries from the [LAPACK for Windows](https://icl.cs.utk.edu/lapack-for-windows/lapack/) site. You must then copy or extract those DLLs into a folder on your path or into the folder containing your compilation target.
 - On MacOS, Apple Accelerate Framework is included in all MacOS versions and provides those.
 - On Linux, you can download libopenblas and liblapack through your package manager.
+
+Windows users may have to download `libopenblas.dll` from the binary releases
+  section of [openblas](https://www.openblas.net), extract it to the compilation
 
 ## Full documentation
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 Arraymancer is a tensor (N-dimensional array) project in Nim. The main focus is providing a fast and ergonomic CPU, Cuda and OpenCL ndarray library on which to build a scientific computing ecosystem.
 
 The library is inspired by Numpy and PyTorch and targets the following use-cases:
-  - N-dimensional arrays (tensors) for numerical computing
-  - machine learning algorithms (as in Scikit-learn: least squares solvers, PCA and dimensionality reduction, classifiers, regressors and clustering algorithms, cross-validation).
-  - deep learning
+
+- N-dimensional arrays (tensors) for numerical computing
+- machine learning algorithms (as in Scikit-learn: least squares solvers, PCA and dimensionality reduction, classifiers, regressors and clustering algorithms, cross-validation).
+- deep learning
 
 The ndarray component can be used without the machine learning and deep learning component.
 It can also use the OpenMP, Cuda or OpenCL backends.
@@ -15,6 +16,7 @@ It can also use the OpenMP, Cuda or OpenCL backends.
 Note: While Nim is compiled and does not offer an interactive REPL yet (like Jupyter), it allows much faster prototyping than C++ due to extremely fast compilation times. Arraymancer compiles in about 5 seconds on my dual-core MacBook.
 
 Reminder of supported compilation flags:
+
 - `-d:release`: Nim release mode (no stacktraces and debugging information)
 - `-d:danger`: No runtime checks like array bound checking
 - `-d:openmp`: Multithreaded compilation
@@ -299,6 +301,7 @@ Reminder: The final interface is still **work in progress.**
 You can also watch the following animated [neural network demo](https://github.com/Vindaar/NeuralNetworkLiveDemo) which shows live training via [nim-plotly](https://github.com/brentp/nim-plotly).
 
 #### Fizzbuzz with fully-connected layers (also called Dense, Affine or Linear layers)
+
 Neural network definition extracted from [example 4](examples/ex04_fizzbuzz_interview_cheatsheet.nim).
 
 ```Nim
@@ -332,6 +335,7 @@ echo answer
 ```
 
 #### Handwritten digit recognition with convolutions
+
 Neural network definition extracted from [example 2](examples/ex02_handwritten_digits_recognition.nim).
 
 ```Nim
@@ -357,6 +361,7 @@ let
 ```
 
 #### Sequence classification with stacked Recurrent Neural Networks
+
 Neural network definition extracted [example 5](examples/ex05_sequence_classification_GRU.nim).
 
 ```Nim
@@ -418,6 +423,7 @@ echo answer.unsqueeze(1)
 ```
 
 #### Composing models
+
 Network models can also act as layers in other network definitions.
 The handwritten-digit-recognition model above can also be written like this:
 
@@ -453,10 +459,12 @@ network DemoNet:
 ```
 
 #### Custom layers
+
 It is also possible to create fully custom layers.
 The documentation for this can be found in the [official API documentation](https://mratsim.github.io/Arraymancer/nn_dsl.html).
 
 ### Tensors on CPU, on Cuda and OpenCL
+
 Tensors, CudaTensors and CLTensors do not have the same features implemented yet.
 Also CudaTensors and CLTensors can only be float32 or float64 while CpuTensors can be integers, string, boolean or any custom object.
 
@@ -491,12 +499,13 @@ Here is a comparative table of the core features.
 The full changelog is available in [changelog.md](./changelog.md).
 
 Here are the highlights:
-  - 0.20.x compatibility
-  - Complex support
-  - `Einsum`
-  - Naive whitespace tokenizer for NLP
-  - Fix height/width order when reading an image in tensor
-  - Preview of Laser backend for matrix multiplication without SIMD autodetection (already 5x faster on integer matrix multiplication)
+
+- 0.20.x compatibility
+- Complex support
+- `Einsum`
+- Naive whitespace tokenizer for NLP
+- Fix height/width order when reading an image in tensor
+- Preview of Laser backend for matrix multiplication without SIMD autodetection (already 5x faster on integer matrix multiplication)
 
 ## 4 reasons why Arraymancer
 
@@ -525,7 +534,9 @@ Arraymancer models can be packaged in a self-contained binary that only depends 
 This means that there is no need to install a huge library or language ecosystem to use Arraymancer. This also makes it naturally suitable for resource-constrained devices like mobile phones and Raspberry Pi.
 
 ### Bridging the gap between deep learning research and production
+
 The deep learning frameworks are currently in two camps:
+
 - Research: Theano, Tensorflow, Keras, Torch, PyTorch
 - Production: Caffe, Darknet, (Tensorflow)
 
@@ -543,6 +554,7 @@ Furthermore, Python preprocessing steps, unless using OpenCV, often needs a cust
 ### So why Arraymancer ?
 
 All those pain points may seem like a huge undertaking however thanks to the Nim language, we can have Arraymancer:
+
 - Be as fast as C
 - Accelerated routines with Intel MKL/OpenBLAS or even NNPACK
 - Access to CUDA and CuDNN and generate custom CUDA kernels on the fly via metaprogramming.
@@ -552,7 +564,9 @@ All those pain points may seem like a huge undertaking however thanks to the Nim
 - For everything that Nim doesn't have yet, you can use Nim bindings to C, C++, Objective-C or Javascript to bring it to Nim. Nim also has unofficial Python->Nim and Nim->Python wrappers.
 
 ## Future ambitions
+
 Because apparently to be successful you need a vision, I would like Arraymancer to be:
+
 - The go-to tool for Deep Learning video processing. I.e. `vid = load_video("./cats/youtube_cat_video.mkv")`
 - Target javascript, WebAssembly, Apple Metal, ARM devices, AMD Rocm, OpenCL, you name it.
 - The base of a Starcraft II AI bot.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Reminder of supported compilation flags:
 
 ## Show me some code
 
-Arraymancer tutorial is available [here](https://mratsim.github.io/Arraymancer/tuto.first_steps.html).
+The Arraymancer tutorial is available [here](https://mratsim.github.io/Arraymancer/tuto.first_steps.html).
 
 Here is a preview of Arraymancer syntax.
 
@@ -56,10 +56,8 @@ const
     y = @[1, 2, 3, 4, 5]
 
 var
-    vandermonde: seq[seq[int]]
+    vandermonde: newSeq[seq[int]]()
     row: seq[int]
-
-vandermonde = newSeq[seq[int]]()
 
 for i, xx in x:
     row = newSeq[int]()
@@ -71,17 +69,17 @@ let foo = vandermonde.toTensor()
 
 echo foo
 
-# Tensor of shape 5x5 of type "int" on backend "Cpu"
-# |1      1       1       1       1|
-# |2      4       8       16      32|
-# |3      9       27      81      243|
-# |4      16      64      256     1024|
-# |5      25      125     625     3125|
+# Tensor[system.int] of shape "[5, 5]" on backend "Cpu"
+# |1          1       1       1       1|
+# |2          4       8      16      32|
+# |3          9      27      81     243|
+# |4         16      64     256    1024|
+# |5         25     125     625    3125|
 
 echo foo[1..2, 3..4] # slice
 
-# Tensor of shape 2x2 of type "int" on backend "Cpu"
-# |16     32|
+# Tensor[system.int] of shape "[2, 2]" on backend "Cpu"
+# |16      32|
 # |81     243|
 
 echo foo[_|-1, _] # reverse the order of the rows
@@ -99,7 +97,6 @@ echo foo[_|-1, _] # reverse the order of the rows
 ```Nim
 import arraymancer, sequtils
 
-
 let a = toSeq(1..4).toTensor.reshape(2,2)
 
 let b = toSeq(5..8).toTensor.reshape(2,2)
@@ -109,19 +106,19 @@ let c0 = c.reshape(3,2)
 let c1 = c.reshape(2,3)
 
 echo concat(a,b,c0, axis = 0)
-# Tensor of shape 7x2 of type "int" on backend "Cpu"
+# Tensor[system.int] of shape "[7, 2]" on backend "Cpu"
 # |1      2|
 # |3      4|
 # |5      6|
 # |7      8|
-# |11     12|
-# |13     14|
-# |15     16|
+# |11    12|
+# |13    14|
+# |15    16|
 
 echo concat(a,b,c1, axis = 1)
-# Tensor of shape 2x7 of type "int" on backend "Cpu"
-# |1      2       5       6       11      12      13|
-# |3      4       7       8       14      15      16|
+# Tensor[system.int] of shape "[2, 7]" on backend "Cpu"
+# |1      2     5     6    11    12    13|
+# |3      4     7     8    14    15    16|
 ```
 
 ### Broadcasting
@@ -137,11 +134,11 @@ let j = [0, 10, 20, 30].toTensor.reshape(4,1)
 let k = [0, 1, 2].toTensor.reshape(1,3)
 
 echo j +. k
-# Tensor of shape 4x3 of type "int" on backend "Cpu"
-# |0      1       2|
-# |10     11      12|
-# |20     21      22|
-# |30     31      32|
+# Tensor[system.int] of shape "[4, 3]" on backend "Cpu"
+# |0      1     2|
+# |10    11    12|
+# |20    21    22|
+# |30    31    32|
 ```
 
 ### A simple two layers neural network
@@ -172,7 +169,7 @@ let
   y = randomTensor[float32](N, D_out, 1'f32)
 
 # ##################################################################
-# Define the model.
+# Define the model
 
 network TwoLayersNet:
   layers:
@@ -305,6 +302,8 @@ You can also watch the following animated [neural network demo](https://github.c
 Neural network definition extracted from [example 4](examples/ex04_fizzbuzz_interview_cheatsheet.nim).
 
 ```Nim
+import arraymancer
+
 const
   NumDigits = 10
   NumHidden = 100
@@ -339,6 +338,8 @@ echo answer
 Neural network definition extracted from [example 2](examples/ex02_handwritten_digits_recognition.nim).
 
 ```Nim
+import arraymancer
+
 network DemoNet:
   layers:
     cv1:        Conv2D(@[1, 28, 28], out_channels = 20, kernel_size = (5, 5))
@@ -365,6 +366,8 @@ let
 Neural network definition extracted [example 5](examples/ex05_sequence_classification_GRU.nim).
 
 ```Nim
+import arraymancer
+
 const
   HiddenSize = 256
   Layers = 4
@@ -409,6 +412,7 @@ let exam = ctx.variable([
     [float32 0.98, 0.97, 0.96], # decreasing
     [float32 0.12, 0.05, 0.01], # decreasing
     [float32 0.95, 0.05, 0.07]  # non-monotonic
+  ])
 # ...
 echo answer.unsqueeze(1)
 # Tensor[ex05_sequence_classification_GRU.SeqKind] of shape [8, 1] of type "SeqKind" on backend "Cpu"
@@ -428,6 +432,7 @@ Network models can also act as layers in other network definitions.
 The handwritten-digit-recognition model above can also be written like this:
 
 ```Nim
+import arraymancer
 
 network SomeConvNet:
   layers h, w:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ const
     y = @[1, 2, 3, 4, 5]
 
 var
-    vandermonde: newSeq[seq[int]]()
+    vandermonde = newSeq[seq[int]]()
     row: seq[int]
 
 for i, xx in x:

--- a/docs/tuto.slicing.rst
+++ b/docs/tuto.slicing.rst
@@ -3,12 +3,12 @@ Tutorial: Slicing
 =================
 
 Arraymancer supports the following slicing syntax. It allows for
-selecting dimension subsets, whole dimension, stepping (one out of 2
-rows), reversing dimensions, counting from the end.
+selecting dimension subsets, whole dimensions, stepping (e.g. one
+out of 2 rows), reversing dimensions and counting from the end.
 
 .. code:: nim
 
-    import math, arraymancer, future
+    import math, arraymancer
 
     const
         x = @[1, 2, 3, 4, 5]
@@ -43,27 +43,74 @@ rows), reversing dimensions, counting from the end.
     # |16      32|
     # |81     243|
 
-    echo foo[3.._, _] # Span slice
+    echo foo[1..<3, 3..<5] # use "..<" if you do not want to include the end in the slice
 
-    # Tensor[int] of shape "[2, 5]" on backend "Cpu"
-    # |4      16       64     256     1024|
-    # |5      25      125     625     3125|
+    # Tensor[int] of shape "[2, 2]" on backend "Cpu"
+    # |16      32|
+    # |81     243|
 
-    echo foo[_..^3, _] # Slice until (inclusive, consistent with Nim)
+    echo foo[_, 3..4] # Span slice (i.e. "_") means "all items" in the dimension (in this case "all rows")
+                      # Note that "_" is equivalent (and preferred) to "_.._"
 
-    # Tensor[int] of shape "[3, 5]" on backend "Cpu"
-    # |1      1        1       1       1|
-    # |2      4        8      16      32|
-    # |3      9       27      81     243|
+    # Tensor[system.int] of shape "[5, 2]" on backend "Cpu"
+    # |1          1|
+    # |16        32|
+    # |81       243|
+    # |256     1024|
+    # |625     3125|
 
-    echo foo[_.._|2, _] # Step
+    echo foo[3.._, _] # Partial span slice (".._" means "until the end")
 
-    # Tensor[int] of shape "[3, 5]" on backend "Cpu"
-    # |1       1        1       1        1|
-    # |3       9       27      81      243|
-    # |5      25      125     625     3125|
+    # Tensor[system.int] of shape "[2, 5]" on backend "Cpu"
+    # |4         16      64     256    1024|
+    # |5         25     125     625    3125|
 
-    echo foo[^1..0|-1, _] # Reverse step
+    echo foo[_..2, _] # Partial span slice ("_.." means "from the beginning" and is rarely useful)
+
+    # Tensor[system.int] of shape "[3, 5]" on backend "Cpu"
+    # |1        1      1      1      1|
+    # |2        4      8     16     32|
+    # |3        9     27     81    243|
+
+    echo foo[1..^3, _] # Slice until the 3rd element from the end (inclusive, consistent with Nim,
+                       # cannot be combined with "..<")
+
+    # Tensor[system.int] of shape "[3, 5]" on backend "Cpu"
+    # |2        4      8     16     32|
+    # |3        9     27     81    243|
+
+    echo foo[_|2, _] # Take steps of 2 to get all the rows in the even positions
+
+    # Tensor[system.int] of shape "[3, 5]" on backend "Cpu"
+    # |1          1       1       1       1|
+    # |3          9      27      81     243|
+    # |5         25     125     625    3125|
+
+    echo foo[1.._|2, _] # Take steps of 2 starting on the second element (i.e. index 1)
+                        # to get all the rows in the odd positions
+
+    # Tensor[system.int] of shape "[2, 5]" on backend "Cpu"
+    # |2          4       8      16      32|
+    # |4         16      64     256    1024|
+
+    echo foo[3..1|-2, _] # Negative steps are also supported,
+                         # but require a slice start that is higher than the slice end
+
+    # Tensor[system.int] of shape "[2, 5]" on backend "Cpu"
+    # |4         16      64     256    1024|
+    # |2          4       8      16      32|
+
+    echo foo[^1..^3|-1, _] # Combining "^" with negative steps is supported,
+                           # and make it easy to go through a tensor from the back,
+                           # but note the offset of 1 compared to positive steps
+                           # (i.e. ^1 points to the last element, not the second to last)
+
+    # Tensor[system.int] of shape "[2, 5]" on backend "Cpu"
+    # |5         25     125     625    3125|
+    # |4         16      64     256    1024|
+    # |3          9      27      81     243|
+
+    echo foo[_|-1, _] # Combining "_" with a -1 step is the easiest way to reverse a tensor
 
     # Tensor[int] of shape "[5, 5]" on backend "Cpu"
     # |5      25      125     625     3125|
@@ -71,6 +118,10 @@ rows), reversing dimensions, counting from the end.
     # |3       9       27      81      243|
     # |2       4        8      16       32|
     # |1       1        1       1        1|
+
+    # Note that while "_" and "_.._" are equivalent to "^1..0"
+    # partial slices currently do not work with negative steps
+
 
 Slice mutations
 ~~~~~~~~~~~~~~~
@@ -85,7 +136,7 @@ an example and the explanation below.
 
 .. code:: nim
 
-    import math, arraymancer, future
+    import math, arraymancer
 
     const
         x = @[1, 2, 3, 4, 5]

--- a/src/arraymancer/tensor/accessors_macros_write.nim
+++ b/src/arraymancer/tensor/accessors_macros_write.nim
@@ -53,7 +53,7 @@ macro `[]=`*[T](t: var Tensor[T], args: varargs[untyped]): untyped =
 
 
 # Linked to: https://github.com/mratsim/Arraymancer/issues/52
-# Unfortunately enabling this breaksthe test suite
+# Unfortunately enabling this breaks the test suite
 # "Setting a slice from a view of the same Tensor"
 #
 # macro `[]`*[T](t: var AnyTensor[T], args: varargs[untyped]): untyped =

--- a/src/arraymancer/tensor/einsum.nim
+++ b/src/arraymancer/tensor/einsum.nim
@@ -22,7 +22,7 @@ import ./shapeshifting
 ## Simple Einstein summation examples
 ## ==================================
 ##
-## Typical examples include matrix-vector multiplcation, matrix-matrix multiplication
+## Typical examples include matrix-vector multiplication, matrix-matrix multiplication
 ## or the cross product. The examples below use the `einsum` / notation for the
 ## elements of tensors, namely `m[i,j]` for element `i,j` of the matrix ``m``, instead of
 ## the more mathematical notation `m_ij`.
@@ -124,7 +124,7 @@ import ./shapeshifting
 ## If only the `RHS` of the examples above are given, the required indices
 ## for the resulting tensor are automatically calculated using pure Einstein
 ## summation. Assuming `a`, `b` are two 2D arraymancer tensors , we could
-## express their matrix mutliplcation as
+## express their matrix mutiplication as
 ##
 ## .. code:: nim
 ##    let c = einsum(a, b):

--- a/tests/tensor/test_accessors_slicer.nim
+++ b/tests/tensor/test_accessors_slicer.nim
@@ -145,6 +145,14 @@ proc main() =
       let test2 = @[@[256],@[81],@[16],@[1]]
       check: t_van[^(4-2)..0|-1, 3] == test2.toTensor()
 
+    test "Span stepping from the end - foo[_|-2, 3]":
+      let test = @[@[625],@[81],@[1]]
+      check: t_van[_|-2, 3] == test.toTensor()
+
+    test "Span stepping from the end - foo[_.._|-2, 3]":
+      let test = @[@[625],@[81],@[1]]
+      check: t_van[_.._|-2, 3] == test.toTensor()
+
     when compileOption("boundChecks") and not defined(openmp):
       test "Slice from the end - expect non-negative step error - foo[^1..0, 3]":
         expect(IndexDefect):


### PR DESCRIPTION
This adds support for `a[_|-2]` and `a[_.._|-2]` syntax, both of which are syntactic sugar for `a[^1..0|-2]`. That is, we assume that the intention behind a "full" span combined with a negative step is to go through the tensor in reverse order.

This makes is extremelly simple to reverse a tensor (i.e. `a[_|-1]`) and is equivalent to python's `a[::-1]` syntax.