### PR TITLE
Type check accessors `[]`, `[]=` and add `index_select` for multiple values

### DIFF
--- a/src/arraymancer/private/ast_utils.nim
+++ b/src/arraymancer/private/ast_utils.nim
@@ -67,8 +67,7 @@ proc replaceSymsByIdents*(ast: NimNode): NimNode =
     of nnkLiterals:
       return node
     of nnkHiddenStdConv: # see `test_fancy_indexing.nim` why needed
-      expectKind(node[1], nnkSym)
-      return ident($node[1])
+      return inspect(node[1])
     else:
       letsGoDeeper()
   result = inspect(ast)

--- a/src/arraymancer/tensor/private/p_accessors_macros_read.nim
+++ b/src/arraymancer/tensor/private/p_accessors_macros_read.nim
@@ -229,6 +229,9 @@ macro slice_typed_dispatch*(t: typed, args: varargs[typed]): untyped =
   ## Note, normal slices and `_` were already converted in the `[]` macro
   ## TODO in total we do 3 passes over the list of arguments :/. It is done only at compile time though
 
+  # Type check the argument for a saner error message
+  checkValidSliceType(args)
+
   # Point indexing
   # -----------------------------------------------------------------
   if isAllInt(args):

--- a/src/arraymancer/tensor/private/p_accessors_macros_write.nim
+++ b/src/arraymancer/tensor/private/p_accessors_macros_write.nim
@@ -192,6 +192,9 @@ proc slicerMut*[T](t: var Tensor[T],
 macro slice_typed_dispatch_mut*(t: typed, args: varargs[typed], val: typed): untyped =
   ## Assign `val` to Tensor T at slice/position `args`
 
+  # Type check the argument for a saner error message
+  checkValidSliceType(args)
+
   # Point indexing
   # -----------------------------------------------------------------
   if isAllInt(args):
@@ -324,6 +327,10 @@ macro slice_typed_dispatch_var*(t: typed, args: varargs[typed]): untyped =
   ## Else, all ints are converted to SteppedSlices and we return a Tensor.
   ## Note, normal slices and `_` were already converted in the `[]` macro
   ## TODO in total we do 3 passes over the list of arguments :/. It is done only at compile time though
+
+  # Type check the argument for a saner error message
+  checkValidSliceType(args)
+
   if isAllInt(args):
     result = newCall(bindSym("atIndex"), t)
     for slice in args:

--- a/src/arraymancer/tensor/selectors.nim
+++ b/src/arraymancer/tensor/selectors.nim
@@ -95,7 +95,7 @@ proc index_fill*[T; Idx: byte or char or SomeInteger](t: var Tensor[T], axis: in
   index_fill_vector_body()
 
 template index_fill_scalar_body(): untyped {.dirty.} =
-  if t.size == 0 or indices.size == 0:
+  if t.len == 0 or indices.len == 0:
     return
   when typeof(indices) isnot Tensor:
     template enumerate(arg): untyped {.gensym.} = pairs(arg)

--- a/src/arraymancer/tensor/selectors.nim
+++ b/src/arraymancer/tensor/selectors.nim
@@ -63,22 +63,25 @@ proc index_select*[T; Idx: byte or char or SomeInteger](t: Tensor[T], axis: int,
 proc index_fill*[T; Idx: byte or char or SomeInteger](t: var Tensor[T], axis: int, indices: Tensor[Idx], value: T) =
   ## Replace elements of `t` indicated by their `indices` along `axis` with `value`
   ## This is equivalent to Numpy `put`.
+template index_fill_scalar_body(): untyped {.dirty.} =
   if t.size == 0 or indices.size == 0:
     return
+  when typeof(indices) isnot Tensor:
+    template enumerate(arg): untyped {.gensym.} = pairs(arg)
   for i, index in enumerate(indices):
     var t_slice = t.atAxisIndex(axis, int(index))
     for old_val in t_slice.mitems():
       old_val = value
 
+proc index_fill*[T; Idx: byte or char or SomeInteger](t: var Tensor[T], axis: int, indices: Tensor[Idx], value: T) =
+  ## Replace elements of `t` indicated by their `indices` along `axis` with `value`
+  ## This is equivalent to Numpy `put`.
+  index_fill_scalar_body()
+
 proc index_fill*[T; Idx: byte or char or SomeInteger](t: var Tensor[T], axis: int, indices: openArray[Idx], value: T) =
   ## Replace elements of `t` indicated by their `indices` along `axis` with `value`
   ## This is equivalent to Numpy `put`.
-  if t.size == 0 or indices.len == 0:
-    return
-  for i, index in indices:
-    var t_slice = t.atAxisIndex(axis, int(index))
-    for old_val in t_slice.mitems():
-      old_val = value
+  index_fill_scalar_body()
 
 # Mask full tensor
 # --------------------------------------------------------------------------------------------

--- a/src/arraymancer/tensor/selectors.nim
+++ b/src/arraymancer/tensor/selectors.nim
@@ -60,9 +60,40 @@ proc index_select*[T; Idx: byte or char or SomeInteger](t: Tensor[T], axis: int,
     var t_slice = t.atAxisIndex(axis, int(index))
     r_slice.copyFrom(t_slice)
 
-proc index_fill*[T; Idx: byte or char or SomeInteger](t: var Tensor[T], axis: int, indices: Tensor[Idx], value: T) =
+template index_fill_vector_body(): untyped {.dirty.} =
+  if t.len == 0 or indices.len == 0:
+    return
+  if indices.len != values.len:
+    raise newException(ValueError, "Cannot assign values to indices, because numbers mismatch: " &
+      "# indices = " & $indices.len & ", # values = " & $values.len)
+  when typeof(indices) isnot Tensor:
+    template enumerate(arg): untyped {.gensym.} = pairs(arg)
+  for i, index in enumerate(indices):
+    var t_slice = t.atAxisIndex(axis, int(index))
+    for old_val in t_slice.mitems():
+      old_val = values[i]
+
+# These are a bit terrible, but trying to overload `openArray[Idx] | Tensor[Idx]` for example doesn't seem to work
+proc index_fill*[T; Idx: byte or char or SomeInteger](t: var Tensor[T], axis: int, indices: openArray[Idx], values: openArray[T]) =
   ## Replace elements of `t` indicated by their `indices` along `axis` with `value`
   ## This is equivalent to Numpy `put`.
+  index_fill_vector_body()
+
+proc index_fill*[T; Idx: byte or char or SomeInteger](t: var Tensor[T], axis: int, indices: Tensor[Idx], values: openArray[T]) =
+  ## Replace elements of `t` indicated by their `indices` along `axis` with `value`
+  ## This is equivalent to Numpy `put`.
+  index_fill_vector_body()
+
+proc index_fill*[T; Idx: byte or char or SomeInteger](t: var Tensor[T], axis: int, indices: openArray[Idx], values: Tensor[T]) =
+  ## Replace elements of `t` indicated by their `indices` along `axis` with `value`
+  ## This is equivalent to Numpy `put`.
+  index_fill_vector_body()
+
+proc index_fill*[T; Idx: byte or char or SomeInteger](t: var Tensor[T], axis: int, indices: Tensor[Idx], values: Tensor[T]) =
+  ## Replace elements of `t` indicated by their `indices` along `axis` with `value`
+  ## This is equivalent to Numpy `put`.
+  index_fill_vector_body()
+
 template index_fill_scalar_body(): untyped {.dirty.} =
   if t.size == 0 or indices.size == 0:
     return


### PR DESCRIPTION
This finally makes the `[]`, `[]=` mostly "type safe". Just handing in any type and falling back to the compile time errors of the (mostly internal) procedures like `index_select` is a thing of the past now. If the argument is not allowed, we simply throw a (better) error message telling the user that the type is not valid.

On Nim devel we can also type check `Tensor[T]` (i.e. the inner type), because nowadays doing

```nim
  let validTensorTypes = [getTypeInst(Tensor[int])[1],
                          getTypeInst(Tensor[bool])[1]]
  for t in validTensorTypes:
    if sameType(typ, t): return true
```

works as expected. Nim issue #14021 https://github.com/nim-lang/Nim/issues/14021 should in principle be fixed on devel (but not 2.0.4). Haven't check the Nim issue fully yet though.

This also adds support to not only index a tensor at multiple indices, but also assign multiple at the same time:

```nim
z2[[0, 2]] = [5.2, 1.2]
z2[[0, 2]] = @[5.2, 1.2]
z2[@[0, 2]] = @[5.2, 1.2]
z2[@[0, 2]] = toTensor [5.2, 1.2]
z2[toTensor [0, 2]] = [5.2, 1.2]
z2[toTensor [0, 2]] = @[5.2, 1.2]
z2[toTensor [0, 2]] = toTensor [5.2, 1.2]
```
are all valid now. Previously we could only read with multiple indices.

Note that multi dimensional slicing of arbitrary indices is still not supported.