### PR TITLE
Add bounds checks for fold and reduce axis inline operations

### DIFF
--- a/src/arraymancer/private/ast_utils.nim
+++ b/src/arraymancer/private/ast_utils.nim
@@ -66,7 +66,7 @@ proc replaceSymsByIdents*(ast: NimNode): NimNode =
       return node
     of nnkLiterals:
       return node
-    of nnkHiddenStdConv: # see `test_fancy_indexing,nim` why needed
+    of nnkHiddenStdConv: # see `test_fancy_indexing.nim` why needed
       expectKind(node[1], nnkSym)
       return ident($node[1])
     else:


### PR DESCRIPTION
The errors that you got when you tried to reduce or fold a tensor along a dimension that does not exist were pretty cryptic. Hopefully these will be an improvement.

It would be great if you could somehow refer to the "op" that is used for the reduction or the fold but I did not find a way to do it.

This PR also fixes an unrelated small typo in ast_utils.nim.