### PR TITLE
Fix cuda on 2.2

### DIFF
--- a/src/arraymancer/tensor/backend/cuda.nim
+++ b/src/arraymancer/tensor/backend/cuda.nim
@@ -90,7 +90,7 @@ type
 
 proc `=destroy`*(p: CudaLayoutArrayObj) {.noSideEffect.}=
   if not p.value.isNil:
-    check cudaFree(p.value)
+    discard cudaFree(p.value)
 
 proc layoutOnDevice*[T:SomeFloat](t: CudaTensor[T]): CudaTensorLayout[T] {.noSideEffect.}=
   ## Store a CudaTensor shape, strides, etc information on the GPU

--- a/src/arraymancer/tensor/backend/cuda.nim
+++ b/src/arraymancer/tensor/backend/cuda.nim
@@ -33,7 +33,7 @@ proc cudaMalloc*[T](size: Natural): ptr UncheckedArray[T] {.noSideEffect, inline
 
 proc newCudaStorage*[T: SomeFloat](length: int): CudaStorage[T] {.noSideEffect.}=
   result.Flen = length
-  new(result.Fref_tracking, deallocCuda)
+  new result.Fref_tracking
   result.Fdata = cast[ptr UncheckedArray[T]](cudaMalloc[T](result.Flen))
   result.Fref_tracking.value = result.Fdata
 

--- a/src/arraymancer/tensor/backend/cuda.nim
+++ b/src/arraymancer/tensor/backend/cuda.nim
@@ -88,7 +88,7 @@ type
     len*: cint                # Number of elements allocated in memory
 
 
-proc deallocCuda*(p: CudaLayoutArray) {.noSideEffect.}=
+proc `=destroy`*(p: CudaLayoutArrayObj) {.noSideEffect.}=
   if not p.value.isNil:
     check cudaFree(p.value)
 
@@ -104,8 +104,8 @@ proc layoutOnDevice*[T:SomeFloat](t: CudaTensor[T]): CudaTensorLayout[T] {.noSid
   result.data = t.get_data_ptr
   result.len = t.size.cint
 
-  new result.shape, deallocCuda
-  new result.strides, deallocCuda
+  new result.shape
+  new result.strides
 
   result.shape.value = cudaMalloc[cint](MAXRANK)
   result.strides.value = cudaMalloc[cint](MAXRANK)

--- a/src/arraymancer/tensor/backend/cuda.nim
+++ b/src/arraymancer/tensor/backend/cuda.nim
@@ -88,9 +88,16 @@ type
     len*: cint                # Number of elements allocated in memory
 
 
-proc `=destroy`*(p: CudaLayoutArrayObj) {.noSideEffect.}=
-  if not p.value.isNil:
-    discard cudaFree(p.value)
+when NimMajor == 1:
+  proc `=destroy`*(p: var CudaLayoutArrayObj) {.noSideEffect.}=
+    if not p.value.isNil:
+      discard cudaFree(p.value)
+else:
+  proc `=destroy`*(p: CudaLayoutArrayObj) {.noSideEffect.}=
+    if not p.value.isNil:
+      discard cudaFree(p.value)
+
+
 
 proc layoutOnDevice*[T:SomeFloat](t: CudaTensor[T]): CudaTensorLayout[T] {.noSideEffect.}=
   ## Store a CudaTensor shape, strides, etc information on the GPU

--- a/src/arraymancer/tensor/data_structure.nim
+++ b/src/arraymancer/tensor/data_structure.nim
@@ -16,7 +16,7 @@ import
   ../laser/dynamic_stack_arrays,
   ../laser/tensor/datatypes,
   nimblas,
-  nimcuda/cuda12_5/[cuda_runtime_api, check],
+  nimcuda/cuda12_5/[cuda_runtime_api],
   # Standard library
   std/[complex]
 
@@ -81,7 +81,7 @@ type
 
 proc `=destroy`*[T](p: CudaTensorRefTrackerObj[T]) {.noSideEffect.}=
   if not p.value.isNil:
-    check cudaFree(p.value)
+    discard cudaFree(p.value)
 
 
 

--- a/src/arraymancer/tensor/data_structure.nim
+++ b/src/arraymancer/tensor/data_structure.nim
@@ -57,9 +57,14 @@ when defined(cuda):
       offset*: int
       storage*: CudaStorage[T]
 
-  proc deallocCuda*[T](p: CudaTensorRefTracker[T]) {.noSideEffect.}=
-    if not p.value.isNil:
-      check cudaFree(p.value)
+  when NimMajor == 1:
+    proc `=destroy`*[T](p: var CudaTensorRefTrackerObj[T]) {.noSideEffect.}=
+      if not p.value.isNil:
+        discard cudaFree(p.value)
+  else:
+    proc `=destroy`*[T](p: CudaTensorRefTrackerObj[T]) {.noSideEffect.}=
+      if not p.value.isNil:
+        discard cudaFree(p.value)
 
 when defined(opencl):
   type
@@ -95,15 +100,6 @@ else:
   type AnyTensor*[T] = Tensor[T]
 
 type GpuTensor[T] = AnyTensor[T] and not Tensor[T]
-
-when NimMajor == 1:
-  proc `=destroy`*[T](p: var CudaTensorRefTrackerObj[T]) {.noSideEffect.}=
-    if not p.value.isNil:
-      discard cudaFree(p.value)
-else:
-  proc `=destroy`*[T](p: CudaTensorRefTrackerObj[T]) {.noSideEffect.}=
-    if not p.value.isNil:
-      discard cudaFree(p.value)
 
 
 

--- a/src/arraymancer/tensor/data_structure.nim
+++ b/src/arraymancer/tensor/data_structure.nim
@@ -79,9 +79,14 @@ type
 
   AnyTensor*[T] = Tensor[T] or CudaTensor[T] or ClTensor[T]
 
-proc `=destroy`*[T](p: CudaTensorRefTrackerObj[T]) {.noSideEffect.}=
-  if not p.value.isNil:
-    discard cudaFree(p.value)
+when NimMajor == 1:
+  proc `=destroy`*[T](p: var CudaTensorRefTrackerObj[T]) {.noSideEffect.}=
+    if not p.value.isNil:
+      discard cudaFree(p.value)
+else:
+  proc `=destroy`*[T](p: CudaTensorRefTrackerObj[T]) {.noSideEffect.}=
+    if not p.value.isNil:
+      discard cudaFree(p.value)
 
 
 

--- a/src/arraymancer/tensor/data_structure.nim
+++ b/src/arraymancer/tensor/data_structure.nim
@@ -79,10 +79,10 @@ type
 
   AnyTensor*[T] = Tensor[T] or CudaTensor[T] or ClTensor[T]
 
-
-proc deallocCuda*[T](p: CudaTensorRefTracker[T]) {.noSideEffect.}=
+proc `=destroy`*[T](p: CudaTensorRefTrackerObj[T]) {.noSideEffect.}=
   if not p.value.isNil:
     check cudaFree(p.value)
+
 
 
 # ###############


### PR DESCRIPTION
Fixes issue #677 by updating cuda memory management to standard inserted `=destroy` calls.