### PR TITLE
Add `tile` and `repeat_values` procedures

### DIFF
--- a/src/arraymancer/tensor/shapeshifting.nim
+++ b/src/arraymancer/tensor/shapeshifting.nim
@@ -573,7 +573,7 @@ proc roll*[T](t: Tensor[T], shift: int, axis: Natural): Tensor[T] {.noinit.} =
     result = concat(rolled_slices, axis)
 
 proc repeat_values*[T](t: Tensor[T], reps: int, axis = -1): Tensor[T] {.noinit.} =
-  ## Create a new tensor with each value repeated (the same amount of)`reps` times
+  ## Create a new tensor with each value repeated (the same amount of) `reps` times
   ##
   ## Inputs:
   ##   - t: A tensor.

--- a/tests/tensor/test_shapeshifting.nim
+++ b/tests/tensor/test_shapeshifting.nim
@@ -344,5 +344,58 @@ proc main() =
         check: a.repeat_values([1, 0, 3, 2]) == expected
         check: a.repeat_values([1, 0, 3, 2].toTensor) == expected
 
+    test "Tile":
+      let t = arange(6).reshape(2, 3)
+
+      block: # Tile over the first axis
+        let expected = [
+          [0, 1, 2],
+          [3, 4, 5],
+          [0, 1, 2],
+          [3, 4, 5],
+        ].toTensor
+        check: t.tile(2) == expected
+
+      block: # Tile over the all the axis of the input tensor
+        let expected = [
+          [0, 1, 2, 0, 1, 2, 0, 1, 2],
+          [3, 4, 5, 3, 4, 5, 3, 4, 5],
+          [0, 1, 2, 0, 1, 2, 0, 1, 2],
+          [3, 4, 5, 3, 4, 5, 3, 4, 5]
+        ].toTensor
+        check: t.tile(2, 3) == expected
+
+      block: # Tile over the more axis than the input tensor has
+        let expected = [
+          [
+            [0, 1, 2, 0, 1, 2, 0, 1, 2],
+            [3, 4, 5, 3, 4, 5, 3, 4, 5],
+            [0, 1, 2, 0, 1, 2, 0, 1, 2],
+            [3, 4, 5, 3, 4, 5, 3, 4, 5]
+          ],
+          [
+            [0, 1, 2, 0, 1, 2, 0, 1, 2],
+            [3, 4, 5, 3, 4, 5, 3, 4, 5],
+            [0, 1, 2, 0, 1, 2, 0, 1, 2],
+            [3, 4, 5, 3, 4, 5, 3, 4, 5]
+          ],
+          [
+            [0, 1, 2, 0, 1, 2, 0, 1, 2],
+            [3, 4, 5, 3, 4, 5, 3, 4, 5],
+            [0, 1, 2, 0, 1, 2, 0, 1, 2],
+            [3, 4, 5, 3, 4, 5, 3, 4, 5]
+          ],
+          [
+            [0, 1, 2, 0, 1, 2, 0, 1, 2],
+            [3, 4, 5, 3, 4, 5, 3, 4, 5],
+            [0, 1, 2, 0, 1, 2, 0, 1, 2],
+            [3, 4, 5, 3, 4, 5, 3, 4, 5]
+          ]
+        ].toTensor
+        check: t.tile(4, 2, 3) == expected
+
+      block: # tiling and repeating values are sometimes equivalent
+        check: t.tile(2, 1, 1) == t.unsqueeze(axis=0).repeat_values(2, axis = 0)
+
 main()
 GC_fullCollect()

--- a/tests/tensor/test_shapeshifting.nim
+++ b/tests/tensor/test_shapeshifting.nim
@@ -305,5 +305,44 @@ proc main() =
           a_permuted_2 == a.permute(1, 2, 0)
           a_permuted_2 == a.moveaxis(1, 0).moveaxis(2, 1)
 
+    test "Repeat Values":
+      let t = arange(6).reshape(2, 3)
+
+      block: # Repeat columns
+        let expected = [
+          [0, 0, 1, 1, 2, 2],
+          [3, 3, 4, 4, 5, 5]
+        ].toTensor
+        check: t.repeat_values(2) == expected
+        check: t.repeat_values(2, axis = 1) == expected
+
+      block: # Repeat rows
+        let expected = [
+          [0, 1, 2],
+          [0, 1, 2],
+          [3, 4, 5],
+          [3, 4, 5]
+        ].toTensor
+        check: t.repeat_values(2, axis = 0) == expected
+
+      block: # Repeat a higher dimension
+        let expected = [
+          [
+            [0, 1, 2],
+            [3, 4, 5],
+          ],
+          [
+            [0, 1, 2],
+            [3, 4, 5]
+          ]
+        ].toTensor
+        check: t.unsqueeze(axis = 0).repeat_values(2, axis = 0) == expected
+
+      block: # Repeat different times each value (including zero times)
+        let a = [3, 5, 2, 4].toTensor
+        let expected = [3, 2, 2, 2, 4, 4].toTensor
+        check: a.repeat_values([1, 0, 3, 2]) == expected
+        check: a.repeat_values([1, 0, 3, 2].toTensor) == expected
+
 main()
 GC_fullCollect()


### PR DESCRIPTION
Add the following new procedures:

- `repeat_values`: Procedures that let you repeat the values of a Tensor multiple times. This functionality exists both in numpy (`repeat`) and in Matlab (`repelem`).
- `tile`: Procedure that lets you construct a new tensor by repeating the input tensor a number of times on one or more axes. This functionality exists both in numpy (`tile`) and in Matlab (`repmat`).

I didn't follow numpy's naming convention for `repeat_values` to avoid a confusing with nim's `sequtils.repeat`, which does not repeat individual values but the whole sequence (like `tile` does).

I measured the performance of these functions and it is comparable to numpy's. `repeat_values` is faster than numpy in --d:danger mode and a bit slower in --d:release mode. `tile` is slower in both cases (but the difference is not too large). `tile`'s implementation could be improved (to avoid intermediate tensor allocations) in the future.