### PR TITLE
Add int2bit functions

### DIFF
--- a/tests/linear_algebra/test_special_matrices.nim
+++ b/tests/linear_algebra/test_special_matrices.nim
@@ -186,6 +186,21 @@ proc main() =
           xy == @[expected_xy_x, expected_xy_y, expected_xy_z]
           ij == @[expected_ij_x, expected_ij_y, expected_ij_z]
 
+  suite "int2bit":
+    test "Scalar value":
+      block:
+        check:
+          int2bit(12, 5) == [false, true, true, false, false].toTensor
+          int2bit(12, 5, msbfirst=false) == [false, false, true, true, false].toTensor
+
+    test "Tensor":
+      block:
+        check:
+          int2bit([12, 6].toTensor, 5) == [[false, true, true, false, false],
+                                           [false, false, true, true, false]].toTensor
+          int2bit([12, 6].toTensor, 5, msbfirst=false) == [[false, false, true, true, false],
+                                                           [false, true, true, false, false]].toTensor
+
 
 main()
 GC_fullCollect()


### PR DESCRIPTION
These let you convert integers or tensors of intengers into tensors of bools representing them. This is similar to Matlab's `int2bit` (except that Matlab's version fills the bit tensors column-wise, while arraymancer's version fills them row-wise). It is also similar to (but more flexible than) numpy's `unpackbits`.