### PR TITLE
Missing special matrices

### DIFF
--- a/src/arraymancer/linear_algebra/special_matrices.nim
+++ b/src/arraymancer/linear_algebra/special_matrices.nim
@@ -304,6 +304,7 @@ proc circulant*[T](t: Tensor[T], axis = -1, step = 1): Tensor[T] {.noInit.} =
   ##         each time. Defaults to 1.
   ## Result:
   ## - The constructed circulant matrix
+  ##
   ## Example:
   ## ```nim
   ## echo circulant([1, 3, 6])
@@ -319,6 +320,54 @@ proc circulant*[T](t: Tensor[T], axis = -1, step = 1): Tensor[T] {.noInit.} =
   else:
     for n in 0 ..< t.len:
       result[_, n] = t.roll(step * n)
+
+proc hankel*[T](c, r: Tensor[T]): Tensor[T] {.noInit.} =
+  ## Construct a Hankel matrix.
+  ##
+  ## A Hankel matrix has constant anti-diagonals, with c as its first column
+  ## and r as its last row (note that `r[0]` is ignored but _should_ be the same
+  ## as `c[^1])`
+  ##
+  ## Inputs:
+  ## - c: The first column of the Hankel matrix
+  ## - r: The last row of the Hankel matrix (note that `r[0]` is ignored)
+  ## Result:
+  ## - The constructed Hankel matrix
+  ##
+  ## Example:
+  ## ```nim
+  ## echo hankel([1, 3, 6], [9, 10, 11, 12])
+  ## # Tensor[system.int] of shape "[3, 4]" on backend "Cpu"
+  ## # |1      3     6    10|
+  ## # |3      6    10    11|
+  ## # |6     10    11    12|
+  ## ```
+  result = newTensor[T](c.len, r.len)
+  let t = c.flatten.append(r[1.._])
+  for n in 0 ..< r.len:
+    result[_, n] = t[n..<(n+c.len)]
+
+proc hankel*[T](c: Tensor[T]): Tensor[T] {.noInit, inline.} =
+  ## Construct a "triangular" Hankel matrix (i.e. with zeros on its last row)
+  ##
+  ## The "triangular" Hankel matrix is a Hankel matrix in which all the items
+  ## below the main anti-diagonal are set to 0. This is equivalent to creating
+  ## a regular Hankel metrix in which the `c` argument is set to all zeros.
+  ##
+  ## Inputs:
+  ## - c: The first column of the Hankel matrix
+  ## Result:
+  ## - The constructed "triangular" Hankel matrix
+  ##
+  ## Example:
+  ## ```nim
+  ## echo hankel([1, 3, 6], [9, 10, 11, 12])
+  ## # Tensor[system.int] of shape "[3, 3]" on backend "Cpu"
+  ## # |1      3     6|
+  ## # |3      6     0|
+  ## # |6      0     0|
+  ## ```
+  hankel(c, zeros_like(c))
 
 type MeshGridIndexing* = enum xygrid, ijgrid
 

