### PR TITLE
Operator_enhancements

### DIFF
--- a/docs/howto.type_conversion.rst
+++ b/docs/howto.type_conversion.rst
@@ -2,7 +2,7 @@
 Spellbook: How to convert a tensor underlying type?
 ===================================================
 
-A type conversion fonction ``asType`` is provided for convenience
+A type conversion function ``asType`` is provided for convenience
 
 .. code:: nim
 

--- a/src/arraymancer/tensor/operators_blas_l1.nim
+++ b/src/arraymancer/tensor/operators_blas_l1.nim
@@ -64,6 +64,26 @@ proc `-=`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: var Tensor[T], b:
 # #########################################################
 # # Tensor-scalar linear algebra
 
+proc `+`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: T, t: Tensor[T]): Tensor[T] {.noinit.} =
+  ## Element-wise addition of a scalar
+  returnEmptyIfEmpty(t)
+  t.map_inline(x + a)
+
+proc `+`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], a: T): Tensor[T] {.noinit.} =
+  ## Element-wise addition of a scalar
+  returnEmptyIfEmpty(t)
+  t.map_inline(x + a)
+
+proc `-`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: T, t: Tensor[T]): Tensor[T] {.noinit.} =
+  ## Element-wise subtraction of a scalar
+  returnEmptyIfEmpty(t)
+  t.map_inline(a - x)
+
+proc `-`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], a: T): Tensor[T] {.noinit.} =
+  ## Element-wise subtraction of a scalar
+  returnEmptyIfEmpty(t)
+  t.map_inline(x - a)
+
 proc `*`*[T: SomeNumber|Complex[float32]|Complex[float64]](a: T, t: Tensor[T]): Tensor[T] {.noinit.} =
   ## Element-wise multiplication by a scalar
   returnEmptyIfEmpty(t)
@@ -85,6 +105,18 @@ proc `div`*[T: SomeInteger](t: Tensor[T], a: T): Tensor[T] {.noinit.} =
 
 # #########################################################
 # # Tensor-scalar in-place linear algebra
+
+proc `+=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], a: T) =
+  ## Element-wise addition of a scalar (in-place)
+  if t.size == 0:
+    return
+  t.apply_inline(x + a)
+
+proc `-=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], a: T) =
+  ## Element-wise substraction of a scalar (in-place)
+  if t.size == 0:
+    return
+  t.apply_inline(x - a)
 
 proc `*=`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: var Tensor[T], a: T) =
   ## Element-wise multiplication by a scalar (in-place)

--- a/src/arraymancer/tensor/operators_blas_l1.nim
+++ b/src/arraymancer/tensor/operators_blas_l1.nim
@@ -103,6 +103,16 @@ proc `div`*[T: SomeInteger](t: Tensor[T], a: T): Tensor[T] {.noinit.} =
   returnEmptyIfEmpty(t)
   t.map_inline(x div a)
 
+proc `mod`*[T: SomeNumber](t: Tensor[T], val: T): Tensor[T] {.noinit.} =
+  ## Broadcasted modulo operation
+  returnEmptyIfEmpty(t)
+  result = t.map_inline(x mod val)
+
+proc `mod`*[T: SomeNumber](val: T, t: Tensor[T]): Tensor[T] {.noinit.} =
+  ## Broadcasted modulo operation
+  returnEmptyIfEmpty(t)
+  result = t.map_inline(val mod x)
+
 # #########################################################
 # # Tensor-scalar in-place linear algebra
 

--- a/src/arraymancer/tensor/operators_blas_l1.nim
+++ b/src/arraymancer/tensor/operators_blas_l1.nim
@@ -93,10 +93,13 @@ proc `*`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], a: T): 
   ## Element-wise multiplication by a scalar
   a * t
 
-proc `/`*[T: SomeFloat|Complex[float32]|Complex[float64]](t: Tensor[T], a: T): Tensor[T] {.noinit.} =
+proc `/`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], a: T): Tensor[T] {.noinit.} =
   ## Element-wise division by a float scalar
   returnEmptyIfEmpty(t)
