### PR TITLE
io_image read_image bugfix & add feature read_image_16 (bit)

### DIFF
--- a/src/arraymancer/io/io_image.nim
+++ b/src/arraymancer/io/io_image.nim
@@ -53,6 +53,35 @@ proc read_image*(buffer: seq[byte]): Tensor[uint8] =
   let raw_pixels = loadFromMemory(buffer, width, height, channels, desired_channels)
   result = raw_pixels.toTensor.reshape(height, width, channels).hwc_to_chw
 
+proc read_image_16*(filepath: string): Tensor[uint16] =
+  ## Read a 16-bit image file and loads it into a Tensor[uint16] of shape
+  ## Channel x Height x Width. Channel is 1 for greyscale, 3 for RGB.
+  ##
+  ## Supports JPEG, PNG, TGA, BMP, PSD, GIF, HDR, PIC, PNM
+  ## See stb_image https://github.com/nothings/stb/blob/master/stb_image.h
+  var width, height, channels: int
+  let desired_channels = Default # Channel autodetection
+  
+  let raw_pixels = load16(filepath, width, height, channels, desired_channels)
+  result = raw_pixels.toTensor.reshape(height, width, channels).hwc_to_chw
+
+proc read_image_16*(buffer: seq[byte]): Tensor[uint16] =
+  ## Read a 16-bit image from a buffer and loads it into a Tensor[uint16] of shape
+  ## Channel x Height x Width. Channel is 1 for greyscale, 3 for RGB.
+  ##
+  ## Supports JPEG, PNG, TGA, BMP, PSD, GIF, HDR, PIC, PNM
+  ## See stb_image https://github.com/nothings/stb/blob/master/stb_image.h
+  ##
+
+  # TODO: ideally this should also accept pointer + length
+  # but nim-stb_image only accept seq[bytes] (and convert it to pointer + length internally)
+
+  var width, height, channels: int
+  let desired_channels = Default # Channel autodetection
+
+  let raw_pixels = load16FromMemory(buffer, width, height, channels, desired_channels)
+  result = raw_pixels.toTensor.reshape(height, width, channels).hwc_to_chw
+
 template gen_write_image(proc_name: untyped): untyped {.dirty.}=
 
   proc proc_name*(img: Tensor[uint8], filepath: string) =

--- a/src/arraymancer/io/io_image.nim
+++ b/src/arraymancer/io/io_image.nim
@@ -18,7 +18,7 @@ func chw_to_hwc[T](img: Tensor[T]): Tensor[T] {.inline.}=
   img.permute(1, 2, 0)
 
 proc read_image*(filepath: string): Tensor[uint8] =
-  ## Read an image file and loads it into a Tensor[uint8] of shape
+  ## Read an 8-bit image file and loads it into a Tensor[uint8] of shape
   ## Channel x Height x Width. Channel is 1 for greyscale, 3 for RGB.
   ##
   ## Supports JPEG, PNG, TGA, BMP, PSD, GIF, HDR, PIC, PNM
@@ -31,13 +31,13 @@ proc read_image*(filepath: string): Tensor[uint8] =
   ##     x.float32 / 255.0
 
   var width, height, channels: int
-  let desired_channels = 0 # Channel autodetection
+  let desired_channels = Default # Channel autodetection
 
   let raw_pixels = load(filepath, width, height, channels, desired_channels)
   result = raw_pixels.toTensor.reshape(height, width, channels).hwc_to_chw
 
 proc read_image*(buffer: seq[byte]): Tensor[uint8] =
-  ## Read an image from a buffer and loads it into a Tensor[uint8] of shape
+  ## Read an 8-bit image from a buffer and loads it into a Tensor[uint8] of shape
   ## Channel x Height x Width. Channel is 1 for greyscale, 3 for RGB.
   ##
   ## Supports JPEG, PNG, TGA, BMP, PSD, GIF, HDR, PIC, PNM
@@ -48,7 +48,7 @@ proc read_image*(buffer: seq[byte]): Tensor[uint8] =
   # but nim-stb_image only accept seq[bytes] (and convert it to pointer + length internally)
 
   var width, height, channels: int
-  let desired_channels = 0 # Channel autodetection
+  let desired_channels = Default # Channel autodetection
 
   let raw_pixels = loadFromMemory(buffer, width, height, channels, desired_channels)
   result = raw_pixels.toTensor.reshape(height, width, channels).hwc_to_chw

--- a/src/arraymancer/io/io_image.nim
+++ b/src/arraymancer/io/io_image.nim
@@ -51,8 +51,7 @@ proc read_image*(buffer: seq[byte]): Tensor[uint8] =
   let desired_channels = 0 # Channel autodetection
 
   let raw_pixels = loadFromMemory(buffer, width, height, channels, desired_channels)
-  result = raw_pixels.toTensor.reshape(width, height, channels).hwc_to_chw
-
+  result = raw_pixels.toTensor.reshape(height, width, channels).hwc_to_chw
 
 template gen_write_image(proc_name: untyped): untyped {.dirty.}=
 


### PR DESCRIPTION
- fixed a bug in the reshape of  `read_image` from buffer proc, which swapped height and width
- added 2 new `read_image_16` proc to be able to read 16-bit images (useful in order to work with medical images)