### PR TITLE
fix `blis` dynamic lib name, avoid `bli_init` output at runtime

### DIFF
--- a/src/arraymancer/tensor/backend/blis.nim
+++ b/src/arraymancer/tensor/backend/blis.nim
@@ -15,7 +15,7 @@
 when defined(blis):
   static: echo "--USING BLIS--"
   include ./blis_api
-  echo "Blis initialization status: " & $bli_init()
+  discard bli_init()
 
   proc quit_blis() {.noconv.}=
     when defined(debug):

--- a/src/arraymancer/tensor/backend/blis_api.nim
+++ b/src/arraymancer/tensor/backend/blis_api.nim
@@ -122,11 +122,18 @@ type
 #################################################
 
 when defined(windows):
-  const blisSuffix = ".dll"
+  const blisPrefix = ""
 else:
-  const blisSuffix = ".so" #MacOS & Linux
+  const blisPrefix = "lib"
 
-const libblis = "libblis" & blisSuffix
+when defined(windows):
+  const blisSuffix = ".dll"
+elif defined(macosx):
+  const blisSuffix = ".dylib"
+else:
+  const blisSuffix = ".so"
+
+const libblis = blisPrefix & "blis" & blisSuffix
 
 proc bli_init(): BlisError {.importc: "bli_init", dynlib: libblis.}
 proc bli_finalize(): BlisError {.importc: "bli_finalize", dynlib: libblis.}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform compatibility for BLIS library loading on Windows, macOS, and Linux.
  * Removed verbose initialization status message from startup output.

* **Improvements**
  * Added ability to check BLIS initialization status during runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->