-  t.map_inline(x / a)
+  when T is SomeInteger:
+    t.map_inline(x div a)
+  else:
+    t.map_inline(x / a)
 
 proc `div`*[T: SomeInteger](t: Tensor[T], a: T): Tensor[T] {.noinit.} =
   ## Element-wise division by an integer

--- a/src/arraymancer/tensor/operators_broadcasted.nim
+++ b/src/arraymancer/tensor/operators_broadcasted.nim
@@ -52,6 +52,13 @@ proc `/.`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Te
   else:
     result = map2_inline(tmp_a, tmp_b, x / y )
 
+proc `mod`*[T: SomeNumber](a, b: Tensor[T]): Tensor[T] {.noinit.} =
+  ## Tensor element-wise modulo operation
+  ##
+  ## And broadcasted element-wise modulo operation.
+  let (tmp_a, tmp_b) = broadcast2(a, b)
+  result = map2_inline(tmp_a, tmp_b, x mod y)
+
 # ##############################################
 # # Broadcasting in-place Tensor-Tensor
 

--- a/src/arraymancer/tensor/operators_broadcasted.nim
+++ b/src/arraymancer/tensor/operators_broadcasted.nim
@@ -39,7 +39,6 @@ proc `*.`*[T: SomeNumber|Complex[float32]|Complex[float64]](a, b: Tensor[T]): Te
   ## Element-wise multiplication (Hadamard product).
   ##
   ## And broadcasted element-wise multiplication.
-
   let (tmp_a, tmp_b) = broadcast2(a, b)
   result = map2_inline(tmp_a, tmp_b, x * y)
 
@@ -117,6 +116,16 @@ proc `-.`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], val: T
   ## Broadcasted substraction for scalar - tensor.
   returnEmptyIfEmpty(t)
   result = t.map_inline(x - val)
+
+proc `*.`*[T: SomeNumber|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noinit.} =
+  ## Broadcasted multiplication for tensor * scalar.
+  returnEmptyIfEmpty(t)
+  result = t.map_inline(x + val)
+
+proc `*.`*[T: SomeNumber|Complex[float32]|Complex[float64]](t: Tensor[T], val: T): Tensor[T] {.noinit.} =
+  ## Broadcasted multiplication for scalar * tensor.
+  returnEmptyIfEmpty(t)
+  result = t.map_inline(x * val)
 
 proc `/.`*[T: SomeNumber|Complex[float32]|Complex[float64]](val: T, t: Tensor[T]): Tensor[T] {.noinit.} =
   ## Broadcasted division

--- a/tests/tensor/test_broadcasting.nim
+++ b/tests/tensor/test_broadcasting.nim
@@ -231,7 +231,7 @@ proc main() =
                     [10.0, 4, 2],
                     [15.0, 6, 3]].toTensor.asType(Complex[float64])
 
-    test "Implicit tensor-scalar broadcasting - basic operations +, -":
+    test "Implicit tensor-scalar broadcasting - basic operations +, -, *":
       block: # Addition
         var a = [0, 10, 20, 30].toTensor().reshape(4,1)
         var a_c = [0, 10, 20, 30].toTensor().reshape(4,1).asType(Complex[float64])
@@ -262,6 +262,20 @@ proc main() =
                       [-120],
                       [-130]].toTensor.asType(Complex[float64])
 
+      block: # Multiplication
+        var a = [0, 10, 20, 30].toTensor().reshape(4,1)
+        var a_c = [0, 10, 20, 30].toTensor().reshape(4,1).asType(Complex[float64])
+
+        a = 10 * a *. 20
+        a_c = complex64(10.0, 0.0) * a_c *. complex64(20.0, 0.0)
+        check: a == [[0],
+                    [2000],
+                    [4000],
+                    [6000]].toTensor
+        check: a_c == [[0],
+                      [2000],
+                      [4000],
+                      [6000]].toTensor.asType(Complex[float64])
 
 
     test "Implicit tensor-scalar broadcasting - basic operations +.=, -.=, .^=":

