### PR TITLE
Reshape consistency fix

### DIFF
--- a/src/arraymancer/tensor/private/p_shapeshifting.nim
+++ b/src/arraymancer/tensor/private/p_shapeshifting.nim
@@ -69,9 +69,6 @@ proc reshapeImpl*(t: AnyTensor, new_shape: varargs[int]|Metadata|seq[int],
   if t.is_C_contiguous:
     reshape_no_copy(t, new_shape, result, rowMajor)
     result.storage = t.storage
-  elif t.is_F_contiguous:
-    reshape_no_copy(t, new_shape, result, colMajor)
-    result.storage = t.storage
   else:
     reshape_with_copy(t, new_shape, result)
 


### PR DESCRIPTION
# What?

Fixing a bug with `reshape`, where it mistakes a non-contiguous C layout for contiguous F layout (see [issue #660](https://github.com/mratsim/Arraymancer/issues/660)).

# Why

A simple illustration why this is a problem:
```
import arraymancer

let x = arange[float](0, 6).reshape(2, 3).permute(1, 0) # has shape [3, 2] and is not C-contiguous (but is F-contiguous)
let y = x.reshape(3*2).reshape(3, 2) # the reshapes shouldn't change the contents

echo x
echo y
doAssert x == y
```
Right now this assertion fails.

# How

The check for whether the tensor is F-contiguous is removed. No-copy reshape is only performed if the tensor is C-contiguous.