### PR TITLE
Add "item" function to convert a Tensor of size 1 (and any rank) into a scalar value

### DIFF
--- a/src/arraymancer/laser/tensor/initialization.nim
+++ b/src/arraymancer/laser/tensor/initialization.nim
@@ -277,3 +277,14 @@ func toUnsafeView*[T: KnownSupportsCopyMem](t: Tensor[T], aligned: static bool =
   ##
   ## Unsafe: the pointer can outlive the input tensor.
   unsafe_raw_offset(t, aligned).distinctBase()
+
+func toScalar*[T](t: Tensor[T]): T =
+  ## Convert a Tensor of size 1 (of any rank) into a scalar
+  ##
+  ## Raises an IndexDefect if the Tensor does not contain exactly 1 element
+  if likely(t.size == 1):
+    result = t.squeeze[]
+  elif t.size > 1:
+    raise newException(IndexDefect, "You cannot convert a Tensor that has more than 1 element into a scalar")
+  else:
+    raise newException(IndexDefect, "You cannot convert an empty Tensor into a scalar")

--- a/src/arraymancer/laser/tensor/initialization.nim
+++ b/src/arraymancer/laser/tensor/initialization.nim
@@ -280,7 +280,7 @@ func toUnsafeView*[T: KnownSupportsCopyMem](t: Tensor[T], aligned: static bool =
   ## Unsafe: the pointer can outlive the input tensor.
   unsafe_raw_offset(t, aligned).distinctBase()
 
-func toScalar*[T_IN, T_OUT](t: Tensor[T_IN], _: typedesc[T_OUT]): T_OUT =
+func item*[T_IN, T_OUT](t: Tensor[T_IN], _: typedesc[T_OUT]): T_OUT =
   ## Returns the value of the input Tensor as a scalar of the selected type.
   ## This only works for Tensors (of any rank) that contain one single element.
   ## If the tensor has more than one element IndexDefect is raised.
@@ -296,8 +296,8 @@ func toScalar*[T_IN, T_OUT](t: Tensor[T_IN], _: typedesc[T_OUT]): T_OUT =
   else:
     raise newException(IndexDefect, "You cannot convert an empty Tensor into a scalar")
 
-func toScalar*[T](t: Tensor[T]): T {.inline.}=
+func item*[T](t: Tensor[T]): T {.inline.}=
   ## Returns the value of the input Tensor as a scalar (without changing its type).
   ## This only works for Tensors (of any rank) that contain one single element.
   ## If the tensor has more than one element IndexDefect is raised.
-  toScalar(t, T)
+  item(t, T)

--- a/src/arraymancer/laser/tensor/initialization.nim
+++ b/src/arraymancer/laser/tensor/initialization.nim
@@ -286,11 +286,11 @@ func item*[T_IN, T_OUT](t: Tensor[T_IN], _: typedesc[T_OUT]): T_OUT =
   ## If the tensor has more than one element IndexDefect is raised.
   if likely(t.size == 1):
     when T_OUT is Complex64:
-      result = complex(float64(t.squeeze[]))
+      result = complex(float64(t.squeeze[0]))
     elif T_OUT is Complex32:
-      result = complex(float32(t.squeeze[]))
+      result = complex(float32(t.squeeze[0]))
     else:
-      result = T_OUT(t.squeeze[])
+      result = T_OUT(t.squeeze[0])
   elif t.size > 1:
     raise newException(IndexDefect, "You cannot convert a Tensor that has more than 1 element into a scalar")
   else:

--- a/tests/tensor/test_shapeshifting.nim
+++ b/tests/tensor/test_shapeshifting.nim
@@ -148,6 +148,16 @@ proc main() =
         check: a.rank == 4
         check: b.rank == 1
 
+    test "Getting the item out of a single element tensor":
+      block:
+        let a = [[[[1.5]]]].toTensor
+        let value = a.item()
+        check value == 1.5
+      block:
+        let a = [[[[1]]]].toTensor
+        let value = a.item(Complex64)
+        check value == complex(1.0, 0)
+
     test "Unsqueeze":
       block:
         let a = toSeq(1..12).toTensor().reshape(3,4)


### PR DESCRIPTION
This can be used, for example, to extract the result of the dot product of a row and a column Tensor.