--- a/tests/tensor/test_broadcasting.nim
+++ b/tests/tensor/test_broadcasting.nim
@@ -291,7 +291,7 @@ proc main() =
                       [1.0/20.0],
                       [1.0/30.0]].toTensor.asType(Complex[float64])
 
-    test "Implicit broadcasting - Sigmoid 1 ./ (1 +. exp(-x)":
+    test "Implicit broadcasting - Sigmoid 1 ./ (1 +. exp(-x))":
       block:
         proc sigmoid[T: SomeFloat](t: Tensor[T]): Tensor[T]=
           1.T /. (1.T +. exp(0.T -. t))

--- a/tests/tensor/test_broadcasting.nim
+++ b/tests/tensor/test_broadcasting.nim
@@ -231,14 +231,50 @@ proc main() =
                     [10.0, 4, 2],
                     [15.0, 6, 3]].toTensor.asType(Complex[float64])
 
+    test "Implicit tensor-scalar broadcasting - basic operations +, -":
+      block: # Addition
+        var a = [0, 10, 20, 30].toTensor().reshape(4,1)
+        var a_c = [0, 10, 20, 30].toTensor().reshape(4,1).asType(Complex[float64])
+
+        a = 100 + a +. 200
+        a_c = complex64(100.0, 0.0) + a_c +. complex64(200.0, 0.0)
+        check: a == [[300],
+                    [310],
+                    [320],
+                    [330]].toTensor
+        check: a_c == [[300],
+                      [310],
+                      [320],
+                      [330]].toTensor.asType(Complex[float64])
+
+      block: # Substraction
+        var a = [0, 10, 20, 30].toTensor().reshape(4,1)
+        var a_c = [0, 10, 20, 30].toTensor().reshape(4,1).asType(Complex[float64])
+
+        a = 100 - a -. 200
+        a_c = complex64(100.0, 0.0) - a_c -. complex64(200.0, 0.0)
+        check: a == [[-100],
+                    [-110],
+                    [-120],
+                    [-130]].toTensor
+        check: a_c == [[-100],
+                      [-110],
+                      [-120],
+                      [-130]].toTensor.asType(Complex[float64])
+
+
 
     test "Implicit tensor-scalar broadcasting - basic operations +.=, -.=, .^=":
       block: # Addition
         var a = [0, 10, 20, 30].toTensor().reshape(4,1)
         var a_c = [0, 10, 20, 30].toTensor().reshape(4,1).asType(Complex[float64])
+        var a2 = a.clone()
+        var a_c2 = a_c.clone()
 
         a +.= 100
+        a2 += 100
         a_c +.= complex64(100.0, 0.0)
+        a_c2 += complex64(100.0, 0.0)
         check: a == [[100],
                     [110],
                     [120],
@@ -247,13 +283,19 @@ proc main() =
                     [110],
                     [120],
                     [130]].toTensor.asType(Complex[float64])
+        check: a == a2
+        check: a_c == a_c2
 
       block: # Substraction
         var a = [0, 10, 20, 30].toTensor().reshape(4,1)
         var a_c = [0, 10, 20, 30].toTensor().reshape(4,1).asType(Complex[float64])
+        var a2 = a.clone()
+        var a_c2 = a_c.clone()
 
         a -.= 100
+        a2 -= 100
         a_c -.= complex64(100.0, 0.0)
+        a_c2 -= complex64(100.0, 0.0)
         check: a == [[-100],
                       [-90],
                       [-80],
@@ -262,6 +304,8 @@ proc main() =
                       [-90],
                       [-80],
                       [-70]].toTensor.asType(Complex[float64])
+        check: a == a2
+        check: a_c == a_c2
 
       block: # Float Exponentiation
         var a = [1.0, 10, 20, 30].toTensor().reshape(4,1)

