### PR TITLE
Improve fix for issue 637

### DIFF
--- a/src/arraymancer/tensor/shapeshifting.nim
+++ b/src/arraymancer/tensor/shapeshifting.nim
@@ -307,17 +307,24 @@ proc append*[T](t: Tensor[T], values: Tensor[T]): Tensor[T] {.noinit.} =
   ##   flatten the inputs if they are not rank-1 tensors. It also does not
   ##   support the `axis` parameter. If you want to append the values along a
   ##   specific axis, you should use `concat` instead.
+  ##
   ## Examples:
-  ## > echo append([1, 2, 3].toTensor, [4, 5, 6, 7].toTensor)
-  ## > # Tensor[system.int] of shape "[9]" on backend "Cpu"
-  ## > #    1     2     3     4     5     6     7
-  ## >
-  ## > echo append([1, 2, 3].toTensor, [[4, 5, 6], [7, 8, 9]].toTensor)
-  ## > # Error: unhandled exception: `values.rank == 1` append only works
-  ## > # on rank-1 tensors but extra values tensor has rank 2 [AssertionDefect]
-  ## >
-  ## > echo append([1, 2, 3].toTensor, [[4, 5, 6], [7, 8, 9]].toTensor.flatten)
-  ## > #    1     2     3     4     5     6     7     8     9
+  ## ```nim
+  ## let t = t
+  ## # Note how we can append a tensor to an unmutable tensor, because
+  ## # `append` does not modify the input tensor, it creates a _new_ tensor
+  ## echo t.append([4, 5, 6, 7].toTensor)
+  ## # Tensor[system.int] of shape "[9]" on backend "Cpu"
+  ## #    1     2     3     4     5     6     7
+  ##
+  ## echo t.append([[4, 5, 6], [7, 8, 9]].toTensor)
+  ## # Error: unhandled exception: `values.rank == 1` append only works
+  ## # on rank-1 tensors but extra values tensor has rank 2 [AssertionDefect]
+  ##
+  ## # Flatten higher ranked tensors before appending them
+  ## echo t.append([[4, 5, 6], [7, 8, 9]].toTensor.flatten)
+  ## #    1     2     3     4     5     6     7     8     9
+  ## ```
   doAssert t.rank <= 1,
     "`append` only works on rank-1 tensors but first input tensor has rank " &
     $t.rank & " (use `concat` for higher rank tensors)"
@@ -347,26 +354,33 @@ proc append*[T](t: Tensor[T], values: varargs[T]): Tensor[T] {.noinit.} =
   ##   flatten the input tensor if its rank is greater than 1. It also does not
   ##   support the `axis` parameter. If you want to append values along a
   ##   specific axis, you should use `concat` instead.
+  ##
   ## Examples:
-  ## - Append a single value
-  ## > echo append([1, 2, 3].toTensor, 4)
-  ## > # Tensor[system.int] of shape "[9]" on backend "Cpu"
-  ## > #    1     2     3     4
-  ## - Append a multiple values
-  ## > echo append([1, 2, 3].toTensor, [4, 5, 6, 7])
-  ## > # Tensor[system.int] of shape "[9]" on backend "Cpu"
-  ## > #    1     2     3     4     5     6     7
-  ## - Append an openArray of values
-  ## > echo append([1, 2, 3].toTensor, [4, 5, 6, 7])
-  ## > # Tensor[system.int] of shape "[9]" on backend "Cpu"
-  ## > #    1     2     3     4     5     6     7
-  ## - Only rank-1 tensors are supported
-  ## > echo append([[1, 2, 3], [4, 5, 6]].toTensor, [7, 8, 9])
-  ## > # Error: unhandled exception: `t.rank == 1` append only works
-  ## > # on rank-1 tensors but first input tensor has rank 2 [AssertionDefect]
-  ## - Flatten higher ranked tensors before appending
-  ## > echo append([[1, 2, 3], [4, 5, 6]].toTensor.flatten, [7, 8, 9])
-  ## > #    1     2     3     4     5     6     7     8     9
+  ## ```nim
+  ## # Append a single value
+  ## echo append([1, 2, 3].toTensor, 4)
+  ## # Tensor[system.int] of shape "[9]" on backend "Cpu"
+  ## #    1     2     3     4
+  ##
+  ## # Append multiple values
+  ## echo append([1, 2, 3].toTensor, [4, 5, 6, 7])
+  ## # Tensor[system.int] of shape "[9]" on backend "Cpu"
+  ## #    1     2     3     4     5     6     7
+  ##
+  ## # Append an openArray of values
+  ## echo append([1, 2, 3].toTensor, [4, 5, 6, 7])
+  ## # Tensor[system.int] of shape "[9]" on backend "Cpu"
+  ## #    1     2     3     4     5     6     7
+  ##
+  ## # Only rank-1 tensors are supported
+  ## echo append([[1, 2, 3], [4, 5, 6]].toTensor, [7, 8, 9])
+  ## # Error: unhandled exception: `t.rank == 1` append only works
+  ## # on rank-1 tensors but first input tensor has rank 2 [AssertionDefect]
+  ##
+  ## # Flatten higher ranked tensors before appending them
+  ## echo append([[1, 2, 3], [4, 5, 6]].toTensor.flatten, [7, 8, 9])
+  ## #    1     2     3     4     5     6     7     8     9
+  ## ```
   doAssert t.rank <= 1,
     "`append` only works on rank-1 tensors but input tensor has rank " &
     $t.rank & " (use `concat` for higher rank tensors)"

