### PR TITLE
Specifiy type of set in `toTensor` for `HashSet | OrderedSet`

### DIFF
--- a/src/arraymancer/laser/tensor/initialization.nim
+++ b/src/arraymancer/laser/tensor/initialization.nim
@@ -276,7 +276,7 @@ proc toTensor*[T; U](a: openArray[T], typ: typedesc[U]): Tensor[U] {.inline.} =
   else:
     toTensor(a).asType(typ)
 
-proc toTensor*[T](a: SomeSet[T]): auto =
+proc toTensor*[T](a: HashSet[T] | OrderedSet[T]): Tensor[T] =
   ## Convert a HashSet or an OrderedSet into a Tensor
   ##
   ## Input:
@@ -288,7 +288,7 @@ proc toTensor*[T](a: SomeSet[T]): auto =
   let data = toSeq(a)
   result = toTensor(data, shape)
 
-proc toTensor*[T; U](a: SomeSet[T], typ: typedesc[U]): Tensor[U] {.inline.} =
+proc toTensor*[T; U](a: HashSet[T] | OrderedSet[T], typ: typedesc[U]): Tensor[U] {.inline.} =
   ## Convert a HashSet or an OrderedSet into a Tensor of type `typ`
   ##
   ## This is a convenience function which given an input `a` is equivalent to

--- a/src/arraymancer/laser/tensor/initialization.nim
+++ b/src/arraymancer/laser/tensor/initialization.nim
@@ -284,8 +284,8 @@ proc toTensor*[T](a: HashSet[T] | OrderedSet[T]): Tensor[T] =
   ## Result:
   ##      - A Tensor of the same shape
   var shape = MetaData()
-  shape.add(a.len)
   let data = toSeq(a)
+  shape.add(data.len)
   result = toTensor(data, shape)
 
 proc toTensor*[T; U](a: HashSet[T] | OrderedSet[T], typ: typedesc[U]): Tensor[U] {.inline.} =


### PR DESCRIPTION
As mentioned in the commit message, the `SomeSet` can make the compiler try to pick the `SomeSet` `toTensor` in cases where it really does not belong.

Example:
https://github.com/SciNim/scinim/actions/runs/9537499650/job/26285671722?pr=20