### PR TITLE
Add support for doing a masked fill from a tensor

### DIFF
--- a/docs/tuto.slicing.rst
+++ b/docs/tuto.slicing.rst
@@ -260,3 +260,35 @@ the second to last operation in reverse in the final operation, thus
 copying exactly the thing we copied to the second to last row in
 reverse back to the last row. But because that is where the values in
 the second to last row originated from, nothing "happens".
+
+
+Boolean Masks
+~~~~~~~~~~~~~
+
+In addition to regular slicing, boolean masks can be used to select items
+from a tensor. The mask should have the same shape as the tensor it is used on.
+However, the result of the mask operation will be a flat, 1-D tensor with the
+selected items.
+
+.. code:: nim
+
+    foo = vandermonde.toTensor()
+    echo foo[foo >. 27]
+
+    # Tensor[system.int] of shape "[9]" on backend "Cpu"
+    #     32      81     243      64     256    1024     125     625    3125
+
+Boolean masks can also be used to mutate a tensor. The tensor is mutated in
+place, and thus it maintains its original shape.
+
+.. code:: nim
+
+    foo = vandermonde.toTensor()
+    foo[foo >. 27] = -arange(9)
+
+    # Tensor[system.int] of shape "[5, 5]" on backend "Cpu"
+    # |1      1     1     1     1|
+    # |2      4     8    16     0|
+    # |3      9    27    -1    -2|
+    # |4     16    -3    -4    -5|
+    # |5     25    -6    -7    -8|

--- a/src/arraymancer/tensor/accessors_macros_read.nim
+++ b/src/arraymancer/tensor/accessors_macros_read.nim
@@ -24,8 +24,10 @@ macro `[]`*[T](t: AnyTensor[T], args: varargs[untyped]): untyped =
   ##   - and:
   ##     - specific coordinates (``varargs[int]``)
   ##     - or a slice (cf. tutorial)
+  ##     - or a boolean tensor or openArray mask with the same shape as the tensor
   ## Returns:
   ##   - a value or a tensor corresponding to the slice
+  ##     or to the true elements of the mask
   ## Warning ⚠ CudaTensor temporary default:
   ##   For CudaTensor only, this is a no-copy operation, data is shared with the input.
   ##   This proc does not guarantee that a ``let`` value is immutable.
@@ -50,6 +52,7 @@ macro `[]`*[T](t: AnyTensor[T], args: varargs[untyped]): untyped =
   ##    - Slice from the end - expect non-negative step error - foo[^1..0, 3]
   ##    - Slice from the end - foo[^(2*2)..2*2, 3]
   ##    - Slice from the end - foo[^3..^2, 3]
+  ##    - Items matching a mask - foo[foo >. 0]
   let new_args = getAst(desugar(args))
 
   result = quote do:

--- a/src/arraymancer/tensor/accessors_macros_write.nim
+++ b/src/arraymancer/tensor/accessors_macros_write.nim
@@ -24,22 +24,28 @@ macro `[]=`*[T](t: var Tensor[T], args: varargs[untyped]): untyped =
   ##
   ## Input:
   ##   - a ``var`` tensor
-  ##   - a location:
+  ##   - a location or a boolean mask:
   ##     - specific coordinates (``varargs[int]``)
   ##     - or a slice (cf. tutorial)
+  ##     - or a boolean tensor or openArray mask with the same shape as the tensor
   ##   - a value:
   ##     - a single value that will
   ##       - replace the value at the specific coordinates
   ##       - or be applied to the whole slice
-  ##     - an openArray with a shape that matches the slice
-  ##     - a tensor with a shape that matches the slice
+  ##       - or be applied to the true elements of the boolean mask
+  ##     - a tensor or openArray with a shape that matches the slice
+  ##     - a tensor whose values will be applied to the true elements
+  ##       of the boolean mask
   ## Result:
   ##   - Nothing, the tensor is modified in-place
   ## Usage:
   ##   - Assign a single value - foo[1..2, 3..4] = 999
+  ##   - Assign a single value to a boolean mask - foo[foo .> 0] = 999
   ##   - Assign an array/seq of values - foo[0..1,0..1] = [[111, 222], [333, 444]]
   ##   - Assign values from a view/Tensor - foo[^2..^1,2..4] = bar
   ##   - Assign values from the same Tensor - foo[^2..^1,2..4] = foo[^1..^2|-1, 4..2|-1]
+  ##   - Assign values from a view/Tensor
+  ##     to a boolean mask - foo[foo .> 0] = [1, 2, 3].toTensor
 
   # varargs[untyped] consumes all arguments so the actual value should be popped
   # https://github.com/nim-lang/Nim/issues/5855

--- a/src/arraymancer/tensor/selectors.nim
+++ b/src/arraymancer/tensor/selectors.nim
@@ -125,10 +125,9 @@ proc masked_select*[T](t: Tensor[T], mask: openArray): Tensor[T] {.noinit.} =
   t.masked_select mask.toTensor()
 
 proc masked_fill*[T](t: var Tensor[T], mask: Tensor[bool], value: T) =
