### PR TITLE
Fix issue 639

### DIFF
--- a/src/arraymancer/laser/dynamic_stack_arrays.nim
+++ b/src/arraymancer/laser/dynamic_stack_arrays.nim
@@ -91,6 +91,8 @@ func `$`*(a: DynamicStackArray): string =
   result.add("]")
 
 func product*[T:SomeNumber](a: DynamicStackArray[T]): T =
+  if unlikely(a.len == 0):
+    return 0
   result = 1
   for value in items(a):
     result *= value

--- a/src/arraymancer/laser/tensor/initialization.nim
+++ b/src/arraymancer/laser/tensor/initialization.nim
@@ -184,7 +184,14 @@ proc setZero*[T](t: var Tensor[T], check_contiguous: static bool = true) =
         chunk_size * sizeof(T)
       )
 
-proc newTensor*[T](shape: varargs[int]): Tensor[T] =
+proc newTensor*[T](shape: varargs[int] = [0]): Tensor[T] =
+  ## Create a new tensor of type T with the given shape.
+  ##
+  ## If no shape is provided, we create an empty rank-1 tensor.
+  ## To create a rank-0 tensor, explicitly pass and empty shape `[]`.
+  ##
+  ## Note that in general it is not a good idea to use rank-0 tensors.
+  ## However, they can be used as "sentinel" values for Tensor arguments.
   var size: int
   initTensorMetadata(result, size, shape)
   allocCpuStorage(result.storage, size)
@@ -193,6 +200,7 @@ proc newTensor*[T](shape: varargs[int]): Tensor[T] =
     setZero(result, check_contiguous = false)
 
 proc newTensor*[T](shape: Metadata): Tensor[T] =
+  ## Create a new tensor of type T with the given shape.
   var size: int
   initTensorMetadata(result, size, shape)
   allocCpuStorage(result.storage, size)
@@ -289,7 +297,7 @@ func item*[T_IN, T_OUT](t: Tensor[T_IN], _: typedesc[T_OUT]): T_OUT =
       # When the input and the output types are Complex, we need to find
       # the "base" type of the output type (e.g. float32 or float64),
       # and then convert the real and imaginary parts of the input value
-      # into the output base type before creating the output complex type 
+      # into the output base type before creating the output complex type
       type TT = typeof(
         block:
           var tmp: T_OUT

--- a/src/arraymancer/tensor/init_cpu.nim
+++ b/src/arraymancer/tensor/init_cpu.nim
@@ -23,15 +23,17 @@ import
 
 export initialization
 
-proc newTensorUninit*[T](shape: varargs[int]): Tensor[T] {.noinit, inline.} =
-  ## Creates a new Tensor on Cpu backend
+proc newTensorUninit*[T](shape: varargs[int] = [0]): Tensor[T] {.noinit, inline.} =
+  ## Creates a new uninitialized Tensor of type `T` on the Cpu backend
   ## Input:
-  ##      - Shape of the Tensor
-  ##      - Type of its elements
+  ##      - Shape of the Tensor (defaults to an empty rank-1 tensor)
   ## Result:
   ##      - A Tensor of the proper shape with NO initialization
-  ## Warning ⚠
-  ##   Tensor data is uninitialized and contains garbage.
+  ## Warnings ⚠:
+  ##      - Tensor data is uninitialized and contains garbage.
+  ##      - If no shape is provided, a 1D tensor of size 0 is created.
+  ##        It is possible to create a rank-0 tensor by explicitly
+  ##        providing an empty shape `[]` (e.g. `newTensorUninit[float]([])`).
   var size: int
   initTensorMetadata(result, size, shape)
   allocCpuStorage(result.storage, size)
@@ -42,14 +44,13 @@ proc newTensorUninit*[T](size: int): Tensor[T] {.noinit, inline.} =
   result = newTensorUninit[T]([size])
 
 proc newTensorUninit*[T](shape: Metadata): Tensor[T] {.noinit, inline.} =
-  ## Creates a new Tensor on Cpu backend
+  ## Creates a new uninitialized Tensor of type `T` on the Cpu backend
   ## Input:
   ##      - Shape of the Tensor
-  ##      - Type of its elements
   ## Result:
   ##      - A Tensor of the proper shape with NO initialization
-  ## Warning ⚠
-  ##   Tensor data is uninitialized and contains garbage.
+  ## Warning ⚠:
+  ##      - Tensor data is uninitialized and contains garbage.
   var size: int
   initTensorMetadata(result, size, shape)
   allocCpuStorage(result.storage, size)


### PR DESCRIPTION
To fix this issue I made 2 sets of changes:

1. Add a check for rank == 0 to the DynamicStackArray's `product` function (which fixes the actual issue).
2. Make it (a bit) harder to accidentally create a rank-0 tensor (by making newTensor and newTensorUninit create an empty rank-1 tensor by default).

It is still possible (and sometimes useful) to create a rank-0 tensor, but users will need to do so explicitly.