### PR TITLE
make typedesc arg of `init` procs not require generic param

### DIFF
--- a/src/arraymancer/nn/layers/conv2D.nim
+++ b/src/arraymancer/nn/layers/conv2D.nim
@@ -138,7 +138,7 @@ type
 
 proc init*[T](
   ctx: Context[Tensor[T]],
-  layerType: typedesc[Conv2D[T]],
+  layerType: typedesc[Conv2D],
   inShape: seq[int],
   outChannels: int,
   kernelSize: Size2D,

--- a/src/arraymancer/nn/layers/embedding.nim
+++ b/src/arraymancer/nn/layers/embedding.nim
@@ -109,7 +109,7 @@ type
 
 proc init*[T](
   ctx: Context[Tensor[T]],
-  layerType: typedesc[Embedding[T]],
+  layerType: typedesc[Embedding],
   vocabSize, embedSize: int,
   paddingIdx: VocabIdx = -1
 ): Embedding[T] =

--- a/src/arraymancer/nn/layers/flatten.nim
+++ b/src/arraymancer/nn/layers/flatten.nim
@@ -8,7 +8,7 @@ type
 
 proc init*[T](
   ctx: Context[Tensor[T]],
-  layerType: typedesc[Flatten[T]],
+  layerType: typedesc[Flatten],
   inShape: seq[int]
 ): Flatten[T] =
 

--- a/src/arraymancer/nn/layers/gcn.nim
+++ b/src/arraymancer/nn/layers/gcn.nim
@@ -111,7 +111,7 @@ type
 
 proc init*[T](
   ctx: Context[Tensor[T]],
-  layerType: typedesc[GCNLayer[T]],
+  layerType: typedesc[GCNLayer],
   numInput, numOutput: int
 ): GCNLayer[T] =
   ## Initializes a graph convolutional layer with `num_input` input features and `num_output` output features.

--- a/src/arraymancer/nn/layers/gru.nim
+++ b/src/arraymancer/nn/layers/gru.nim
@@ -168,7 +168,7 @@ type
 
 proc init*[T](
   ctx: Context[Tensor[T]],
-  layerType: typedesc[GRULayer[T]],
+  layerType: typedesc[GRULayer],
   numInputFeatures, hiddenSize, layers: int
 ): GRULayer[T] =
 

--- a/src/arraymancer/nn/layers/linear.nim
+++ b/src/arraymancer/nn/layers/linear.nim
@@ -120,7 +120,7 @@ type
 
 proc init*[T](
   ctx: Context[Tensor[T]],
-  layerType: typedesc[Linear[T]],
+  layerType: typedesc[Linear],
   numInput, numOutput: int
 ): Linear[T] =
   ## Initializes a linear layer with `numInput` input features and `numOutput` output features.

--- a/src/arraymancer/nn/layers/maxpool2D.nim
+++ b/src/arraymancer/nn/layers/maxpool2D.nim
@@ -120,7 +120,7 @@ type
 
 proc init*[T](
   ctx: Context[Tensor[T]],
-  layerType: typedesc[MaxPool2D[T]],
+  layerType: typedesc[MaxPool2D],
   inShape: seq[int],
   kernelSize, padding, stride: Size2D
 ): MaxPool2D[T] =

--- a/src/arraymancer/nn/nn_dsl.nim
+++ b/src/arraymancer/nn/nn_dsl.nim
@@ -131,7 +131,7 @@ proc createModelType(layerInfos: seq[LayerInfo], modelName: NimNode): NimNode =
 proc createInitProc(layerInfos: seq[LayerInfo], sectionInfo: SectionInfo, modelName: NimNode): NimNode =
 
   # creates init function of the model, e.g.:
-  #   proc init[T](ctx: Context[AnyTensor[T]], modelType: typedesc[SomeConvNet[T]], h: auto; w: auto): SomeConvNet[T] =
+  #   proc init[T](ctx: Context[AnyTensor[T]], modelType: typedesc[SomeConvNet], h: auto; w: auto): SomeConvNet[T] =
   #     template cv(): auto =
   #       result.cv
   #     template mp(): auto =
@@ -201,10 +201,7 @@ proc createInitProc(layerInfos: seq[LayerInfo], sectionInfo: SectionInfo, modelN
       genSym(nskParam, "modelType"),
       newNimNode(nnkBracketExpr).add(
         ident"typedesc",
-        newNimNode(nnkBracketExpr).add(
-          modelName,
-          underlyingTypeSymbol
-        )
+        modelName
       )
     )
   ]
@@ -357,7 +354,7 @@ macro network*(modelName: untyped, config: untyped): untyped =
   ## .. code:: nim
   ##   proc init*[T](
   ##     ctx: Context[Tensor[T]], # could also be Context[AnyTensor[T]] for example
-  ##     layerType: typedesc[MyLayer[T]],
+  ##     layerType: typedesc[MyLayer],
   ##     myInitParam: string
   ##     # ... here you can add all the necessary init parameters, like shapes and number of output features
   ##   ): MyLayer[T] =


### PR DESCRIPTION
A fix to https://github.com/nim-lang/Nim/issues/24688 could imply that typedesc args with types like `Foo[T]` should not match a type `Foo`, especially if the `T` is inferred. `init` procs are usually called as such i.e. `init(ctx, NetName)`, so their parameters are given a type `typedesc[NetName]` rather than `typedesc[NetName[T]]`. Hopefully this is not too much of an incompatibility.