### PR TITLE
Improve the error message when trying to assign to a slice of an immutable tensor

### DIFF
--- a/src/arraymancer/tensor/accessors_macros_write.nim
+++ b/src/arraymancer/tensor/accessors_macros_write.nim
@@ -72,3 +72,6 @@ macro `[]=`*[T](t: var Tensor[T], args: varargs[untyped]): untyped =
 #
 #   result = quote do:
 #     slice_typed_dispatch_var(`t`, `new_args`)
+
+template `[]=`*[T](t: Tensor[T], args: varargs[untyped]): untyped =
+  {.error: "a slice of an immutable tensor cannot be assigned to".}


### PR DESCRIPTION
Before this change the compilation errors you'd get when trying to assign to an immutable tensor were very cryptic (a type mismatch, and you had to notice that the only tensor related option had a "var Tensor" type). This change results in a much more understandable and explicit error.