### PR TITLE
More missing numpy

### DIFF
--- a/docs/tuto.slicing.rst
+++ b/docs/tuto.slicing.rst
@@ -8,25 +8,9 @@ out of 2 rows), reversing dimensions and counting from the end.
 
 .. code:: nim
 
-    import math, arraymancer
+    import arraymancer
 
-    const
-        x = @[1, 2, 3, 4, 5]
-        y = @[1, 2, 3, 4, 5]
-
-    var
-        vandermonde: seq[seq[int]]
-        row: seq[int]
-
-    vandermonde = newSeq[seq[int]]()
-
-    for i, xx in x:
-        row = newSeq[int]()
-        vandermonde.add(row)
-        for j, yy in y:
-            vandermonde[i].add(xx^yy)
-
-    let foo = vandermonde.toTensor()
+    let foo = vandermonde(arange(1, 6), arange(1, 6)).asType(int)
 
     echo foo
 
@@ -136,25 +120,9 @@ an example and the explanation below.
 
 .. code:: nim
 
-    import math, arraymancer
+    import arraymancer
 
-    const
-        x = @[1, 2, 3, 4, 5]
-        y = @[1, 2, 3, 4, 5]
-
-    var
-        vandermonde: seq[seq[int]]
-        row: seq[int]
-
-    vandermonde = newSeq[seq[int]]()
-
-    for i, xx in x:
-        row = newSeq[int]()
-        vandermonde.add(row)
-        for j, yy in y:
-            vandermonde[i].add(xx^yy)
-
-    var foo = vandermonde.toTensor()
+    var foo = vandermonde(arange(1, 6), arange(1, 6)).asType(int)
 
     echo foo
 

--- a/src/arraymancer/linear_algebra/special_matrices.nim
+++ b/src/arraymancer/linear_algebra/special_matrices.nim
@@ -45,7 +45,7 @@ proc vandermonde*[T](x: Tensor[T], orders: Tensor[SomeNumber]): Tensor[float] =
   ##
   ## Inputs:
   ##   - x: The input tensor `x` (which must be a rank-1 tensor)
-  ##   - orders: The "exponentes" tensor (which must also be a rank-1 tensor)
+  ##   - orders: The "exponents" tensor (which must also be a rank-1 tensor)
   ## Result:
   ##   - The constructed Vandermonde matrix
   assert x.squeeze.rank == 1

--- a/src/arraymancer/tensor/operators_comparison.nim
+++ b/src/arraymancer/tensor/operators_comparison.nim
@@ -114,7 +114,6 @@ proc `==.`*[T](t: Tensor[T], value : T): Tensor[bool] {.noinit.} =
   ##   - A tensor of boolean
   gen_broadcasted_scalar_comparison(`==`)
 
-
 proc `!=.`*[T](t: Tensor[T], value : T): Tensor[bool] {.noinit.} =
   ## Tensor element-wise inequality with scalar
   ## Returns:
@@ -144,6 +143,47 @@ proc `>.`*[T](t: Tensor[T], value : T): Tensor[bool] {.noinit.} =
   ## Returns:
   ##   - A tensor of boolean
   gen_broadcasted_scalar_comparison(`>`)
+
+
+# ###########################################
+# Broadcasted  scalar ops with reversed order
+
+template `==.`*[T](value : T, t: Tensor[T]): Tensor[bool] =
+  ## Element-wise scalar equality with tensor
+  ## Returns:
+  ##   - A tensor of boolean
+  t ==. value
+
+template `!=.`*[T](value : T, t: Tensor[T]): Tensor[bool] =
+  ## Element-wise scalar inequality with tensor
+  ## Returns:
+  ##   - A tensor of boolean
+  t !=. value
+
+template `<=.`*[T](value : T, t: Tensor[T]): Tensor[bool] =
+  ## Element-wise scalar smaller or equal than tensor
+  ## Returns:
+  ##   - A tensor of boolean
+  t >=. value
+
+template `<.`*[T](value : T, t: Tensor[T]): Tensor[bool] =
+  ## Element-wise scalar smaller than tensor
+  ## Returns:
+  ##   - A tensor of boolean
+  t >. value
+
+template `>=.`*[T](value : T, t: Tensor[T]): Tensor[bool] =
+  ## Element-wise scalar greater or equal than tensor
+  ## Returns:
+  ##   - A tensor of boolean
+  t <=. value
+
+template `>.`*[T](value : T, t: Tensor[T]): Tensor[bool] =
+  ## Element-wise scalar greater than tensor
+  ## Returns:
+  ##   - A tensor of boolean
+  t <. value
+
 
 # ##################################
 # broadcasted special float handling

