### PR TITLE
Fix least squares solver

### DIFF
--- a/src/arraymancer/linear_algebra/helpers/least_squares_lapack.nim
+++ b/src/arraymancer/linear_algebra/helpers/least_squares_lapack.nim
@@ -70,7 +70,7 @@ proc gelsd*[T: SomeFloat](
   const smlsiz = 25'i32 # equal to the maximum size of the subproblems at the bottom of the computation tree
   let
     minmn = min(m,n).int
-    nlvl = max(0, (minmn.T / (smlsiz+1).T).ln.int32 + 1)
+    nlvl = max(0, (minmn.T / (smlsiz+1).T).log2.int32 + 1)
     # Bug in some Lapack, liwork must be determined manually: http://icl.cs.utk.edu/lapack-forum/archives/lapack/msg00899.html
     liwork = max(1, 3 * minmn * nlvl + 11 * minmn)
 


### PR DESCRIPTION
Solves #683.
Not enough memory was being allocated for the iwork array which caused Lapack to sometimes write past the end of the sequence.
The natural log was used instead of binary log which was fine for certain tensor shapes since `floor(ln(n)) == floor(log2(n))` for certain small `n`.
From [Lapack's documentation](https://www.netlib.org/lapack/explore-html/d9/d67/group__gelsd_ga0ccf8647f7c3764ed543f385c2b9de2c.html):
```
!>          LWORK is INTEGER
!>          The dimension of the array WORK. LWORK must be at least 1.
!>          The exact minimum amount of workspace needed depends on M,
!>          N and NRHS. As long as LWORK is at least
!>              12*N + 2*N*SMLSIZ + 8*N*NLVL + N*NRHS + (SMLSIZ+1)**2,
!>          if M is greater than or equal to N or
!>              12*M + 2*M*SMLSIZ + 8*M*NLVL + M*NRHS + (SMLSIZ+1)**2,
!>          if M is less than N, the code will execute correctly.
!>          SMLSIZ is returned by ILAENV and is equal to the maximum
!>          size of the subproblems at the bottom of the computation
!>          tree (usually about 25), and
!>             NLVL = MAX( 0, INT( LOG_2( MIN( M,N )/(SMLSIZ+1) ) ) + 1 )
!>          For good performance, LWORK should generally be larger.
!>
!>          If LWORK = -1, then a workspace query is assumed; the routine
!>          only calculates the optimal size of the array WORK and the
!>          minimum size of the array IWORK, and returns these values as
!>          the first entries of the WORK and IWORK arrays, and no error
!>          message related to LWORK is issued by XERBLA.
```