### PR TITLE
Complex enhancements

### DIFF
--- a/src/arraymancer/tensor/complex.nim
+++ b/src/arraymancer/tensor/complex.nim
@@ -8,18 +8,28 @@ import
   ./accessors,
   ./higher_order_applymap
 
-proc complex*[T: SomeFloat](re: Tensor[T], im: Tensor[T]): auto {.inline, noinit.} =
+proc complex*[T: SomeNumber](re: Tensor[T], im: Tensor[T]): auto {.inline, noinit.} =
   ## Create a new, complex Tensor by combining two real Tensors
   ##
   ## The first input Tensor is copied into the real part of the output Tensor,
   ## while the second input Tensor is copied into the imaginary part.
-  map2_inline(re, im, complex(x, y))
+  ##
+  ## If the inputs are integer Tensors, the output will be a Tensor of
+  ## Complex64 to avoid any loss of precision.
+  when T is SomeInteger:
+    map2_inline(re, im, complex(float64(x), float64(y)))
+  else:
+    map2_inline(re, im, complex(x, y))
 
 proc complex*[T: SomeNumber](re: Tensor[T]): auto {.inline, noinit.} =
   ## Create a new, complex Tensor from a single real Tensor
   ##
   ## The input Tensor is copied into the real part of the output Tensor,
   ## while the imaginary part is set to all zeros.
+  ##
+  ## If the input is an integer Tensor, the output will be a Tensor of
+  ## Complex64 to avoid any loss of precision. If you want to convert it
+  ## into a Tensor of Complex32, you can use `.asType(Complex32)` instead.
   ##
   ## Note that you can also convert a real tensor into a complex tensor by
   ## means of the `asType` procedure. However, this has the advantage that
@@ -28,7 +38,10 @@ proc complex*[T: SomeNumber](re: Tensor[T]): auto {.inline, noinit.} =
   ## Another advantage is that this function will automatically use the right
   ## Complex type for the output tensor, leading to more generic code. Use
   ## `asType` only when you want to control the type of the Complex tensor.
-  map_inline(re, complex(x))
+  when T is SomeInteger:
+    map_inline(re, complex(float64(x)))
+  else:
+    map_inline(re, complex(x))
 
 proc real*[T: SomeFloat](t: Tensor[Complex[T]]): Tensor[T] {.inline, noinit.} =
   ## Get the real part of a complex Tensor (as a float Tensor)

--- a/src/arraymancer/tensor/complex.nim
+++ b/src/arraymancer/tensor/complex.nim
@@ -8,12 +8,27 @@ import
   ./accessors,
   ./higher_order_applymap
 
-proc complex*[T: SomeFloat](re: Tensor[T], im: Tensor[T]): Tensor[Complex[T]] {.inline, noinit.} =
+proc complex*[T: SomeFloat](re: Tensor[T], im: Tensor[T]): auto {.inline, noinit.} =
   ## Create a new, complex Tensor by combining two real Tensors
   ##
   ## The first input Tensor is copied into the real part of the output Tensor,
-  ## while the second input Tensor is copied into the imaginary part
+  ## while the second input Tensor is copied into the imaginary part.
   map2_inline(re, im, complex(x, y))
+
+proc complex*[T: SomeNumber](re: Tensor[T]): auto {.inline, noinit.} =
+  ## Create a new, complex Tensor from a single real Tensor
+  ##
+  ## The input Tensor is copied into the real part of the output Tensor,
+  ## while the imaginary part is set to all zeros.
+  ##
+  ## Note that you can also convert a real tensor into a complex tensor by
+  ## means of the `asType` procedure. However, this has the advantage that
+  ## you can use the same function to combine a real and imaginary tensor
+  ## or a single real tensor into a complex tensor.
+  ## Another advantage is that this function will automatically use the right
+  ## Complex type for the output tensor, leading to more generic code. Use
+  ## `asType` only when you want to control the type of the Complex tensor.
+  map_inline(re, complex(x))
 
 proc real*[T: SomeFloat](t: Tensor[Complex[T]]): Tensor[T] {.inline, noinit.} =
   ## Get the real part of a complex Tensor (as a float Tensor)

--- a/tests/tensor/test_complex.nim
+++ b/tests/tensor/test_complex.nim
@@ -30,15 +30,30 @@ proc main() =
 
         check: c == expected_c
 
+      block: # Create a complex tensor from 2 real integer tensors
+        var re = [1, -10, 20].toTensor
+        var im = [-300, 20, -1].toTensor
+        var c = complex(re, im)
+        var expected_c = [
+          complex(1.0, -300.0),
+          complex(-10.0, 20.0),
+          complex(20.0, -1.0),
+        ].toTensor
+
+        check: c == expected_c
+
       block: # Single tensor to complex conversion
-        var re_float64 = [1.0, -10.0, 20.0].toTensor.asType(float64)
-        var re_float32 = [1.0, -10.0, 20.0].toTensor.asType(float32)
+        var re_int = [1, -10, 20].toTensor
+        var re_float64 = re_int.asType(float64)
+        var re_float32 = re_int.asType(float32)
+        var c64_from_int = complex(re_int)
         var c64 = complex(re_float64)
         var c32 = complex(re_float32)
         var expected_c64 = re_float64.asType(Complex64)
         var expected_c32 = re_float32.asType(Complex32)
 
         check: c64 == expected_c64
+        check: c64_from_int == expected_c64
         check: c32 == expected_c32
 
     test "Get the Real and Imaginary Components of a Complex Tensor":

--- a/tests/tensor/test_complex.nim
+++ b/tests/tensor/test_complex.nim
@@ -18,16 +18,28 @@ import std/[unittest, math]
 proc main() =
   suite "Basic Complex Tensor Operations":
     test "Complex Tensor Creation":
-      var re = [1.0, -10, 20].toTensor
-      var im = [-300.0, 20, -1].toTensor
-      var c = complex(re, im)
-      var expected_c = [
-        complex(1.0, -300.0),
-        complex(-10.0, 20.0),
-        complex(20.0, -1.0),
-      ].toTensor
+      block:
+        var re = [1.0, -10, 20].toTensor
+        var im = [-300.0, 20, -1].toTensor
+        var c = complex(re, im)
+        var expected_c = [
+          complex(1.0, -300.0),
+          complex(-10.0, 20.0),
+          complex(20.0, -1.0),
+        ].toTensor
 
-      check: c == expected_c
+        check: c == expected_c
+
+      block: # Single tensor to complex conversion
+        var re_float64 = [1.0, -10.0, 20.0].toTensor.asType(float64)
+        var re_float32 = [1.0, -10.0, 20.0].toTensor.asType(float32)
+        var c64 = complex(re_float64)
+        var c32 = complex(re_float32)
+        var expected_c64 = re_float64.asType(Complex64)
+        var expected_c32 = re_float32.asType(Complex32)
+
+        check: c64 == expected_c64
+        check: c32 == expected_c32
 
     test "Get the Real and Imaginary Components of a Complex Tensor":
       var c = [


### PR DESCRIPTION
A couple of improvements to the complex() function:

- It is now possible to call it without the second (imaginary) tensor. This let's you use similar code whether you are creating a complex tensor by combining 2 tensors or by taking just a single, real tensor. It also has the advantage over `asType` that it automatically chooses the right Complex type based on the input, leading to more generic code.
- It is now possible to use complex() to directly convert integer tensors into complex tensors. This avoids unnecessary copies and also leads to more uniform code when dealing with complex tensors.