### PR TITLE
Reshape consistency fix

### DIFF
--- a/src/arraymancer/tensor/private/p_accessors.nim
+++ b/src/arraymancer/tensor/private/p_accessors.nim
@@ -215,7 +215,7 @@ template stridedIterationLoop*(strider: IterKind, data, t, iter_offset, iter_siz
   let rank = t.rank
   let size = t.size
 
-  initStridedIteration(coord, backstrides, iter_pos, t, 0, size)
+  initStridedIteration(coord, backstrides, iter_pos, t, iter_offset, iter_size)
 
   # The end of the main block that loops over (prev_d, last_d) subtensors.
   # Can be smaller that iter_offset, which means that no complete (prev_d, last_d)
@@ -269,7 +269,6 @@ template stridedIterationLoop*(strider: IterKind, data, t, iter_offset, iter_siz
         break iteration
       # i is divisible by prev_d*last_d at this point
 
-    # main iteration block
     while i < main_block_end:
       for _ in 0..<prev_d:
         for _ in 0..<last_d:

--- a/src/arraymancer/tensor/private/p_shapeshifting.nim
+++ b/src/arraymancer/tensor/private/p_shapeshifting.nim
@@ -69,9 +69,6 @@ proc reshapeImpl*(t: AnyTensor, new_shape: varargs[int]|Metadata|seq[int],
   if t.is_C_contiguous:
     reshape_no_copy(t, new_shape, result, rowMajor)
     result.storage = t.storage
-  elif t.is_F_contiguous:
-    reshape_no_copy(t, new_shape, result, colMajor)
-    result.storage = t.storage
   else:
     reshape_with_copy(t, new_shape, result)
 

--- a/src/arraymancer/tensor/private/p_shapeshifting.nim
+++ b/src/arraymancer/tensor/private/p_shapeshifting.nim
@@ -36,9 +36,8 @@ proc reshape_no_copy*(t: AnyTensor, new_shape: varargs[int]|Metadata|seq[int], r
   result.offset = t.offset
 
 proc reshape_with_copy*[T](t: Tensor[T], new_shape: varargs[int]|Metadata|seq[int], result: var Tensor[T]) =
-  var cont: Tensor[T]
-  contiguousImpl(t, rowMajor, cont)
-  reshape_no_copy(cont, new_shape, result, rowMajor)
+  contiguousImpl(t, rowMajor, result)
+  reshape_no_copy(t, new_shape, result, rowMajor)
 
 proc infer_shape*(t: Tensor, new_shape: varargs[int]): seq[int] {.noinit.} =
   ## Replace the single -1 value on `new_shape` with the value that

--- a/src/arraymancer/tensor/private/p_shapeshifting.nim
+++ b/src/arraymancer/tensor/private/p_shapeshifting.nim
@@ -30,14 +30,15 @@ proc contiguousImpl*[T](t: Tensor[T], layout: OrderType, result: var Tensor[T]) 
     apply2_inline(result, t):
       y
 
-proc reshape_with_copy*[T](t: Tensor[T], new_shape: varargs[int]|Metadata|seq[int], result: var Tensor[T]) =
-  result = newTensorUninit[T](new_shape)
-  result.apply2_inline(t,y)
-
 proc reshape_no_copy*(t: AnyTensor, new_shape: varargs[int]|Metadata|seq[int], result: var AnyTensor, layout: OrderType) {.noSideEffect.}=
   result.shape.copyFrom(new_shape)
   shape_to_strides(result.shape, layout, result.strides)
   result.offset = t.offset
+
+proc reshape_with_copy*[T](t: Tensor[T], new_shape: varargs[int]|Metadata|seq[int], result: var Tensor[T]) =
+  var cont: Tensor[T]
+  contiguousImpl(t, rowMajor, cont)
+  reshape_no_copy(cont, new_shape, result, rowMajor)
 
 proc infer_shape*(t: Tensor, new_shape: varargs[int]): seq[int] {.noinit.} =
   ## Replace the single -1 value on `new_shape` with the value that


### PR DESCRIPTION
# What?

Fixing a bug with `reshape`, where it mistakes a non-contiguous C layout with contiguous F layout (see [issue #660](https://github.com/mratsim/Arraymancer/issues/660)).

# Why

A simple illustration why this is a problem:
```
import arraymancer

let x = arange[float](0, 6).reshape(2, 3).permute(1, 0) # has shape [3, 2] and is not C-contiguous (but is F-contiguous)
let y = x.reshape(3*2).reshape(3, 2) # the reshapes shouldn't change the contents

echo x
echo y
doAssert x == y
```
Right now this assertion fails.

# How

The check for whether the tensor is F-contiguous is removed. No-copy reshape is only performed if the tensor is C-contiguous.