### PR TITLE
More complex tensor features

### DIFF
--- a/src/arraymancer/tensor/complex.nim
+++ b/src/arraymancer/tensor/complex.nim
@@ -88,10 +88,10 @@ proc `imag=`*[T: SomeFloat](t: var Tensor[Complex[T]], val: Tensor[T]) {.inline.
   for it, srcit in mzip(t, val):
     it.im = srcit
 
-proc conjugate*[T: Complex32 | Complex64](A: Tensor[T]): Tensor[T] =
+proc conjugate*[T: Complex32 | Complex64](t: Tensor[T]): Tensor[T] =
   ## Return the element-wise complex conjugate of a tensor of complex numbers.
   ## The complex conjugate of a complex number is obtained by changing the sign of its imaginary part.
-  A.map_inline(x.conjugate)
+  t.map_inline(x.conjugate)
 
 proc cswap*[T: Complex32 | Complex64](t: Tensor[T]): Tensor[T] {.inline, noinit.} =
   ## Swap the real and imaginary components of the elements of a complex Tensor

--- a/src/arraymancer/tensor/complex.nim
+++ b/src/arraymancer/tensor/complex.nim
@@ -43,6 +43,21 @@ proc complex*[T: SomeNumber](re: Tensor[T]): auto {.inline, noinit.} =
   else:
     map_inline(re, complex(x))
 
+proc complex_imag*[T: SomeNumber](im: Tensor[T]): auto {.inline, noinit.} =
+  ## Create a new, imaginary Tensor from a single real Tensor
+  ##
+  ## The input Tensor is copied into the imaginary part of the output Tensor,
+  ## while the real part is set to all zeros.
+  ##
+  ## If the input is an integer Tensor, the output will be a Tensor of
+  ## Complex64 to avoid any loss of precision. If you want to convert it
+  ## into a Tensor of Complex32, you must convert the input to float32 first
+  ## by using `.asType(float32)`.
+  when T is SomeInteger:
+    map_inline(im, complex(float64(0.0), float64(x)))
+  else:
+    map_inline(im, complex(T(0.0), x))
+
 proc real*[T: SomeFloat](t: Tensor[Complex[T]]): Tensor[T] {.inline, noinit.} =
   ## Get the real part of a complex Tensor (as a float Tensor)
   t.map_inline(x.re)

--- a/src/arraymancer/tensor/complex.nim
+++ b/src/arraymancer/tensor/complex.nim
@@ -92,3 +92,7 @@ proc conjugate*[T: Complex32 | Complex64](A: Tensor[T]): Tensor[T] =
   ## Return the element-wise complex conjugate of a tensor of complex numbers.
   ## The complex conjugate of a complex number is obtained by changing the sign of its imaginary part.
   A.map_inline(x.conjugate)
+
+proc cswap*[T: Complex32 | Complex64](t: Tensor[T]): Tensor[T] {.inline, noinit.} =
+  ## Swap the real and imaginary components of the elements of a complex Tensor
+  map_inline(t, complex(x.im, x.re))

--- a/tests/tensor/test_complex.nim
+++ b/tests/tensor/test_complex.nim
@@ -121,5 +121,20 @@ proc main() =
 
       check: c.conjugate == expected_c_conjugate
 
+    test "Complex Component Swap":
+      var c = [
+        complex(1.0, -300.0),
+        complex(-10.0, 20.0),
+        complex(20.0, -1.0),
+      ].toTensor
+
+      var expected_c_swapped = [
+        complex(-300.0, 1.0),
+        complex(20.0, -10.0),
+        complex(-1.0, 20.0),
+      ].toTensor
+
+      check: c.cswap == expected_c_swapped
+
 main()
 GC_fullCollect()

--- a/tests/tensor/test_complex.nim
+++ b/tests/tensor/test_complex.nim
@@ -56,6 +56,24 @@ proc main() =
         check: c64_from_int == expected_c64
         check: c32 == expected_c32
 
+      block: # Single tensor to imaginary complex conversion
+        var im_int = [1, -10, 20].toTensor
+        var im_float64 = im_int.asType(float64)
+        var im_float32 = im_int.asType(float32)
+        var c64_imag_from_int = complex_imag(im_int)
+        var c64_imag = complex_imag(im_float64)
+        var c32_imag = complex_imag(im_float32)
+        var expected_imag64 = [complex64(0.0, 1.0),
+                               complex64(0.0, -10.0),
+                               complex64(0.0, 20.0)].toTensor
+        var expected_imag32 = [complex32(0.0, 1.0),
+                               complex32(0.0, -10.0),
+                               complex32(0.0, 20.0)].toTensor
+
+        check: c64_imag == expected_imag64
+        check: c64_imag_from_int == expected_imag64
+        check: c32_imag == expected_imag32
+
     test "Get the Real and Imaginary Components of a Complex Tensor":
       var c = [
         complex(1.0, -300.0),


### PR DESCRIPTION
This PR adds a couple of procedures to the complex module:
- complex_imag: Creates a complex, imaginary tensor from a real tensor.
- cswap: Swaps the real and imaginary components of a complex tensor.