### PR TITLE
Add at_mut template to enable masked_fill on slices

### DIFF
--- a/src/arraymancer/tensor/syntactic_sugar.nim
+++ b/src/arraymancer/tensor/syntactic_sugar.nim
@@ -55,25 +55,3 @@ template at_mut*[T](t: var Tensor[T], args: varargs[untyped]): untyped =
   ##     Singleton dimension are collapsed
   var mt = t[args].squeeze
   mt
-
-template mut*[T](t: Tensor[T]): var Tensor[T] =
-# template mut*[T](t: Tensor[T]): untyped =
-  ## Return a mutable view of a Tensor
-  ## 
-  ## This can be useful, for example, when assigning a value into a chain
-  ## of slice operations which are usually considered immutable even if
-  ## the original tensor is mutable. For example, this lets you do:
-  ##
-  ## .. code:: nim
-  ##   var x = arange(20).reshape([4, 3])
-  ##   # The code `x[1..2, _][condition] = 100` would fail with
-  ##   # a `a slice of an immutable tensor cannot be assigned to` error
-  ##   # Using `mut` allows assignment to the slice
-  ##   x[1..2, _].mut[condition] = 100
-  ##
-  ## Input:
-  ##   - a Tensor
-  ## Returns:
-  ##   - a mutable value or view of the Tensor corresponding to the slice
-  var mt = t
-  mt

--- a/src/arraymancer/tensor/syntactic_sugar.nim
+++ b/src/arraymancer/tensor/syntactic_sugar.nim
@@ -29,3 +29,51 @@ template at*[T](t: Tensor[T], args: varargs[untyped]): untyped =
   ## Usage:
   ##   See the ``[]`` macro
   t[args].squeeze
+
+template at_mut*[T](t: var Tensor[T], args: varargs[untyped]): untyped =
+  ## Slice a Tensor, collapse singleton dimension, returning a mutable slice of the input
+  ##
+  ## This can be useful, for example, when assigning a value into a chain
+  ## of slice operations which are usually considered immutable even if
+  ## the original tensor is mutable. For example, this lets you do:
+  ##
+  ## .. code:: nim
+  ##   var x = arange(12).reshape([4, 3])
+  ##   let condition = [[true, false, true], [true, false, true]].toTensor
+  ##   # The code `x[1..2, _][condition] = 1000` would fail with
+  ##   # a `a slice of an immutable tensor cannot be assigned to` error
+  ##   # Instead, using `at_mut` allows assignment to the slice
+  ##   x.at_mut(1..2, _)[condition] = 1000
+  ##
+  ## Input:
+  ##   - a Tensor
+  ##   - and:
+  ##     - specific coordinates (``varargs[int]``)
+  ##     - or a slice (cf. tutorial)
+  ## Returns:
+  ##   - a mutable value or view of the Tensor corresponding to the slice
+  ##     Singleton dimension are collapsed
+  var mt = t[args].squeeze
+  mt
+
+template mut*[T](t: Tensor[T]): var Tensor[T] =
+# template mut*[T](t: Tensor[T]): untyped =
+  ## Return a mutable view of a Tensor
+  ## 
+  ## This can be useful, for example, when assigning a value into a chain
+  ## of slice operations which are usually considered immutable even if
+  ## the original tensor is mutable. For example, this lets you do:
+  ##
+  ## .. code:: nim
+  ##   var x = arange(20).reshape([4, 3])
+  ##   # The code `x[1..2, _][condition] = 100` would fail with
+  ##   # a `a slice of an immutable tensor cannot be assigned to` error
+  ##   # Using `mut` allows assignment to the slice
+  ##   x[1..2, _].mut[condition] = 100
+  ##
+  ## Input:
+  ##   - a Tensor
+  ## Returns:
+  ##   - a mutable value or view of the Tensor corresponding to the slice
+  var mt = t
+  mt

--- a/tests/tensor/test_selectors.nim
+++ b/tests/tensor/test_selectors.nim
@@ -378,5 +378,20 @@ proc main() =
 
         check: checkered == expected
 
+    test "at_mut":
+      block:
+        var x = arange(12).reshape([4, 3])
+        # The code `x[1..2, _][condition] = 1000` would fail with
+        # a `a slice of an immutable tensor cannot be assigned to` error
+        # Instead, using `at_mut` allows assignment to the slice
+        let condition = [[true, false, true], [true, false, true]].toTensor
+        let expected = [[   0, 1,    2],
+                        [1000, 4, 1000],
+                        [1000, 7, 1000],
+                        [   9, 10, 11]].toTensor
+        x.at_mut(1..2, _)[condition] = 1000
+        check: expected == x
+
+
 main()
 GC_fullCollect()


### PR DESCRIPTION
This can be useful, for example, when assigning a value into a chain of slice operations which are usually considered immutable even if the original tensor is mutable. For example, the following code:

```nim
var x = arange(20).reshape([4, 3])
x[1..2, _][condition] = 100
```
will fail with a `a slice of an immutable tensor cannot be assigned to` error. Using `at_mut` you can do:
```nim
x.at_mut(1..2, _)[condition] = 100
```
which works fine.