--- a/src/arraymancer/linear_algebra/special_matrices.nim
+++ b/src/arraymancer/linear_algebra/special_matrices.nim
@@ -211,10 +211,10 @@ proc with_diagonal*[T](a: Tensor[T], d: Tensor[T], k = 0, anti = false): Tensor[
   set_diagonal(result, d, k, anti=anti)
 
 proc diag*[T](d: Tensor[T], k = 0, anti = false): Tensor[T] {.noInit.} =
-  ## Creates new square diagonal matrix from an rank-1 input tensor
+  ## Creates a new square diagonal matrix from an rank-1 input tensor
   ##
   ## Input:
-  ##      - Rank-1 tensor containg the elements of the diagonal
+  ##      - Rank-1 tensor containing the elements of the diagonal
   ##      - k: The index of the diagonal that will be set. The default is 0.
   ##        Use k>0 for diagonals above the main diagonal, and k<0 for diagonals below the main diagonal.
   ##      - anti: If true, set the k-th "anti-diagonal" instead of the k-th regular diagonal.
@@ -285,6 +285,40 @@ proc tri*[T](shape_ax1, shape_ax0: int, k: static int = 0, upper: static bool = 
 # Also export the tril and triu functions which are also part of numpy's API
 # and which are implemented in helpers/triangular.nim
 export tril, triu
+
+proc circulant*[T](t: Tensor[T], axis = -1, step = 1): Tensor[T] {.noInit.} =
+  ## Construct a circulant matrix from a rank-1 tensor
+  ##
+  ## A circulant matrix is a square matrix in which each column (or row) is
+  ## a cyclic shift of the previous column (or row).
+  ##
+  ## By default this function cirulates over the columns of the output which
+  ## are rotated down by 1 element over the previous column, but this behavior
+  ## can be changed by using the `axis` and `step` arguments.
+  ##
+  ## Inputs:
+  ## - A rank-1 Tensor
+  ## - axis: The axis along which the circulant matrix will be constructed.
+  ##         Defaults to -1 (i.e. the columns, which are the last axis).
+  ## - step: The number of elements by which the input tensor will be shifted
+  ##         each time. Defaults to 1.
+  ## Result:
+  ## - The constructed circulant matrix
+  ## Example:
+  ## ```nim
+  ## echo circulant([1, 3, 6])
+  ## Tensor[system.int] of shape "[3, 3]" on backend "Cpu"
+  ## # |1      6     3|
+  ## # |3      1     6|
+  ## # |6      3     1|
+  ## ```
+  result = newTensor[T](t.len, t.len)
+  if axis == 0:
+    for n in 0 ..< t.len:
+      result[n, _] = t.roll(step * n)
+  else:
+    for n in 0 ..< t.len:
+      result[_, n] = t.roll(step * n)
 
 type MeshGridIndexing* = enum xygrid, ijgrid
 

--- a/tests/linear_algebra/test_special_matrices.nim
+++ b/tests/linear_algebra/test_special_matrices.nim
@@ -142,6 +142,19 @@ proc main() =
       check: circulant([1.0, 3.0, 6.0, 9.0].toTensor, step = -1) == expected_c3
       check: circulant([1.0, 3.0, 6.0, 9.0].toTensor, step = 2) == expected_c4
 
+    test "Toeplitz Matrices":
+      let expected_t1 = [[1, 10, 11, 12],
+                         [3,  1, 10, 11],
+                         [6,  3,  1, 10]].toTensor
+      let expected_t2 = [[1, 3, 6],
+                         [3, 1, 3],
+                         [6, 3, 1]].toTensor
+      let expected_t3 = [[1.0+2.0.im, 3.0-4.0.im],
+                         [3.0+4.0.im, 1.0+2.0.im]].toTensor
+      check: toeplitz([1, 3, 6].toTensor, [9, 10, 11, 12].toTensor) == expected_t1
+      check: toeplitz([1, 3, 6].toTensor) == expected_t2
+      check: toeplitz([1.0+2.0.im, 3.0+4.0.im].toTensor) == expected_t3
+
     test "Hankel Matrices":
       let expected_h1 = [[1,  3,  6, 10],
                          [3,  6, 10, 11],

--- a/tests/linear_algebra/test_special_matrices.nim
+++ b/tests/linear_algebra/test_special_matrices.nim
@@ -120,6 +120,28 @@ proc main() =
           t2b == expected_t2
           t3b == expected_t3
 
+    test "Circulant Matrices":
+      let expected_c1 = [[1.0, 9.0, 6.0, 3.0],
+                       [3.0, 1.0, 9.0, 6.0],
+                       [6.0, 3.0, 1.0, 9.0],
+                       [9.0, 6.0, 3.0, 1.0]].toTensor
+      let expected_c2 = [[1.0, 3.0, 6.0, 9.0],
+                       [9.0, 1.0, 3.0, 6.0],
+                       [6.0, 9.0, 1.0, 3.0],
+                       [3.0, 6.0, 9.0, 1.0]].toTensor
+      let expected_c3 = [[1.0, 3.0, 6.0, 9.0],
+                       [3.0, 6.0, 9.0, 1.0],
+                       [6.0, 9.0, 1.0, 3.0],
+                       [9.0, 1.0, 3.0, 6.0]].toTensor
+      let expected_c4 = [[1.0, 6.0, 1.0, 6.0],
+                       [3.0, 9.0, 3.0, 9.0],
+                       [6.0, 1.0, 6.0, 1.0],
+                       [9.0, 3.0, 9.0, 3.0]].toTensor
+      check: circulant([1.0, 3.0, 6.0, 9.0].toTensor) == expected_c1
+      check: circulant([1.0, 3.0, 6.0, 9.0].toTensor, axis = 0) == expected_c2
+      check: circulant([1.0, 3.0, 6.0, 9.0].toTensor, step = -1) == expected_c3
+      check: circulant([1.0, 3.0, 6.0, 9.0].toTensor, step = 2) == expected_c4
+
   suite "meshgrid":
     test "meshgrid-2D":
       block:

--- a/tests/linear_algebra/test_special_matrices.nim
+++ b/tests/linear_algebra/test_special_matrices.nim
@@ -142,6 +142,16 @@ proc main() =
       check: circulant([1.0, 3.0, 6.0, 9.0].toTensor, step = -1) == expected_c3
       check: circulant([1.0, 3.0, 6.0, 9.0].toTensor, step = 2) == expected_c4
 
+    test "Hankel Matrices":
+      let expected_h1 = [[1,  3,  6, 10],
+                         [3,  6, 10, 11],
+                         [6, 10, 11, 12]].toTensor
+      let expected_h2 = [[1, 3, 6],
+                         [3, 6, 0],
+                         [6, 0, 0]].toTensor
+      check: hankel([1, 3, 6].toTensor, [9, 10, 11, 12].toTensor) == expected_h1
+      check: hankel([1, 3, 6].toTensor) == expected_h2
+
   suite "meshgrid":
     test "meshgrid-2D":
       block:


### PR DESCRIPTION
Add 3 types of special matrices that were missing from numpy / scipy. All of them are "diagonal related":

- Circulant: A square matrix in which each column (or row) is a cyclic shift of the previous column (or row)
- Toeplitz: A matrix that has constant diagonals, with c as its first column and r as its first row (note that r[0] is ignored but should be the same as c[^1]).
- Hankel: A matrix that has constant anti-diagonals, with c as its first column and r as its last row (note that r[0] is ignored but should be the same as c[^1]).
