### PR TITLE
Remove support for nim 1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 20
       matrix:
         # branch: [version-1-0, version-1-2, version-1-4, version-1-6] # [devel]
-        nim: ['version-1-4', 'version-1-6', 'version-2-0', 'devel'] # 'devel'
+        nim: ['version-1-6', 'version-2-0', 'devel'] # 'devel'
         target:
           - os: linux
             cpu: amd64


### PR DESCRIPTION
A few incoming PR's become simpler if we drop support for nim 1.4, which according to the most recent Nim Community Survey is used by less than 1.5% of nim's users.