-  ## For the index of each element of t.
-  ## Fill the elements at ``t[index]`` with the ``value``
-  ## if their corresponding ``mask[index]`` is true.
-  ## If not they are untouched.
+  ## For each element ``t[index]`` of the input tensor ``t`` with index ``index``,
+  ## check if ``mask[index]`` is true. If so, fill it ``value``.
+  ## Otherwise leave it untouched.
   ##
   ## Example:
   ##
@@ -137,6 +136,10 @@ proc masked_fill*[T](t: var Tensor[T], mask: Tensor[bool], value: T) =
   ## or alternatively:
   ##
   ##   t.masked_fill(t > 0): -1
+  ##
+  ## In this version of this procedure the boolean mask is a ``Tensor[bool]``
+  ## with the same size as the input tensor ``t``.
+
   if t.size == 0 or mask.size == 0:
     return
   check_elementwise(t, mask)
@@ -156,41 +159,47 @@ proc masked_fill*[T](t: var Tensor[T], mask: Tensor[bool], value: T) =
         tElem = value
 
 proc masked_fill*[T](t: var Tensor[T], mask: openArray, value: T) =
-  ## For the index of each element of t.
-  ## Fill the elements at ``t[index]`` with the ``value``
-  ## if their corresponding ``mask[index]`` is true.
-  ## If not they are untouched.
+  ## For each element ``t[index]`` of the input tensor ``t`` with index ``index``,
+  ## check if ``mask[index]`` is true. If so, fill it ``value``.
+  ## Otherwise leave it untouched.
   ##
   ## Example:
   ##
-  ##   t.masked_fill(t > 0, -1)
+  ##   t.masked_fill([true, false, true, true], -1)
   ##
   ## or alternatively:
   ##
-  ##   t.masked_fill(t > 0): -1
+  ##   t.masked_fill([true, false, true, true]): -1
   ##
-  ## The boolean mask must be
+  ## In this version of this procedure the boolean mask, which must have the
+  ## same size as the input tensor ``t``, is an openArray of bools, i.e.:
   ##   - an array or sequence of bools
   ##   - an array of arrays of bools,
   ##   - ...
-  ##
   if t.size == 0 or mask.len == 0:
     return
   t.masked_fill(mask.toTensor(), value)
 
 proc masked_fill*[T](t: var Tensor[T], mask: Tensor[bool], value: Tensor[T]) =
-  ## For the index of each element of t.
-  ## Fill the elements at ``t[index]`` with the ``value``
-  ## if their corresponding ``mask[index]`` is true.
-  ## If not they are untouched.
+  ## For each element ``t[index]`` of the input tensor ``t`` with index ``index``,
+  ## check if ``mask[index]`` is true. If so fill it with the _next_
+  ## element from the ``value`` tensor. Otherwise leave it untouched.
+  ##
+  ## Note that this does _not_ fill ``t[index]`` with ``value[index]``, but
+  ## with the n-th element of ``value`` where n is the number of true elements
+  ## in the mask before and including the index-th mask element.
+  ## Because of this, the value tensor must have at least as many elements as
+  ## the number of true elements in the mask. If that is not the case an
+  ## IndexDefect exception will be raised at runtime. The ``value`` tensor
+  ## can have even more values which will simply be ignored.
   ##
   ## Example:
   ##
-  ##   t.masked_fill(t > 0, -1)
+  ##   t.masked_fill(t > 0, [3, 4, -1].toTensor)
   ##
-  ## or alternatively:
-  ##
-  ##   t.masked_fill(t > 0): -1
+  ## In this version of this procedure the boolean mask is a ``Tensor[bool]``
+  ## with the same size as the input tensor ``t``.
+
   if t.size == 0 or mask.size == 0:
     return
   check_elementwise(t, mask)
@@ -232,24 +241,28 @@ proc masked_fill*[T](t: var Tensor[T], mask: Tensor[bool], value: Tensor[T]) =
     raise newException(IndexDefect, error_msg)
 
 proc masked_fill*[T](t: var Tensor[T], mask: openArray, value: Tensor[T]) =
-  ## For the index of each element of t.
-  ## Fill the elements at ``t[index]`` with the ``value``
-  ## if their corresponding ``mask[index]`` is true.
-  ## If not they are untouched.
+  ## For each element ``t[index]`` of the input tensor ``t`` with index ``index``,
+  ## check if ``mask[index]`` is true. If so fill it with the _next_
+  ## element from the ``value`` tensor. Otherwise leave it untouched.
+  ##
+  ## Note that this does _not_ fill ``t[index]`` with ``value[index]``, but
+  ## with the n-th element of ``value`` where n is the number of true elements
+  ## in the mask before and including the index-th mask element.
+  ## Because of this, the value tensor must have at least as many elements as
+  ## the number of true elements in the mask. If that is not the case an
+  ## IndexDefect exception will be raised at runtime. The ``value`` tensor
+  ## can have even more values which will simply be ignored.
   ##
   ## Example:
   ##