--- a/src/arraymancer/tensor/shapeshifting.nim
+++ b/src/arraymancer/tensor/shapeshifting.nim
@@ -239,6 +239,76 @@ proc concat*[T](t_list: varargs[Tensor[T]], axis: int): Tensor[T] {.noinit.} =
     result.slicerMut(slices, t)
     iaxis += t.shape[axis]
 
+proc append*[T](t: Tensor[T], values: Tensor[T]): Tensor[T] {.noinit.} =
+  ## Create a copy of an rank-1 input tensor with values appended to its end
+  ##
+  ## Inputs:
+  ##   - Rank-1 tensor
+  ##   - Rank-1 tensor of extra values to append
+  ## Returns:
+  ##   - A copy of the input tensor t with the extra values appended at the end.
+  ## Notes:
+  ##   Append does not occur in-place (a new tensor is allocated and filled).
+  ##   To concatenate more than one tensor or tensors that you must use `concat`.
+  ##   Compared to numpy's `append`, this proc requires that you explicitly
+  ##   flatten the inputs if they are not rank-1 tensors. It also does not
+  ##   support the `axis` parameter. If you want to append the values along a
+  ##   specific axis, you should use `concat` instead.
+  ## Examples:
+  ## > echo append([1, 2, 3].toTensor, [4, 5, 6, 7].toTensor)
+  ## > # Tensor[system.int] of shape "[9]" on backend "Cpu"
+  ## > #    1     2     3     4     5     6     7
+  ## >
+  ## > echo append([1, 2, 3].toTensor, [[4, 5, 6], [7, 8, 9]].toTensor)
+  ## > # Error: unhandled exception: `values.rank == 1` append only works
+  ## > # on rank-1 tensors but extra values tensor has rank 2 [AssertionDefect]
+  ## >
+  ## > echo append([1, 2, 3].toTensor, [[4, 5, 6], [7, 8, 9]].toTensor.flatten)
+  ## > #    1     2     3     4     5     6     7     8     9
+  doAssert t.rank == 1,
+    "`append` only works on rank-1 tensors but first input tensor has rank " &
+    $t.rank & " (use `concat` for higher rank tensors)"
+  doAssert values.rank == 1,
+    "`append` only works on rank-1 tensors but extra values tensor has rank " &
+    $values.rank & " (use `concat` for higher rank tensors)"
+  let result_size = t.size + values.size
+  result = newTensorUninit[T](result_size)
+  result[0 ..< t.size] = t
+  result[t.size ..< result.size] = values
+
+proc append*[T](t: Tensor[T], values: openArray[T]): Tensor[T] {.noinit.} =
+  ## Create a copy of an rank-1 input tensor with values appended to its end
+  ##
+  ## Inputs:
+  ##   - Rank-1 tensor of type T
+  ##   - An open array of values of type T
+  ## Returns:
+  ##   - A copy of the input tensor t with the extra values appended at the end.
+  ## Notes:
+  ##   Append does not occur in-place (a new tensor is allocated and filled).
+  ##   Compared to numpy's `append`, this proc requires that you explicitly
+  ##   flatten the input tensor if its rank is greater than 1. It also does not
+  ##   support the `axis` parameter. If you want to append values along a
+  ##   specific axis, you should use `concat` instead.
+  ## Examples:
+  ## > echo append([1, 2, 3].toTensor, [4, 5, 6, 7])
+  ## > # Tensor[system.int] of shape "[9]" on backend "Cpu"
+  ## > #    1     2     3     4     5     6     7
+  ## >
+  ## > echo append([[1, 2, 3], [4, 5, 6]].toTensor, [7, 8, 9])
+  ## > # Error: unhandled exception: `t.rank == 1` append only works
+  ## > # on rank-1 tensors but first input tensor has rank 2 [AssertionDefect]
+  ## >
+  ## > echo append([[1, 2, 3], [4, 5, 6]].toTensor.flatten, [7, 8, 9])
+  ## > #    1     2     3     4     5     6     7     8     9
+  doAssert t.rank == 1,
+    "`append` only works on rank-1 tensors but input tensor has rank " &
+    $t.rank & " (use `concat` for higher rank tensors)"
+  let result_size = t.size + values.len
+  result = newTensorUninit[T](result_size)
+  result[0 ..< t.size] = t
+  result[t.size ..< result.size] = values
+
 func squeeze*(t: AnyTensor): AnyTensor {.noinit.}=
   ## Squeeze tensors. For example a Tensor of shape [4,1,3] will become [4,3]
   ## Input:

