### PR TITLE
Fix "imported and not used: 'datatypes' [UnusedImport]" warning

### DIFF
--- a/src/arraymancer/laser/primitives/matrix_multiplication/gemm.nim
+++ b/src/arraymancer/laser/primitives/matrix_multiplication/gemm.nim
@@ -11,7 +11,8 @@ import
 
 # This import is needed for our current docgen. Otherwise it fails
 # on this submodule.
-from ../../tensor/datatypes import KnownSupportsCopyMem
+when defined(nimdoc):
+  from ../../tensor/datatypes import KnownSupportsCopyMem
 
 when defined(i386) or defined(amd64):
   import ../../cpuinfo_x86


### PR DESCRIPTION
The warning is fixed by only importing KnownSupportsCopyMem from datatypes when in nimdoc mode.