--- a/tests/tensor/test_broadcasting.nim
+++ b/tests/tensor/test_broadcasting.nim
@@ -151,6 +151,15 @@ proc main() =
                             [1.0/20.0],
                             [1.0/30.0]].toTensor.asType(Complex[float64])
 
+      block: # Modulo operation
+        let a = [1, 10, 20, 30].toTensor().reshape(4,1)
+        let b = [2, 3, 4].toTensor().reshape(1,3)
+
+        check: a mod b == [[1, 1, 1],
+                          [0, 1, 2],
+                          [0, 2, 0],
+                          [0, 0, 2]].toTensor
+
     test "Implicit tensor-tensor broadcasting - basic in-place operations +.=, -.=, *.=, /.=":
       block: # Addition
         # Note: We can't broadcast the lhs with in-place operations
@@ -231,7 +240,7 @@ proc main() =
                     [10.0, 4, 2],
                     [15.0, 6, 3]].toTensor.asType(Complex[float64])
 
-    test "Implicit tensor-scalar broadcasting - basic operations +, -, *":
+    test "Implicit tensor-scalar broadcasting - basic operations +, -, *, mod":
       block: # Addition
         var a = [0, 10, 20, 30].toTensor().reshape(4,1)
         var a_c = [0, 10, 20, 30].toTensor().reshape(4,1).asType(Complex[float64])
@@ -277,6 +286,11 @@ proc main() =
                       [4000],
                       [6000]].toTensor.asType(Complex[float64])
 
+      block: # Modulo operation
+        let a = [2, 5, 10].toTensor().reshape(1,3)
+
+        check: a mod 3 == [[2, 2, 1]].toTensor
+        check: 3 mod a == [[1, 3, 3]].toTensor
 
     test "Implicit tensor-scalar broadcasting - basic operations +.=, -.=, .^=":
       block: # Addition

--- a/tests/tensor/test_broadcasting.nim
+++ b/tests/tensor/test_broadcasting.nim
@@ -240,7 +240,7 @@ proc main() =
                     [10.0, 4, 2],
                     [15.0, 6, 3]].toTensor.asType(Complex[float64])
 
-    test "Implicit tensor-scalar broadcasting - basic operations +, -, *, mod":
+    test "Implicit tensor-scalar broadcasting - basic operations +, -, *, /, mod":
       block: # Addition
         var a = [0, 10, 20, 30].toTensor().reshape(4,1)
         var a_c = [0, 10, 20, 30].toTensor().reshape(4,1).asType(Complex[float64])
@@ -285,6 +285,21 @@ proc main() =
                       [2000],
                       [4000],
                       [6000]].toTensor.asType(Complex[float64])
+
+      block: # Division
+        var a = [0, 10, 20, 30].toTensor().reshape(4,1)
+        var a_c = [0, 10, 20, 30].toTensor().reshape(4,1).asType(Complex[float64])
+
+        a = (a /. 2) / 5
+        a_c = (a_c /. complex[float64](2.0)) / complex[float64](5.0)
+        check: a == [[0],
+                    [1],
+                    [2],
+                    [3]].toTensor
+        check: a_c == [[0],
+                      [1],
+                      [2],
+                      [3]].toTensor.asType(Complex[float64])
 
       block: # Modulo operation
         let a = [2, 5, 10].toTensor().reshape(1,3)


### PR DESCRIPTION
This PR adds several operator enhancements:

1. It makes Tensor-Scalar additions and subtractions behave in a way that is more consistent with Matlab and numpy.

In particular, up until now you could not use +, -, += and -= with a scalar, you had to use the "dot" versions of those operators. This was inconsistent with the * operation, which can _only_ be used without a dot. It was also inconsistent with how Matlab and numpy works (in both cases you can add or subtract a scalar without a dot.

2. Adds broadcast support to the mod operator

In addition to this we might want to add support for using *. with a scalar, which is currently not supported, while *.= is supported and +. is supported.