--- a/tests/linear_algebra/test_linear_algebra.nim
+++ b/tests/linear_algebra/test_linear_algebra.nim
@@ -33,6 +33,14 @@ proc main() =
         for j in 0 ..< axSq.size:
           check axSq[j] == pow(el.float, order.float)
           inc order
+      let vandermonde_3x3 = vandermonde(arange(3), 3)
+      let vander_3x3 = vander(arange(3), 3)
+      check:
+        vandermonde_3x3 == vandermonde(3)
+        vandermonde_3x3 == vandermonde(arange(3))
+        vandermonde_3x3 == vandermonde(arange(3), arange(3))
+        vandermonde_3x3 == vander_3x3[_, _|-1]
+        vandermonde_3x3 == vander(arange(3), 3, increasing=true)
 
     test "Linear equation solver using least squares":
       block: # "Single equation"

--- a/tests/tensor/test_operators_comparison.nim
+++ b/tests/tensor/test_operators_comparison.nim
@@ -55,15 +55,26 @@ proc main() =
       check: t_van_complex[1..3,1..3] == t_test_complex
 
     test "Testing element-wise/broadcasted comparison":
-      let
-        a = [0, 2, 1, 3].toTensor
-        b = [0, 1, 2, 3].toTensor
-        a_complex = a.asType(Complex[float64])
-        b_complex = b.asType(Complex[float64])
+      block: # Element-wise Tensor-Tensor comparison
+        let
+          a = [0, 1, 2, 3].toTensor
+          b = [0, 2, 1, 3].toTensor
+          a_complex = a.asType(Complex[float64])
+          b_complex = b.asType(Complex[float64])
 
-      check: (a ==. b) == [true, false, false, true].toTensor
-      check: (a >. b)  == [false, true, false, false].toTensor
-      check: (a_complex ==. b_complex) == [true, false, false, true].toTensor
+        check: (a ==. b) == [true, false, false, true].toTensor
+        check: (a <. b)  == [false, true, false, false].toTensor
+        check: (a_complex ==. b_complex) == [true, false, false, true].toTensor
+
+      block: # Element-wise Tensor-Scalar and Scalar-Tensor comparison
+        let
+          a = [0, 1, 2, 3].toTensor
+          a_complex = a.asType(Complex[float64])
+
+        check: (a >=. 2)  == [false, false, true, true].toTensor
+        check: (2 <=. a)  == [false, false, true, true].toTensor
+        check: (a_complex ==. complex(2.0))  == [false, false, true, false].toTensor
+
 
 main()
 GC_fullCollect()

--- a/tests/tensor/test_shapeshifting.nim
+++ b/tests/tensor/test_shapeshifting.nim
@@ -103,6 +103,13 @@ proc main() =
       check: concat(a,b, axis = 1) == [[1,2,5,6],
                                       [3,4,7,8]].toTensor()
 
+    test "Append":
+      let a = toSeq(1..4).toTensor()
+      let b = toSeq(5..8)
+
+      check: a.append(b) == [1,2,3,4,5,6,7,8].toTensor()
+      check: a.append(b.toTensor()) == [1,2,3,4,5,6,7,8].toTensor()
+
     test "Squeeze":
       block:
         let a = toSeq(1..12).toTensor().reshape(3,1,2,1,1,2)

--- a/tests/tensor/test_shapeshifting.nim
+++ b/tests/tensor/test_shapeshifting.nim
@@ -280,5 +280,20 @@ proc main() =
           a.roll(-1) == [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 0]].toTensor
           a.roll(-5) == a.roll(7)
 
+    test "Axis permute and move":
+      block: # Permute and moveaxis
+        let a = arange(6).reshape(1, 2, 3)
+        let a_permuted_1 = [[[0, 3], [1, 4], [2, 5]]].toTensor
+        let a_permuted_2 = [[[0], [1], [2]], [[3], [4], [5]]].toTensor
+        check:
+          # Keep dim 0 at 0 and swap dimensions 1 and 2
+          a_permuted_1 == a.permute(0, 2, 1)
+          a_permuted_1 == a.moveaxis(2, 1)
+
+          # Move dim 0 to 2, which is the same as
+          # moving dim 1 to 0 and then moving 2 to 1
+          a_permuted_2 == a.permute(1, 2, 0)
+          a_permuted_2 == a.moveaxis(1, 0).moveaxis(2, 1)
+
 main()
 GC_fullCollect()


### PR DESCRIPTION
This adds a few more missing numpy functions: append, moveaxis, vander (similar to vandermonde by with reversed column order by default) and several scalar-tensor comparison operators (until now we only supported tensor-tensor and tensor-scalar versions of those operators, but not scalar-tensor).