### PR TITLE
squeezing single element tensor yields rank 1

### DIFF
--- a/src/arraymancer/tensor/private/p_shapeshifting.nim
+++ b/src/arraymancer/tensor/private/p_shapeshifting.nim
@@ -134,13 +134,14 @@ proc permuteImpl*[T](result: var Tensor[T], dims: varargs[int]) {.noSideEffect.}
 proc squeezeImpl*(t: var AnyTensor) {.noSideEffect.} =
   var idx_real_dim = 0
 
-  for i in 0..<t.rank:
+  for i in 0 ..< t.rank:
     if t.shape[i] != 1:
       if i != idx_real_dim:
         t.shape[idx_real_dim] = t.shape[i]
         t.strides[idx_real_dim] = t.strides[i]
       inc idx_real_dim
 
+  idx_real_dim = max(idx_real_dim, 1)
   t.shape = t.shape[0..<idx_real_dim]
   t.strides = t.strides[0..<idx_real_dim]
 

--- a/tests/tensor/test_shapeshifting.nim
+++ b/tests/tensor/test_shapeshifting.nim
@@ -123,6 +123,31 @@ proc main() =
 
         check: b == [4, 3, 2, 1, 8, 7, 6, 5].toTensor.reshape(2,1,4)
 
+    test "Squeezing a single element tensor":
+      # Previously squeezing a single element tensor turned the result into
+      # a 0 rank tensor. But we don't actually fully support zero rank tensors!
+      # Hence `squeeze` now leaves at least a rank 1 tensor
+      block:
+        let a = [1].toTensor
+        let b = a.squeeze()
+        check: a.rank == 1
+        check: b.rank == 1
+      block:
+        let a = [[1]].toTensor
+        let b = a.squeeze()
+        check: a.rank == 2
+        check: b.rank == 1
+      block:
+        let a = [[[1]]].toTensor
+        let b = a.squeeze()
+        check: a.rank == 3
+        check: b.rank == 1
+      block:
+        let a = [[[[1]]]].toTensor
+        let b = a.squeeze()
+        check: a.rank == 4
+        check: b.rank == 1
+
     test "Unsqueeze":
       block:
         let a = toSeq(1..12).toTensor().reshape(3,4)


### PR DESCRIPTION
Previously squeezing a tensor with a single element of rank N returned a rank 0 tensor, which we don't fully support. Now at most a rank 1 tensor is returned.

Note:
this is technically a breaking change if someone relied on the old behavior. I personally think that is acceptable, given that rank 0 tensors are barely supported and thus it is unlikely anyone made serious use of them as a result of a `squeeze` call.