-  ##   t.masked_fill(t > 0, -1)
+  ##   t.masked_fill([true, false, true, true], [3, 4, -1].toTensor)
   ##
-  ## or alternatively:
-  ##
-  ##   t.masked_fill(t > 0): -1
-  ##
-  ## The boolean mask must be
+  ## In this version of this procedure the boolean mask, which must have the
+  ## same size as the input tensor ``t``, is an openArray of bools, i.e.:
   ##   - an array or sequence of bools
   ##   - an array of arrays of bools,
   ##   - ...
-  ##
+
   if t.size == 0 or mask.len == 0:
     return
   t.masked_fill(mask.toTensor(), value)
@@ -347,7 +360,7 @@ template masked_axis_fill_impl[T](t: var Tensor[T], mask: Tensor[bool] or openAr
 
 proc masked_axis_fill*[T](t: var Tensor[T], mask: Tensor[bool], axis: int, value: T or Tensor[T]) =
   ## Take a 1D boolean mask tensor with size equal to the `t.shape[axis]`
-  ## The axis index that are set to true in the mask will be filled with `value`
+  ## The axis indexes that are set to true in the mask will be filled with `value`
   ##
   ## Limitation:
   ##   If value is a Tensor, only filling via broadcastable tensors is supported at the moment
@@ -381,7 +394,7 @@ proc masked_axis_fill*[T](t: var Tensor[T], mask: Tensor[bool], axis: int, value
 
 proc masked_axis_fill*[T](t: var Tensor[T], mask: openArray[bool], axis: int, value: T or Tensor[T]) =
   ## Take a 1D boolean mask tensor with size equal to the `t.shape[axis]`
-  ## The axis index that are set to true in the mask will be filled with `value`
+  ## The axis indexes that are set to true in the mask will be filled with `value`
   ##
   ## Limitation:
   ##   If value is a Tensor, only filling via broadcastable tensors is supported at the moment

--- a/tests/tensor/test_selectors.nim
+++ b/tests/tensor/test_selectors.nim
@@ -164,26 +164,34 @@ proc main() =
         check: r == expected
 
     test "Masked_fill":
-      block: # Numpy reference doc
-            # https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html#boolean-array-indexing
-            # select non NaN
-        # x = np.array([[1., 2.], [np.nan, 3.], [np.nan, np.nan]])
-        # x[np.isnan(x)] = -1
-        # x
-        # np.array([[1., 2.], [-1, 3.], [-1, -1]])
-        var x = [[1.0, 2.0],
-                [NaN, 3.0],
-                [NaN, NaN]].toTensor
+      # Numpy reference doc
+      # https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html#boolean-array-indexing
+      # select non NaN
+      # x = np.array([[1., 2.], [np.nan, 3.], [np.nan, np.nan]])
+      # x[np.isnan(x)] = -1
+      # x
+      # np.array([[1., 2.], [-1, 3.], [-1, -1]])
+      let t = [[1.0, 2.0],
+        [NaN, 3.0],
+        [NaN, NaN]].toTensor
+      block: # Single value masked fill
+        var x = t.clone()
 
         x.masked_fill(x.isNaN, -1.0)
 
         let expected = [[1.0, 2.0], [-1.0, 3.0], [-1.0, -1.0]].toTensor()
         check: x == expected
 
-      block: # with regular arrays/sequences
-        var x = [[1.0, 2.0],
-                [NaN, 3.0],
-                [NaN, NaN]].toTensor
+      block: # Multiple value masked fill
+        var x = t.clone()
+
+        x.masked_fill(x.isNaN, [-10.0, -20.0, -30.0].toTensor())
+
+        let expected = [[1.0, 2.0], [-10.0, 3.0], [-20.0, -30.0]].toTensor()
+        check: x == expected
+
+      block: # Fill with regular arrays/sequences
+        var x = t.clone()
 
         x.masked_fill(
           [[false,  false],

--- a/tests/tensor/test_selectors.nim
+++ b/tests/tensor/test_selectors.nim
@@ -190,6 +190,18 @@ proc main() =
         let expected = [[1.0, 2.0], [-10.0, 3.0], [-20.0, -30.0]].toTensor()
         check: x == expected
 
+        when compileOption("mm", "arc") or compileOption("mm", "orc"):
+          # Check that we throw an exception when there are less values than
+          # true elements in the mask
+          # This only works when using ARC or ORC
+          x = t.clone()
+          var exception_thrown_when_true_element_mask_count_exceeds_value_tensor_size = false
+          try:
+            x.masked_fill(x.isNaN, [-10.0, -20.0].toTensor())
+          except IndexDefect:
+            exception_thrown_when_true_element_mask_count_exceeds_value_tensor_size = true
+          check: exception_thrown_when_true_element_mask_count_exceeds_value_tensor_size
+
       block: # Fill with regular arrays/sequences
         var x = t.clone()
 


### PR DESCRIPTION
This is supported by numpy but was not supported by Arraymancer yet.

I'm hoping I've implemented it in a sufficiently performant way. If I can do it in a better way, please let me know.