--- a/src/arraymancer/tensor/shapeshifting.nim
+++ b/src/arraymancer/tensor/shapeshifting.nim
@@ -318,12 +318,16 @@ proc append*[T](t: Tensor[T], values: Tensor[T]): Tensor[T] {.noinit.} =
   ## >
   ## > echo append([1, 2, 3].toTensor, [[4, 5, 6], [7, 8, 9]].toTensor.flatten)
   ## > #    1     2     3     4     5     6     7     8     9
-  doAssert t.rank == 1,
+  doAssert t.rank <= 1,
     "`append` only works on rank-1 tensors but first input tensor has rank " &
     $t.rank & " (use `concat` for higher rank tensors)"
-  doAssert values.rank == 1,
+  doAssert values.rank <= 1,
     "`append` only works on rank-1 tensors but extra values tensor has rank " &
     $values.rank & " (use `concat` for higher rank tensors)"
+  if values.size == 0:
+    return t.clone()
+  if t.size == 0:
+    return values.clone()
   let result_size = t.size + values.size
   result = newTensorUninit[T](result_size)
   result[0 ..< t.size] = t
@@ -363,13 +367,16 @@ proc append*[T](t: Tensor[T], values: varargs[T]): Tensor[T] {.noinit.} =
   ## - Flatten higher ranked tensors before appending
   ## > echo append([[1, 2, 3], [4, 5, 6]].toTensor.flatten, [7, 8, 9])
   ## > #    1     2     3     4     5     6     7     8     9
-  doAssert t.rank == 1,
+  doAssert t.rank <= 1,
     "`append` only works on rank-1 tensors but input tensor has rank " &
     $t.rank & " (use `concat` for higher rank tensors)"
+  if values.len == 0:
+    return t.clone()
+  if t.size == 0:
+    return values.toTensor()
   let result_size = t.size + values.len
   result = newTensorUninit[T](result_size)
-  if t.size > 0:
-    result[0 ..< t.size] = t
+  result[0 ..< t.size] = t
   result[t.size ..< result.size] = values
 
 func squeeze*(t: AnyTensor): AnyTensor {.noinit.}=

--- a/tests/tensor/test_shapeshifting.nim
+++ b/tests/tensor/test_shapeshifting.nim
@@ -117,8 +117,15 @@ proc main() =
       check: a.append(b.toTensor()) == expected
 
       # Test fix for issue #637 (https://github.com/mratsim/Arraymancer/issues/637)
-      let c = newTensor[int](0)
-      check: c.append(1) == [1].toTensor
+      # 1. Properly handle empty rank-1 tensors
+      let empty_tensor = newTensor[int](0)
+      check: empty_tensor.append(1) == [1].toTensor
+      check: empty_tensor.append(a) == a
+      check: a.append(empty_tensor) == a
+      # 2. Properly handle rank-0 (empty) tensors
+      let rank0_tensor = newTensor[int]([])
+      check: a.append(rank0_tensor) == a
+      check: rank0_tensor.append(a) == a
 
     test "Squeeze":
       block:


### PR DESCRIPTION
The previous fix was incomplete. We could still assert if the input was an empty _tensor_.

This change also improves the handling of empty, rank-0 tensors. Up until now we would assert with the wrong message (talking about higher than rank-1 tensors not being supported). Now we don't assert and the code does the right thing.
